### PR TITLE
Fix mixed distribution losing shares for standalone family members

### DIFF
--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -323,7 +323,15 @@ function calculateExpenseShares(
       // Assign per-person share to STANDALONE individuals only
       standaloneParticipants.forEach(participantId => {
         if (trackingMode === 'families') {
-          shares.set(participantId, perPersonShare)
+          // In families mode, aggregate under the family ID so it matches the balance map
+          const participant = participants.find(p => p.id === participantId)
+          const familyId = participant?.family_id
+          if (familyId) {
+            const currentShare = shares.get(familyId) || 0
+            shares.set(familyId, currentShare + perPersonShare)
+          } else {
+            shares.set(participantId, perPersonShare)
+          }
         } else {
           shares.set(participantId, perPersonShare)
         }
@@ -350,7 +358,14 @@ function calculateExpenseShares(
         standaloneSplits.forEach(split => {
           const shareAmount = (expense.amount * split.value) / 100
           if (trackingMode === 'families') {
-            shares.set(split.participantId, shareAmount)
+            const participant = participants.find(p => p.id === split.participantId)
+            const familyId = participant?.family_id
+            if (familyId) {
+              const currentShare = shares.get(familyId) || 0
+              shares.set(familyId, currentShare + shareAmount)
+            } else {
+              shares.set(split.participantId, shareAmount)
+            }
           } else {
             shares.set(split.participantId, shareAmount)
           }
@@ -376,7 +391,14 @@ function calculateExpenseShares(
 
         standaloneSplits.forEach(split => {
           if (trackingMode === 'families') {
-            shares.set(split.participantId, split.value)
+            const participant = participants.find(p => p.id === split.participantId)
+            const familyId = participant?.family_id
+            if (familyId) {
+              const currentShare = shares.get(familyId) || 0
+              shares.set(familyId, currentShare + split.value)
+            } else {
+              shares.set(split.participantId, split.value)
+            }
           } else {
             shares.set(split.participantId, split.value)
           }


### PR DESCRIPTION
## Summary

- **Bug:** In families tracking mode, expenses with `mixed` distribution (some families + some individual participants) were silently dropping the individual participants' shares. The shares were keyed by participant ID, but the balance map only contains family IDs, so they were never applied.
- **Impact:** On the Himos 2025 trip, the "Pood supi ja muu jaoks" (€60) expense split among 3 families + 4 individual Hindriks members lost the Hindriks ~€15 share, causing Elias to show +€15.01 owed while the settlements page showed "All Settled."
- **Fix:** Aggregate standalone participants' shares under their family ID in all three split modes (equal, percentage, amount) of the mixed distribution handler, matching the pattern already used in the individuals distribution handler.

## Test plan

- [ ] Verify Himos 2025 dashboard balances now net to ~€0 (within rounding)
- [ ] Verify settlements page and dashboard agree on settled status
- [ ] Test creating a new mixed-distribution expense (families + individual members) and confirm shares are correctly assigned
- [ ] Test that non-mixed distribution expenses are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)