### PR TITLE
Fix race condition causing 'Trip Not Found' error on page refresh

### DIFF
--- a/src/components/TripRouteGuard.tsx
+++ b/src/components/TripRouteGuard.tsx
@@ -14,23 +14,19 @@ interface TripRouteGuardProps {
  * Shows loading state while trip is being loaded
  */
 export function TripRouteGuard({ children }: TripRouteGuardProps) {
-  const { currentTrip, tripCode } = useCurrentTrip()
+  const { currentTrip, tripCode, loading } = useCurrentTrip()
   const navigate = useNavigate()
 
   useEffect(() => {
-    // Wait for trips to load (give it a moment)
-    const timer = setTimeout(() => {
-      if (tripCode && !currentTrip) {
-        // Trip code exists in URL but trip not found
-        navigate(`/trip-not-found/${tripCode}`, { replace: true })
-      }
-    }, 500)
+    // Only check if trip exists after loading completes
+    if (!loading && tripCode && !currentTrip) {
+      // Trip code exists in URL but trip not found
+      navigate(`/trip-not-found/${tripCode}`, { replace: true })
+    }
+  }, [loading, currentTrip, tripCode, navigate])
 
-    return () => clearTimeout(timer)
-  }, [currentTrip, tripCode, navigate])
-
-  // Show loading while waiting
-  if (tripCode && !currentTrip) {
+  // Show loading while trips are being fetched
+  if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <Card className="w-full max-w-md">

--- a/src/hooks/useCurrentTrip.ts
+++ b/src/hooks/useCurrentTrip.ts
@@ -5,7 +5,7 @@ import { addToMyTrips } from '@/lib/myTripsStorage'
 
 export function useCurrentTrip() {
   const { tripCode } = useParams<{ tripCode: string }>()
-  const { getTripByCode } = useTripContext()
+  const { getTripByCode, loading } = useTripContext()
 
   const currentTrip = tripCode ? getTripByCode(tripCode) : null
 
@@ -19,5 +19,6 @@ export function useCurrentTrip() {
   return {
     currentTrip,
     tripCode,
+    loading,
   }
 }


### PR DESCRIPTION
## Problem

Users were intermittently seeing the "Trip Not Found" error page when refreshing the browser, even though the trip URL was correct. This was particularly noticeable on slower connections or when Supabase took longer to respond.

## Root Cause

Race condition in the trip loading flow:

1. On page refresh, `TripContext` starts loading all trips from Supabase
2. `TripRouteGuard` immediately checks if `currentTrip` exists
3. Since trips haven't loaded yet, `currentTrip` is `null`
4. After an arbitrary 500ms timeout, `TripRouteGuard` would redirect to "Trip Not Found"
5. If Supabase took longer than 500ms to respond, the user would see the error page

## Solution

Properly use the existing `loading` state from `TripContext`:

**Before:**
- `TripRouteGuard` used arbitrary 500ms timeout
- Didn't check if trips were still loading
- Could redirect to error page while trips were being fetched

**After:**
- `useCurrentTrip` now exposes `loading` state from `TripContext`
- `TripRouteGuard` shows loading spinner while `loading === true`
- Only checks if trip exists after `loading === false`
- Removed arbitrary timeout in favor of proper state management

## Changes

### src/hooks/useCurrentTrip.ts
- Added `loading` to return value from `useTripContext()`
- Exposed loading state to consumers

### src/components/TripRouteGuard.tsx
- Updated to use `loading` state from `useCurrentTrip`
- Shows loading spinner while `loading === true`
- Only navigates to "Trip Not Found" after loading completes
- Removed arbitrary 500ms timeout

## Testing

- ✅ Type check passes
- ✅ Build succeeds
- ✅ Loading spinner now shows while trips are being fetched
- ✅ No more false "Trip Not Found" errors on page refresh
- ✅ Actual invalid trip codes still redirect correctly

## Impact

This fix eliminates the intermittent "Trip Not Found" error on page refresh, especially on slower connections. Users will now see a proper loading state while trips are being fetched from Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)