### PR TITLE
Add location-based themed trip banners

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import { SettlementProvider } from '@/contexts/SettlementContext'
 import { MealProvider } from '@/contexts/MealContext'
 import { ShoppingProvider } from '@/contexts/ShoppingContext'
 import { Toaster } from '@/components/ui/toaster'
+import { TripBanner } from '@/components/TripBanner'
 import {
   Sheet,
   SheetContent,
@@ -36,7 +37,7 @@ const iconMap = {
 
 export function Layout() {
   const location = useLocation()
-  const { tripCode } = useCurrentTrip()
+  const { currentTrip, tripCode } = useCurrentTrip()
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
 
   // Desktop navigation - all items visible
@@ -105,14 +106,20 @@ export function Layout() {
       <header className="bg-card border-b border-border soft-shadow-sm fixed top-0 left-0 right-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center justify-between">
-            <motion.h1
-              className="text-2xl font-bold text-foreground"
-              initial={{ opacity: 0, x: -20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.3 }}
-            >
-              Trip Splitter Pro
-            </motion.h1>
+            {currentTrip ? (
+              <div className="flex-1 max-w-md">
+                <TripBanner tripName={currentTrip.name} compact />
+              </div>
+            ) : (
+              <motion.h1
+                className="text-2xl font-bold text-foreground"
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                Trip Splitter Pro
+              </motion.h1>
+            )}
           </div>
         </div>
       </header>

--- a/src/components/TripBanner.tsx
+++ b/src/components/TripBanner.tsx
@@ -1,0 +1,112 @@
+import { getTripGradientPattern } from '@/services/tripGradientService'
+import { motion } from 'framer-motion'
+
+export interface TripBannerProps {
+  tripName: string
+  compact?: boolean // For mobile/header version
+}
+
+export function TripBanner({ tripName, compact = false }: TripBannerProps) {
+  // Get deterministic gradient pattern for this trip
+  const pattern = getTripGradientPattern(tripName)
+
+  if (compact) {
+    // Compact version for header
+    return (
+      <motion.div
+        className="relative h-12 rounded-lg overflow-hidden shadow-md"
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.3 }}
+      >
+        {/* Gradient Background */}
+        <div
+          className="absolute inset-0"
+          style={{ background: pattern.gradient }}
+        />
+
+        {/* Icon Pattern Overlay (fewer icons for compact) */}
+        {pattern.icons.slice(0, 2).map((icon, i) => {
+          const Icon = icon.Icon
+          return (
+            <Icon
+              key={i}
+              size={icon.size * 0.6} // Smaller icons for compact
+              className="absolute text-white pointer-events-none"
+              style={{
+                left: `${icon.x}%`,
+                top: `${icon.y}%`,
+                transform: `translate(-50%, -50%) rotate(${icon.rotation}deg)`,
+                opacity: icon.opacity * 0.8,
+              }}
+            />
+          )
+        })}
+
+        {/* Gradient Overlay for text readability */}
+        <div className="absolute inset-0 bg-gradient-to-r from-black/40 via-black/20 to-transparent" />
+
+        {/* Content */}
+        <div className="relative h-full px-4 flex items-center">
+          <h1 className="text-white font-bold text-lg drop-shadow-md truncate">
+            {tripName}
+          </h1>
+        </div>
+      </motion.div>
+    )
+  }
+
+  // Full version for page headers
+  return (
+    <motion.div
+      className="relative w-full h-[160px] md:h-[200px] lg:h-[240px] rounded-lg overflow-hidden shadow-lg"
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      {/* Gradient Background */}
+      <div
+        className="absolute inset-0"
+        style={{ background: pattern.gradient }}
+      />
+
+      {/* Icon Pattern Overlay */}
+      {pattern.icons.map((icon, i) => {
+        const Icon = icon.Icon
+        return (
+          <Icon
+            key={i}
+            size={icon.size}
+            className="absolute text-white pointer-events-none"
+            style={{
+              left: `${icon.x}%`,
+              top: `${icon.y}%`,
+              transform: `translate(-50%, -50%) rotate(${icon.rotation}deg)`,
+              opacity: icon.opacity,
+            }}
+          />
+        )
+      })}
+
+      {/* Gradient Overlay for text readability */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent" />
+
+      {/* Content */}
+      <div className="relative h-full p-6 md:p-8 flex flex-col justify-end">
+        <div>
+          {/* Theme Badge */}
+          <div className="inline-block bg-white/20 backdrop-blur-sm px-3 py-1 rounded-full mb-3">
+            <span className="text-white text-xs md:text-sm font-medium capitalize">
+              {pattern.theme} Trip
+            </span>
+          </div>
+
+          {/* Trip Name */}
+          <h1 className="text-white font-bold text-3xl md:text-4xl lg:text-5xl drop-shadow-lg">
+            {tripName}
+          </h1>
+        </div>
+      </div>
+    </motion.div>
+  )
+}

--- a/src/services/tripGradientService.ts
+++ b/src/services/tripGradientService.ts
@@ -1,0 +1,171 @@
+/**
+ * Trip Gradient Service with Location-Themed Patterns
+ * Generates themed gradient backgrounds with location-specific icon overlays
+ */
+
+import type { LucideIcon } from 'lucide-react'
+import {
+  Palmtree,
+  Waves,
+  Sun,
+  Fish,
+  Shell,
+  Mountain,
+  Trees,
+  CloudSnow,
+  Snowflake,
+  TreePine,
+  Building2,
+  Landmark,
+  Coffee,
+  ShoppingBag,
+  Camera,
+  Plane,
+  MapPin,
+  Compass,
+  Luggage,
+  Map,
+} from 'lucide-react'
+
+export interface TripGradientPattern {
+  gradient: string
+  icons: Array<{
+    Icon: LucideIcon
+    x: number // percentage 0-100
+    y: number // percentage 0-100
+    size: number // pixels
+    rotation: number // degrees
+    opacity: number
+  }>
+  theme: string
+}
+
+// Theme definitions with keywords, gradients, and icons
+const THEMES = {
+  beach: {
+    keywords: ['beach', 'thailand', 'bali', 'hawaii', 'maldives', 'caribbean', 'coast', 'island', 'tropical', 'sea', 'ocean'],
+    gradients: [
+      'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', // Purple-blue
+      'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)', // Bright blue
+      'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)', // Turquoise
+      'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)', // Soft blue-pink
+      'linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%)', // Sandy
+    ],
+    icons: [Palmtree, Waves, Sun, Fish, Shell],
+  },
+  mountain: {
+    keywords: ['mountain', 'alps', 'hiking', 'trek', 'hill', 'peak', 'valley'],
+    gradients: [
+      'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', // Purple mountains
+      'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)', // Green
+      'linear-gradient(135deg, #30cfd0 0%, #330867 100%)', // Deep blue-green
+      'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)', // Soft pastels
+    ],
+    icons: [Mountain, Trees, TreePine],
+  },
+  ski: {
+    keywords: ['ski', 'snow', 'winter', 'himos', 'levi', 'alps', 'whistler', 'aspen', 'slope'],
+    gradients: [
+      'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)', // Icy pastels
+      'linear-gradient(135deg, #e0c3fc 0%, #8ec5fc 100%)', // Purple-blue ice
+      'linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)', // White-blue
+      'linear-gradient(135deg, #89f7fe 0%, #66a6ff 100%)', // Ice blue
+    ],
+    icons: [CloudSnow, Snowflake, Mountain, TreePine],
+  },
+  city: {
+    keywords: ['city', 'urban', 'paris', 'london', 'tokyo', 'york', 'berlin', 'rome', 'barcelona', 'amsterdam'],
+    gradients: [
+      'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', // Urban purple
+      'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)', // Vibrant pink
+      'linear-gradient(135deg, #fa709a 0%, #fee140 100%)', // Sunset city
+      'linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%)', // Soft pink
+    ],
+    icons: [Building2, Landmark, Coffee, ShoppingBag, Camera],
+  },
+  generic: {
+    keywords: [],
+    gradients: [
+      'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+      'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
+      'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
+      'linear-gradient(135deg, #fa709a 0%, #fee140 100%)',
+      'linear-gradient(135deg, #30cfd0 0%, #330867 100%)',
+      'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)',
+      'linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%)',
+      'linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%)',
+      'linear-gradient(135deg, #ff6e7f 0%, #bfe9ff 100%)',
+    ],
+    icons: [Plane, MapPin, Compass, Luggage, Map, Camera],
+  },
+}
+
+type ThemeKey = keyof typeof THEMES
+
+/**
+ * Detects theme from trip name
+ */
+function detectTheme(tripName: string): ThemeKey {
+  const lowerName = tripName.toLowerCase()
+
+  // Check each theme's keywords
+  for (const [themeName, theme] of Object.entries(THEMES)) {
+    if (themeName === 'generic') continue
+
+    for (const keyword of theme.keywords) {
+      if (lowerName.includes(keyword)) {
+        return themeName as ThemeKey
+      }
+    }
+  }
+
+  return 'generic'
+}
+
+/**
+ * Seeded random number generator for deterministic patterns
+ * Same seed + index always produces same result
+ */
+function seededRandom(seed: string, index: number): number {
+  const hash = (seed + index).split('').reduce((acc, char) => {
+    return ((acc << 5) - acc) + char.charCodeAt(0)
+  }, 0)
+  return Math.abs(Math.sin(hash))
+}
+
+/**
+ * Gets gradient pattern for a specific trip
+ * Same trip name always returns same themed gradient + icon pattern
+ */
+export function getTripGradientPattern(tripName: string): TripGradientPattern {
+  const theme = detectTheme(tripName)
+  const themeData = THEMES[theme]
+
+  // Select gradient deterministically based on trip name
+  const gradientIndex =
+    Math.abs(tripName.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)) %
+    themeData.gradients.length
+
+  const gradient = themeData.gradients[gradientIndex]
+
+  // Generate 3-4 icons deterministically
+  const iconCount = 3 + Math.floor(seededRandom(tripName, 0) * 2)
+  const icons = []
+
+  for (let i = 0; i < iconCount; i++) {
+    const iconIndex = Math.floor(seededRandom(tripName, i) * themeData.icons.length)
+    const Icon = themeData.icons[iconIndex]
+
+    icons.push({
+      Icon,
+      x: 10 + seededRandom(tripName, i * 10) * 80, // 10-90% positioning
+      y: 10 + seededRandom(tripName, i * 11) * 80, // 10-90% positioning
+      size: 80 + seededRandom(tripName, i * 12) * 60, // 80-140px
+      rotation: -20 + seededRandom(tripName, i * 13) * 40, // -20 to +20 degrees
+      opacity: 0.06 + seededRandom(tripName, i * 14) * 0.08, // 0.06-0.14 (subtle)
+    })
+  }
+
+  return { gradient, icons, theme }
+}


### PR DESCRIPTION
## Summary
- Implements dynamic trip banners with themed gradients and icons based on destination keywords
- Trip gradient service with 5 theme categories (beach, mountain, ski, city, generic)
- TripBanner component with compact (header) and full (page) display modes
- Updated Layout component to display trip banner in header when viewing a trip

## Key Features
- **Smart theme detection**: Analyzes trip names for location keywords (e.g., "Thailand" → beach, "Himos" → ski)
- **Deterministic patterns**: Same trip name always produces consistent visual theme
- **Icon overlays**: Location-specific Lucide icons (palm trees, snowflakes, buildings, etc.)
- **Responsive design**: Compact mode for header (48px), full mode for page headers (160-240px)

## Examples
- "Thailand Beach Trip" → Beach theme with tropical blue gradients + palm trees, waves, sun
- "Himos Ski Weekend" → Ski theme with icy gradients + snowflakes, mountains
- "Paris Adventure" → City theme with vibrant gradients + buildings, landmarks, camera
- "Mountain Hiking" → Mountain theme with green gradients + mountains, trees

## Technical Implementation
- `src/services/tripGradientService.ts` - Core theming logic with keyword detection
- `src/components/TripBanner.tsx` - Reusable banner component (compact/full modes)
- `src/components/Layout.tsx` - Updated to use TripBanner in header

## Test Plan
- [x] Create trips with different names (beach, ski, city, mountain locations)
- [x] Verify themes apply correctly based on keywords
- [x] Check responsive display in header (compact mode)
- [x] Confirm deterministic pattern generation (same trip → same visuals)
- [ ] Test on mobile devices
- [ ] Verify accessibility (contrast, readability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)