### PR TITLE
Simplify split summary to be clearer

### DIFF
--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -90,15 +90,11 @@ export function WizardStep3({
           <Users size={24} className="text-primary flex-shrink-0" />
           <div className="flex-1 min-w-0">
             <p className="font-medium text-foreground">{getSelectionText()}</p>
-            {allSelected && (
+            {allSelected && !isIndividualsMode && selectedFamilies.length > 0 && (
               <p className="text-sm text-muted-foreground mt-0.5">
-                {isIndividualsMode
-                  ? 'Everyone shares the cost equally'
-                  : selectedFamilies.length > 0
-                    ? accountForFamilySize
-                      ? 'Each person pays equally (families pay proportionally by size)'
-                      : 'Each family pays equally (regardless of size)'
-                    : 'Everyone shares the cost equally'
+                {accountForFamilySize
+                  ? 'Split by people - larger families pay more'
+                  : 'Split by families - all families pay the same'
                 }
               </p>
             )}


### PR DESCRIPTION
## Problem
The summary message was too wordy and confusing:
- Toggle OFF: "Each family pays equally (regardless of size)" + "All families pay equally regardless of size" (redundant!)
- Toggle ON: "Each person pays equally (families pay proportionally by size)" (too technical)

## Solution
Simple, clear messages:

### Toggle OFF
**"Split by families - all families pay the same"**
- Easy to understand
- Makes it clear what "families pay the same" means

### Toggle ON
**"Split by people - larger families pay more"**
- Immediately clear
- Shows the consequence (larger families pay more)

## Additional Changes
- Only show this summary when families are involved
- Removed for individuals-only mode to avoid redundancy

Much clearer UX! ✨

🤖 Generated with [Claude Code](https://claude.com/claude-code)