### PR TITLE
Fix workflow to use regular push instead of force-push

### DIFF
--- a/.github/workflows/claude-issue-handler.yml
+++ b/.github/workflows/claude-issue-handler.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: claude/issue-${{ github.event.issue.number }}
+          force: false
           commit-message: |
             Implement changes from issue #${{ github.event.issue.number }}
 


### PR DESCRIPTION
## Summary
- Set `force: false` in peter-evans/create-pull-request action to use regular push instead of force-push
- Resolves repository rule violations that were preventing the Claude issue handler workflow from pushing branches

## Changes
- Updated `.github/workflows/claude-issue-handler.yml` to add `force: false` parameter

## Why
The repository has branch protection rules that prevent force-pushing. The peter-evans/create-pull-request action uses `--force-with-lease` by default, which was causing the workflow to fail with repository rule violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)