### PR TITLE
Fix confusing summary message in mobile expense wizard

### DIFF
--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -92,7 +92,14 @@ export function WizardStep3({
             <p className="font-medium text-foreground">{getSelectionText()}</p>
             {allSelected && (
               <p className="text-sm text-muted-foreground mt-0.5">
-                Everyone shares the cost equally
+                {isIndividualsMode
+                  ? 'Everyone shares the cost equally'
+                  : selectedFamilies.length > 0
+                    ? accountForFamilySize
+                      ? 'Each person pays equally (families pay proportionally by size)'
+                      : 'Each family pays equally (regardless of size)'
+                    : 'Everyone shares the cost equally'
+                }
               </p>
             )}
           </div>


### PR DESCRIPTION
## Problem
The summary message in Step 3 said **"Everyone shares the cost equally"** which was misleading when families are involved.

With the toggle OFF, it actually means:
- Each FAMILY pays equally (not each person)
- A family of 4 pays the same as a family of 2
- So individuals in larger families pay less per person

## Solution
Made the summary message conditional and accurate:

### Toggle OFF (default)
**"Each family pays equally (regardless of size)"**
- Clear that families pay the same amount
- Not individuals

### Toggle ON  
**"Each person pays equally (families pay proportionally by size)"**
- Clear that each person pays the same
- Families with more people pay more

## Screenshots
Before: "Everyone shares the cost equally" (confusing ❌)
After: Accurate message based on toggle state (clear ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)