### PR TITLE
Fix expense form to only show standalone individuals in families mode

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -59,7 +59,6 @@ export function ExpenseForm({
   )
   const [comment, setComment] = useState(initialValues?.comment || '')
   const [showMoreDetails, setShowMoreDetails] = useState(false)
-  const [showIndividualMembers, setShowIndividualMembers] = useState(false)
 
   // Distribution state
   const [selectedParticipants, setSelectedParticipants] = useState<string[]>([])
@@ -516,7 +515,7 @@ export function ExpenseForm({
             ))}
           </div>
         ) : (
-          // Families mode - show families and individuals
+          // Families mode - show families and standalone individuals only
           <div className="space-y-3">
             {families.length > 0 && (
               <div>
@@ -554,75 +553,45 @@ export function ExpenseForm({
                 </div>
               </div>
             )}
-            {participants.length > 0 && (
-              <div>
-                <button
-                  type="button"
-                  onClick={() => setShowIndividualMembers(!showIndividualMembers)}
-                  className="flex items-center gap-2 text-xs text-muted-foreground mb-2 hover:text-foreground transition-colors"
-                >
-                  {showIndividualMembers ? (
-                    <ChevronDown size={14} />
-                  ) : (
-                    <ChevronRight size={14} />
-                  )}
-                  Individual Members ({participants.length})
-                </button>
-                <AnimatePresence>
-                  {showIndividualMembers && (
-                    <motion.div
-                      initial={{ height: 0, opacity: 0 }}
-                      animate={{ height: 'auto', opacity: 1 }}
-                      exit={{ height: 0, opacity: 0 }}
-                      transition={{ duration: 0.2 }}
-                      className="overflow-hidden"
-                    >
-                      <div className="space-y-2 rounded-lg border border-input p-3">
-                        {participants.map(participant => {
-                          const participantFamily = participant.family_id
-                            ? families.find(f => f.id === participant.family_id)
-                            : null
-
-                          return (
-                            <div key={participant.id} className="flex items-center space-x-2 min-h-[44px]">
-                              <Checkbox
-                                id={`participant-${participant.id}`}
-                                checked={selectedParticipants.includes(participant.id)}
-                                onCheckedChange={() => handleParticipantToggle(participant.id)}
-                                disabled={loading}
-                              />
-                              <label
-                                htmlFor={`participant-${participant.id}`}
-                                className="text-sm text-foreground cursor-pointer flex-1"
-                              >
-                                {participant.name} {participant.is_adult ? '' : '(child)'}
-                                {participantFamily && (
-                                  <span className="text-xs text-muted-foreground ml-1">
-                                    ({participantFamily.family_name})
-                                  </span>
-                                )}
-                              </label>
-                              {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
-                                <Input
-                                  type="number"
-                                  value={participantSplitValues[participant.id] || ''}
-                                  onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value)}
-                                  placeholder={splitMode === 'percentage' ? '%' : currency}
-                                  step={splitMode === 'percentage' ? '0.1' : '0.01'}
-                                  min="0"
-                                  disabled={loading}
-                                  className="w-24 h-9"
-                                />
-                              )}
-                            </div>
-                          )
-                        })}
+            {/* Standalone individuals (not in any family) */}
+            {(() => {
+              const standaloneParticipants = participants.filter(p => p.family_id === null)
+              return standaloneParticipants.length > 0 && (
+                <div>
+                  <p className="text-xs text-muted-foreground mb-2">Standalone Individuals</p>
+                  <div className="space-y-2 rounded-lg border border-input p-3">
+                    {standaloneParticipants.map(participant => (
+                      <div key={participant.id} className="flex items-center space-x-2 min-h-[44px]">
+                        <Checkbox
+                          id={`participant-${participant.id}`}
+                          checked={selectedParticipants.includes(participant.id)}
+                          onCheckedChange={() => handleParticipantToggle(participant.id)}
+                          disabled={loading}
+                        />
+                        <label
+                          htmlFor={`participant-${participant.id}`}
+                          className="text-sm text-foreground cursor-pointer flex-1"
+                        >
+                          {participant.name} {participant.is_adult ? '' : '(child)'}
+                        </label>
+                        {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
+                          <Input
+                            type="number"
+                            value={participantSplitValues[participant.id] || ''}
+                            onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value)}
+                            placeholder={splitMode === 'percentage' ? '%' : currency}
+                            step={splitMode === 'percentage' ? '0.1' : '0.01'}
+                            min="0"
+                            disabled={loading}
+                            className="w-24 h-9"
+                          />
+                        )}
                       </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-            )}
+                    ))}
+                  </div>
+                </div>
+              )
+            })()}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Problem

In families tracking mode with both families AND standalone individuals, the expense form was showing confusing participant lists:

**Before:**
- Families section (3 families) ✓
- Individual Members (10) - **included everyone** ❌
  - Showed all 10 people (family members + standalone individuals)
  - User couldn't tell who was standalone vs who was in a family
  - Families were already selectable, so this was redundant

## Solution

Filter the participants list to only show standalone individuals (those with `family_id === null`).

**After:**
- Families section (3 families) ✓
- Standalone Individuals section (only solo travelers) ✓
  - Shows only people NOT in any family
  - Clear and unambiguous
  - No collapsible needed (fewer items)

## Changes

**src/components/expenses/ExpenseForm.tsx:**
- Changed section label from "Individual Members" to "Standalone Individuals"
- Filter participants: `participants.filter(p => p.family_id === null)`
- Removed collapsible dropdown UI (not needed anymore)
- Removed unused `showIndividualMembers` state
- Display directly as simple list (same as families)

## Example

If you have:
- 3 families with 7 total members
- 3 standalone individuals (Kersti, John, etc.)

**Old behavior:** "Individual Members (10)" - showed all 10 people
**New behavior:** "Standalone Individuals" - shows only the 3 solo travelers

## Testing

- ✅ Type check passes
- ✅ Build succeeds
- ✅ Families still checkable
- ✅ Only standalone individuals shown in second section
- ✅ No duplicate selections possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)