### PR TITLE
Fix Participants card to count both families and individuals

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -91,10 +91,19 @@ export function DashboardPage() {
           <CardContent className="pt-6">
             <div className="text-sm text-muted-foreground mb-1">Participants</div>
             <div className="text-2xl font-bold text-foreground tabular-nums">
-              {currentTrip.tracking_mode === 'families' ? families.length : participants.length}
+              {currentTrip.tracking_mode === 'families'
+                ? families.length + participants.filter(p => p.family_id === null).length
+                : participants.length}
             </div>
             <div className="text-xs text-muted-foreground mt-1">
-              {currentTrip.tracking_mode === 'families' ? 'families' : 'individuals'}
+              {currentTrip.tracking_mode === 'families'
+                ? (() => {
+                    const standaloneCount = participants.filter(p => p.family_id === null).length
+                    if (standaloneCount === 0) return `${families.length} ${families.length === 1 ? 'family' : 'families'}`
+                    if (families.length === 0) return `${standaloneCount} ${standaloneCount === 1 ? 'individual' : 'individuals'}`
+                    return `${families.length} ${families.length === 1 ? 'family' : 'families'}, ${standaloneCount} ${standaloneCount === 1 ? 'individual' : 'individuals'}`
+                  })()
+                : 'individuals'}
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Problem
In Families tracking mode, the Participants card only showed the count of families, completely ignoring standalone individuals.

**Example from screenshot:**
- Dashboard showed: "3" with label "families"
- But Current Balances showed 4 entities:
  - Kivinugise Eliased (Family)
  - Lammuka Eliased (Family)
  - Tiirikud (Family)
  - Kersti (standalone individual - no Family badge)

The count was wrong because Kersti wasn't included.

## Solution
Updated the Participants card to:
1. **Count both families AND standalone individuals**
   - Total = `families.length + standaloneIndividuals.length`

2. **Show adaptive labels** based on content:
   - Only families: "3 families"
   - Only individuals: "1 individual"
   - Both: "3 families, 1 individual"

## After This Fix
Using the example from the screenshot:
- Count: **4** (instead of 3)
- Label: **"3 families, 1 individual"** (instead of just "families")

## Files Modified
- `src/pages/DashboardPage.tsx` - Updated Participants card logic

## Testing
- [x] Type check passed
- [x] Build passed
- [x] Handles edge cases (0 families, 0 individuals, singular/plural)

🤖 Generated with [Claude Code](https://claude.com/claude-code)