### PR TITLE
Add Settings page to navigation and routes

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -54,6 +54,7 @@ export function Layout() {
         { path: `/t/${tripCode}/meals`, label: 'Meals', requiresTrip: true },
         { path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true },
         { path: `/t/${tripCode}/dashboard`, label: 'Dashboard', requiresTrip: true },
+        { path: `/t/${tripCode}/settings`, label: 'Settings', requiresTrip: true },
       )
     }
 
@@ -86,6 +87,7 @@ export function Layout() {
       { path: '/', label: 'Trips', requiresTrip: false },
       { path: `/t/${tripCode}/setup`, label: 'Setup', requiresTrip: true },
       { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
+      { path: `/t/${tripCode}/settings`, label: 'Settings', requiresTrip: true },
     ]
   }
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,6 +9,7 @@ import { MealsPage } from './pages/MealsPage'
 import { ShoppingPage } from './pages/ShoppingPage'
 import { DashboardPage } from './pages/DashboardPage'
 import { SettlementsPage } from './pages/SettlementsPage'
+import { SettingsPage } from './pages/SettingsPage'
 import { AdminAllTripsPage } from './pages/AdminAllTripsPage'
 import { TripNotFoundPage } from './pages/TripNotFoundPage'
 
@@ -32,6 +33,7 @@ export function AppRoutes() {
         <Route path="t/:tripCode/meals" element={<TripRouteGuard><MealsPage /></TripRouteGuard>} />
         <Route path="t/:tripCode/shopping" element={<TripRouteGuard><ShoppingPage /></TripRouteGuard>} />
         <Route path="t/:tripCode/dashboard" element={<TripRouteGuard><DashboardPage /></TripRouteGuard>} />
+        <Route path="t/:tripCode/settings" element={<TripRouteGuard><SettingsPage /></TripRouteGuard>} />
       </Route>
     </Routes>
   )


### PR DESCRIPTION
## Problem

The Settings page was implemented in PR #14 but was not accessible from the UI because:
- No route was defined in `routes.tsx`
- No navigation links were added to the Layout

Users couldn't find where to edit trip details or delete trips.

## Solution

Added the missing route and navigation links:

### Changes

**src/routes.tsx**
- Added `SettingsPage` import
- Added route: `/t/:tripCode/settings`

**src/components/Layout.tsx**
- Added Settings to desktop navigation (side nav)
- Added Settings to mobile overflow menu ("More" button)

### Where to find Settings now

**Desktop:** Side navigation → Settings (at the bottom of the list)
**Mobile:** Bottom navigation → More → Settings

## Testing

- ✅ Type check passes
- ✅ Build succeeds
- ✅ Settings accessible from desktop navigation
- ✅ Settings accessible from mobile "More" menu
- ✅ Route properly protected by TripRouteGuard

🤖 Generated with [Claude Code](https://claude.com/claude-code)