### PR TITLE
Add Individuals section to show all people in families mode

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -719,6 +719,44 @@ export function ExpenseForm({
                 </div>
               )
             })()}
+            {/* All individuals - allows selecting specific people from families */}
+            <div>
+              <p className="text-xs text-muted-foreground mb-2">Individuals</p>
+              <div className="space-y-2 max-h-48 overflow-y-auto rounded-lg border border-input p-3">
+                {participants.map(participant => (
+                  <div key={participant.id} className="flex items-center space-x-2 min-h-[44px]">
+                    <Checkbox
+                      id={`individual-${participant.id}`}
+                      checked={selectedParticipants.includes(participant.id)}
+                      onCheckedChange={() => handleParticipantToggle(participant.id)}
+                      disabled={loading}
+                    />
+                    <label
+                      htmlFor={`individual-${participant.id}`}
+                      className="text-sm text-foreground cursor-pointer flex-1"
+                    >
+                      {participant.name} {participant.is_adult ? '' : '(child)'}
+                      {participant.family_id && (() => {
+                        const family = families.find(f => f.id === participant.family_id)
+                        return family ? ` (${family.family_name})` : ''
+                      })()}
+                    </label>
+                    {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
+                      <Input
+                        type="number"
+                        value={participantSplitValues[participant.id] || ''}
+                        onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value)}
+                        placeholder={splitMode === 'percentage' ? '%' : currency}
+                        step={splitMode === 'percentage' ? '0.1' : '0.01'}
+                        min="0"
+                        disabled={loading}
+                        className="w-24 h-9"
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
Adds an **Individuals** section to the expense form in families mode, allowing users to select specific people from within families.

## Problem Solved
Previously in families mode, users could only:
- Select whole families
- Select standalone individuals (people not in any family)

But couldn't select specific individuals from within families (e.g., buy coffee for just one person from a family).

## Changes
- Added "Individuals" section that shows ALL participants
- Each person displays their family name in parentheses for clarity
- Example: "Kristjan (Küngas)" shows Kristjan belongs to Küngas family
- Works with Select/Deselect All buttons
- Scrollable list (max-h-48) for many participants

## Use Case
Now you can:
1. Click "Deselect All"  
2. Select just one person from "Individuals" section
3. Add expense allocated to that one person

Perfect for scenarios like buying coffee for one friend!

🤖 Generated with [Claude Code](https://claude.com/claude-code)