### PR TITLE
Fix trip deletion navigation to home page

### DIFF
--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -111,8 +111,8 @@ export function ManageTripPage() {
           description: 'The trip has been permanently deleted.',
         })
 
-        // Navigate to trips page
-        navigate('/trips')
+        // Navigate to home page
+        navigate('/')
       } else {
         toast({
           variant: 'destructive',


### PR DESCRIPTION
## Problem

After deleting a trip from the Manage Trip page, users were seeing a blank page because the app was navigating to `/trips`, which doesn't exist in the routing configuration.

**What happens:**
1. User clicks "Delete Trip" in Manage Trip page
2. Trip gets deleted successfully
3. App navigates to `/trips`
4. Result: Blank page (route doesn't exist)

## Solution

Navigate to `/` (home page) instead, which shows the user's trip list.

## Changes

**src/pages/ManageTripPage.tsx (line 115):**
```typescript
// Before
navigate('/trips')

// After
navigate('/')
```

## Routes Reference

From `src/routes.tsx`:
- `/` - HomePage (shows trip list) ✓
- `/create-trip` - TripsPage (create new trip form)
- No `/trips` route exists ❌

## Testing

- ✅ Type check passes
- ✅ Build succeeds
- ✅ After deletion, user sees home page with trip list
- ✅ Success toast still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)