### PR TITLE
Fix: Disable force-with-lease in GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude-issue-handler.yml
+++ b/.github/workflows/claude-issue-handler.yml
@@ -58,6 +58,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: claude/issue-${{ github.event.issue.number }}
           force: false
+          force-with-lease: false
           commit-message: |
             Implement changes from issue #${{ github.event.issue.number }}
 


### PR DESCRIPTION
## Summary
- Added `force-with-lease: false` parameter to the `peter-evans/create-pull-request` action
- This prevents force-push attempts that violate repository rules

## Problem
The GitHub Actions workflow was failing because the `create-pull-request` action was using `--force-with-lease` even with `force: false` set. The repository has rules that prevent force-pushing and require changes through pull requests.

## Solution
Explicitly set both `force: false` and `force-with-lease: false` to ensure no force-push attempts are made.

## Test Plan
- [ ] Trigger the workflow by creating an issue with the 'claude' label
- [ ] Verify the workflow completes successfully without force-push errors
- [ ] Confirm the pull request is created properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)