### PR TITLE
Add Select/Deselect All buttons and Account for Family Size toggle to mobile

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -172,6 +172,16 @@ export function ExpenseForm({
     })
   }
 
+  const handleSelectAll = () => {
+    setSelectedParticipants(participants.map(p => p.id))
+    setSelectedFamilies(families.map(f => f.id))
+  }
+
+  const handleDeselectAll = () => {
+    setSelectedParticipants([])
+    setSelectedFamilies([])
+  }
+
   const handleParticipantSplitChange = (id: string, value: string) => {
     setParticipantSplitValues(prev => ({
       ...prev,
@@ -573,6 +583,31 @@ export function ExpenseForm({
       {/* Split Between */}
       <div className="space-y-2">
         <Label>Split Between</Label>
+
+        {/* Selection Controls */}
+        <div className="flex items-center gap-2 mb-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleSelectAll}
+            disabled={loading}
+            className="h-8 px-2 text-xs"
+          >
+            Select All
+          </Button>
+          <span className="text-muted-foreground">|</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleDeselectAll}
+            disabled={loading}
+            className="h-8 px-2 text-xs"
+          >
+            Deselect All
+          </Button>
+        </div>
 
         {isIndividualsMode ? (
           // Individuals mode - show participants

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -109,6 +109,7 @@ function MobileWizard({
     initialValues?.expense_date || new Date().toISOString().split('T')[0]
   )
   const [comment, setComment] = useState(initialValues?.comment || '')
+  const [accountForFamilySize, setAccountForFamilySize] = useState(false)
 
   const adults = getAdultParticipants()
   const isIndividualsMode = currentTrip?.tracking_mode === 'individuals'
@@ -158,6 +159,16 @@ function MobileWizard({
     )
   }
 
+  const handleSelectAll = () => {
+    setSelectedParticipants(participants.map((p) => p.id))
+    setSelectedFamilies(families.map((f) => f.id))
+  }
+
+  const handleDeselectAll = () => {
+    setSelectedParticipants([])
+    setSelectedFamilies([])
+  }
+
   const handleBack = () => {
     setCurrentStep((prev) => Math.max(1, prev - 1))
     setError(null)
@@ -182,6 +193,18 @@ function MobileWizard({
     setIsSubmitting(true)
 
     try {
+      // Validate selection
+      if (isIndividualsMode && selectedParticipants.length === 0) {
+        setError('Please select at least one person to split between')
+        setIsSubmitting(false)
+        return
+      }
+      if (!isIndividualsMode && selectedFamilies.length === 0 && selectedParticipants.length === 0) {
+        setError('Please select at least one family or person to split between')
+        setIsSubmitting(false)
+        return
+      }
+
       // Build distribution based on tracking mode
       let distribution: ExpenseDistribution
 
@@ -202,12 +225,14 @@ function MobileWizard({
             families: selectedFamilies,
             participants: selectedParticipants,
             splitMode: splitMode,
+            accountForFamilySize,
           }
         } else if (hasFamilies) {
           distribution = {
             type: 'families',
             families: selectedFamilies,
             splitMode: splitMode,
+            accountForFamilySize,
           }
         } else {
           distribution = {
@@ -322,6 +347,10 @@ function MobileWizard({
               selectedFamilies={selectedFamilies}
               onParticipantToggle={handleParticipantToggle}
               onFamilyToggle={handleFamilyToggle}
+              onSelectAll={handleSelectAll}
+              onDeselectAll={handleDeselectAll}
+              accountForFamilySize={accountForFamilySize}
+              onAccountForFamilySizeChange={setAccountForFamilySize}
               onAdvancedClick={handleAdvanced}
               disabled={isSubmitting}
             />

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -27,6 +27,10 @@ interface WizardStep3Props {
   selectedFamilies: string[]
   onParticipantToggle: (id: string) => void
   onFamilyToggle: (id: string) => void
+  onSelectAll: () => void
+  onDeselectAll: () => void
+  accountForFamilySize: boolean
+  onAccountForFamilySizeChange: (value: boolean) => void
   onAdvancedClick: () => void
   disabled?: boolean
 }
@@ -39,6 +43,10 @@ export function WizardStep3({
   selectedFamilies,
   onParticipantToggle,
   onFamilyToggle,
+  onSelectAll,
+  onDeselectAll,
+  accountForFamilySize,
+  onAccountForFamilySizeChange,
   onAdvancedClick,
   disabled = false,
 }: WizardStep3Props) {
@@ -90,6 +98,57 @@ export function WizardStep3({
           </div>
         </div>
       </div>
+
+      {/* Selection Controls */}
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onSelectAll}
+          disabled={disabled}
+          className="h-11 px-3 text-sm flex-1"
+        >
+          Select All
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onDeselectAll}
+          disabled={disabled}
+          className="h-11 px-3 text-sm flex-1"
+        >
+          Deselect All
+        </Button>
+      </div>
+
+      {/* Account for Family Size Toggle - Only show in families mode with families selected */}
+      {!isIndividualsMode && selectedFamilies.length > 0 && (
+        <div className="p-3 bg-accent/5 rounded-lg border border-accent/10">
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="accountForFamilySize-mobile"
+              checked={accountForFamilySize}
+              onCheckedChange={(checked) => onAccountForFamilySizeChange(checked as boolean)}
+              disabled={disabled}
+            />
+            <div className="flex-1 space-y-1">
+              <label
+                htmlFor="accountForFamilySize-mobile"
+                className="text-sm font-medium text-foreground cursor-pointer leading-none"
+              >
+                Account for family size
+              </label>
+              <p className="text-xs text-muted-foreground">
+                {accountForFamilySize
+                  ? 'Families pay proportionally by number of people (e.g., family of 4 pays 2× family of 2)'
+                  : 'All families pay equally regardless of size'}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Choose Specific People */}
       <div className="space-y-3">


### PR DESCRIPTION
## Summary
Improves expense allocation UX with two key features:

### 1. Select/Deselect All Buttons (Mobile + Desktop)
- Added buttons to quickly select or deselect all participants/families
- **Problem solved**: Users can now easily allocate expenses to just one person (e.g., coffee for one friend) by clicking "Deselect All" first, instead of manually unchecking everyone
- Mobile buttons are touch-friendly (44px height)
- Added validation with helpful error messages

### 2. Account for Family Size Toggle (Mobile)
- Added missing toggle to mobile wizard step 3
- **Problem solved**: Feature parity between mobile and desktop - toggle now appears on both
- Only shows when families are selected (conditional rendering)
- State management properly wired to distribution objects

## Files Modified
- `ExpenseForm.tsx`: Desktop Select/Deselect All handlers + UI
- `WizardStep3.tsx`: Mobile buttons + Account for Family Size toggle UI
- `ExpenseWizard.tsx`: Mobile state management + handlers + validation

## Test Plan
- [x] TypeScript type checking passes
- [x] Code compiles without errors
- [ ] Manual testing: Desktop Select All → all checked
- [ ] Manual testing: Desktop Deselect All → all unchecked
- [ ] Manual testing: Submit with none selected → validation error
- [ ] Manual testing: Mobile Select/Deselect All works
- [ ] Manual testing: Mobile family size toggle appears when families selected
- [ ] Manual testing: Toggle state included in expense distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)