### PR TITLE
Remove confusing reactive summary message

### DIFF
--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -90,14 +90,6 @@ export function WizardStep3({
           <Users size={24} className="text-primary flex-shrink-0" />
           <div className="flex-1 min-w-0">
             <p className="font-medium text-foreground">{getSelectionText()}</p>
-            {allSelected && !isIndividualsMode && selectedFamilies.length > 0 && (
-              <p className="text-sm text-muted-foreground mt-0.5">
-                {accountForFamilySize
-                  ? 'Split by people - larger families pay more'
-                  : 'Split by families - all families pay the same'
-                }
-              </p>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Problem
The summary message at the top was **changing based on toggle state**, which created confusion:

### Before Toggling:
- Summary: "Split by families - all families pay the same"
- Toggle: "All families pay equally regardless of size"
- User thinks: "These say the same thing... why is there a toggle?"

### After Toggling:
- Summary changes to: "Split by people - larger families pay more"
- User is surprised the summary changed

**Key Issues:**
1. Not obvious the summary would change
2. Summary and toggle seemed redundant before toggling
3. Unclear what the toggle actually does

## Solution
**Remove the reactive summary message completely.**

Now the summary is **static** and just shows the selection:
> "Split equally between all 4 families and 16 individuals"

The toggle's own description is already clear:
- OFF: "All families pay equally regardless of size"
- ON: "Families pay proportionally by number of people"

No more confusion! 🎉

## Changes
- Removed lines 93-100 from WizardStep3.tsx
- Summary card now only shows selection text (static)
- Toggle descriptions remain clear and self-explanatory

🤖 Generated with [Claude Code](https://claude.com/claude-code)