### PR TITLE
Fix critical double-counting bug in expense distribution

### DIFF
--- a/src/components/expenses/ExpenseSplitPreview.tsx
+++ b/src/components/expenses/ExpenseSplitPreview.tsx
@@ -164,8 +164,15 @@ export function ExpenseSplitPreview({
       }
     } else if (distribution.type === 'mixed') {
       if (splitMode === 'equal') {
-        // Mixed always accounts for family size (our recent fix)
-        let totalPeople = distribution.participants.length
+        // CRITICAL: Filter out family members from participants to avoid double-counting
+        const standaloneParticipants = distribution.participants.filter(participantId => {
+          const participant = participants.find(p => p.id === participantId)
+          if (!participant) return false
+          if (participant.family_id === null) return true
+          return !distribution.families.includes(participant.family_id)
+        })
+
+        let totalPeople = standaloneParticipants.length
 
         distribution.families.forEach(familyId => {
           const family = families.find(f => f.id === familyId)
@@ -193,8 +200,8 @@ export function ExpenseSplitPreview({
           }
         })
 
-        // Add standalone individuals
-        distribution.participants.forEach(participantId => {
+        // Add ONLY standalone individuals
+        standaloneParticipants.forEach(participantId => {
           const participant = participants.find(p => p.id === participantId)
           if (participant) {
             entries.push({
@@ -225,9 +232,16 @@ export function ExpenseSplitPreview({
           })
         }
 
-        // Add individuals by percentage
+        // Add ONLY standalone individuals by percentage
         if (distribution.participantSplits) {
-          distribution.participantSplits.forEach(split => {
+          const standaloneSplits = distribution.participantSplits.filter(split => {
+            const participant = participants.find(p => p.id === split.participantId)
+            if (!participant) return false
+            if (participant.family_id === null) return true
+            return !distribution.families.includes(participant.family_id)
+          })
+
+          standaloneSplits.forEach(split => {
             const participant = participants.find(p => p.id === split.participantId)
             if (participant) {
               const shareAmount = (amount * split.value) / 100
@@ -259,9 +273,16 @@ export function ExpenseSplitPreview({
           })
         }
 
-        // Add individuals by amount
+        // Add ONLY standalone individuals by amount
         if (distribution.participantSplits) {
-          distribution.participantSplits.forEach(split => {
+          const standaloneSplits = distribution.participantSplits.filter(split => {
+            const participant = participants.find(p => p.id === split.participantId)
+            if (!participant) return false
+            if (participant.family_id === null) return true
+            return !distribution.families.includes(participant.family_id)
+          })
+
+          standaloneSplits.forEach(split => {
             const participant = participants.find(p => p.id === split.participantId)
             if (participant) {
               entries.push({


### PR DESCRIPTION
## Critical Bug Fix

Fixes a **CRITICAL double-counting bug** where family members were being counted twice in expense calculations.

## The Problem

When creating expenses with both families and individuals selected, family members were being included in BOTH:
1. Their family's share (as part of family size)
2. The individual participants list

**Example from user data:**
- Total expense: €1,989.60
- Participants: 3 families (10 people) + 1 standalone individual (Kersti)
- **Expected**: €1,989.60 ÷ 11 people = **€180.87** per person
- **ACTUAL (buggy)**: Kersti paid only **€104.72** ❌

## Root Cause

No filtering was applied when building mixed distributions to ensure `distribution.participants` only contained standalone individuals (those with `family_id === null` and not in selected families).

## The Fix

**3 files modified:**

1. **ExpenseForm.tsx** (lines 293-304): Filter out family members when building mixed distribution
2. **balanceCalculator.ts** (3 locations): Added defensive filtering in equal/percentage/amount split modes
3. **ExpenseSplitPreview.tsx** (3 locations): Filter participants in preview for all split modes

## Impact

- **Before**: Family members counted twice → incorrect balances
- **After**: Each person counted exactly once → correct financial tracking

Now Kersti correctly pays €180.87 instead of €104.72.

## Testing

- ✅ Type check passes
- ✅ Build completes successfully
- Verified fix resolves user's reported issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)