### PR TITLE
Add Thai Baht currency support with exchange rates

### DIFF
--- a/src/components/CostPerParticipantChart.tsx
+++ b/src/components/CostPerParticipantChart.tsx
@@ -5,9 +5,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 interface CostPerParticipantChartProps {
   balances: ParticipantBalance[]
+  currency?: string
 }
 
-export function CostPerParticipantChart({ balances }: CostPerParticipantChartProps) {
+export function CostPerParticipantChart({ balances, currency = 'EUR' }: CostPerParticipantChartProps) {
   const chartData = useMemo(() => {
     return balances
       .map(balance => ({
@@ -42,7 +43,7 @@ export function CostPerParticipantChart({ balances }: CostPerParticipantChartPro
           <p className="text-sm text-muted-foreground">
             Total Share: {new Intl.NumberFormat('en-US', {
               style: 'currency',
-              currency: 'EUR',
+              currency: currency,
             }).format(data.totalShare)}
           </p>
         </div>
@@ -72,7 +73,7 @@ export function CostPerParticipantChart({ balances }: CostPerParticipantChartPro
             />
             <YAxis
               tick={{ fill: 'hsl(var(--foreground))', fontSize: 12 }}
-              tickFormatter={(value) => `€${value}`}
+              tickFormatter={(value) => new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: 0 }).format(value)}
             />
             <Tooltip content={<CustomTooltip />} />
             <Bar dataKey="totalShare" radius={[8, 8, 0, 0]}>

--- a/src/components/ExpenseByCategoryChart.tsx
+++ b/src/components/ExpenseByCategoryChart.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 interface ExpenseByCategoryChartProps {
   expenses: Expense[]
+  currency?: string
 }
 
 const CATEGORY_COLORS = {
@@ -16,7 +17,7 @@ const CATEGORY_COLORS = {
   Other: 'hsl(0, 0%, 60%)', // Gray
 }
 
-export function ExpenseByCategoryChart({ expenses }: ExpenseByCategoryChartProps) {
+export function ExpenseByCategoryChart({ expenses, currency = 'EUR' }: ExpenseByCategoryChartProps) {
   const chartData = useMemo(() => {
     // Group expenses by category and sum amounts
     const categoryTotals = expenses.reduce((acc, expense) => {
@@ -69,7 +70,7 @@ export function ExpenseByCategoryChart({ expenses }: ExpenseByCategoryChartProps
           <p className="text-sm text-muted-foreground">
             {new Intl.NumberFormat('en-US', {
               style: 'currency',
-              currency: 'EUR',
+              currency: currency,
             }).format(data.value)}
           </p>
           <p className="text-xs text-accent font-semibold">{data.percentage}%</p>
@@ -112,7 +113,7 @@ export function ExpenseByCategoryChart({ expenses }: ExpenseByCategoryChartProps
                 <span className="text-sm text-foreground">
                   {value} ({new Intl.NumberFormat('en-US', {
                     style: 'currency',
-                    currency: 'EUR',
+                    currency: currency,
                   }).format(entry.payload.value)})
                 </span>
               )}

--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -33,7 +33,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote 
   const [fromParticipantId, setFromParticipantId] = useState('')
   const [toParticipantId, setToParticipantId] = useState('')
   const [amount, setAmount] = useState(initialAmount?.toString() || '')
-  const [currency, setCurrency] = useState('EUR')
+  const [currency, setCurrency] = useState(currentTrip?.default_currency || 'EUR')
   const [settlementDate, setSettlementDate] = useState(
     new Date().toISOString().split('T')[0]
   )
@@ -269,6 +269,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote 
               <SelectItem value="EUR">EUR</SelectItem>
               <SelectItem value="USD">USD</SelectItem>
               <SelectItem value="GBP">GBP</SelectItem>
+              <SelectItem value="THB">THB</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/components/TopExpensesList.tsx
+++ b/src/components/TopExpensesList.tsx
@@ -9,9 +9,10 @@ interface TopExpensesListProps {
   expenses: Expense[]
   participants: Participant[]
   limit?: number
+  currency?: string
 }
 
-export function TopExpensesList({ expenses, participants, limit = 5 }: TopExpensesListProps) {
+export function TopExpensesList({ expenses, participants, limit = 5, currency = 'EUR' }: TopExpensesListProps) {
   const topExpenses = useMemo(() => {
     return expenses
       .slice()
@@ -79,7 +80,7 @@ export function TopExpensesList({ expenses, participants, limit = 5 }: TopExpens
                 <span className="font-bold text-foreground tabular-nums text-lg">
                   {new Intl.NumberFormat('en-US', {
                     style: 'currency',
-                    currency: 'EUR',
+                    currency: expense.currency || currency,
                   }).format(expense.amount)}
                 </span>
               </div>

--- a/src/components/TripForm.tsx
+++ b/src/components/TripForm.tsx
@@ -4,6 +4,13 @@ import { CreateTripInput, TrackingMode } from '@/types/trip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
 
 interface TripFormProps {
@@ -27,6 +34,7 @@ export function TripForm({
   const [startDate, setStartDate] = useState(initialValues?.start_date || new Date().toISOString().split('T')[0])
   const [endDate, setEndDate] = useState(initialValues?.end_date || new Date().toISOString().split('T')[0])
   const [trackingMode, setTrackingMode] = useState<TrackingMode>(initialValues?.tracking_mode || 'individuals')
+  const [defaultCurrency, setDefaultCurrency] = useState(initialValues?.default_currency || 'EUR')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -52,7 +60,8 @@ export function TripForm({
         name: name.trim(),
         start_date: startDate,
         end_date: endDate,
-        tracking_mode: trackingMode
+        tracking_mode: trackingMode,
+        default_currency: defaultCurrency,
       })
     } catch (err) {
       setError('Failed to save trip. Please try again.')
@@ -117,6 +126,28 @@ export function TripForm({
             disabled={isSubmitting}
           />
         </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="defaultCurrency">Default Currency</Label>
+        <Select
+          value={defaultCurrency}
+          onValueChange={setDefaultCurrency}
+          disabled={isSubmitting}
+        >
+          <SelectTrigger id="defaultCurrency">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="EUR">EUR - Euro</SelectItem>
+            <SelectItem value="USD">USD - US Dollar</SelectItem>
+            <SelectItem value="GBP">GBP - British Pound</SelectItem>
+            <SelectItem value="THB">THB - Thai Baht</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          All balances and settlements will be shown in this currency
+        </p>
       </div>
 
       <div className="space-y-3">

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -52,7 +52,7 @@ export function ExpenseForm({
 
   const [description, setDescription] = useState(initialValues?.description || '')
   const [amount, setAmount] = useState(initialValues?.amount?.toString() || '')
-  const [currency, setCurrency] = useState(initialValues?.currency || 'EUR')
+  const [currency, setCurrency] = useState(initialValues?.currency || currentTrip?.default_currency || 'EUR')
   const [paidBy, setPaidBy] = useState(initialValues?.paid_by || '')
   const [category, setCategory] = useState<ExpenseCategory>(initialValues?.category || 'Food')
   const [expenseDate, setExpenseDate] = useState(
@@ -79,7 +79,7 @@ export function ExpenseForm({
 
   // Calculate balances to find suggested payer (including settlements)
   const balanceCalculation = currentTrip
-    ? calculateBalances(expenses, participants, families, currentTrip.tracking_mode, settlements)
+    ? calculateBalances(expenses, participants, families, currentTrip.tracking_mode, settlements, currentTrip.default_currency, currentTrip.exchange_rates)
     : null
   const suggestedPayer = balanceCalculation?.suggestedNextPayer
 
@@ -453,6 +453,7 @@ export function ExpenseForm({
               <SelectItem value="EUR">EUR</SelectItem>
               <SelectItem value="USD">USD</SelectItem>
               <SelectItem value="GBP">GBP</SelectItem>
+              <SelectItem value="THB">THB</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -97,7 +97,7 @@ function MobileWizard({
   // Form state
   const [description, setDescription] = useState(initialValues?.description || '')
   const [amount, setAmount] = useState(initialValues?.amount?.toString() || '')
-  const [currency, setCurrency] = useState(initialValues?.currency || 'EUR')
+  const [currency, setCurrency] = useState(initialValues?.currency || currentTrip?.default_currency || 'EUR')
   const [paidBy, setPaidBy] = useState(initialValues?.paid_by || '')
   const [selectedParticipants, setSelectedParticipants] = useState<string[]>([])
   const [selectedFamilies, setSelectedFamilies] = useState<string[]>([])
@@ -116,7 +116,7 @@ function MobileWizard({
 
   // Calculate balances for smart payer suggestion
   const balanceCalculation = currentTrip
-    ? calculateBalances(expenses, participants, families, currentTrip.tracking_mode, settlements)
+    ? calculateBalances(expenses, participants, families, currentTrip.tracking_mode, settlements, currentTrip.default_currency, currentTrip.exchange_rates)
     : null
   const suggestedPayer = balanceCalculation?.suggestedNextPayer
 

--- a/src/components/expenses/wizard/WizardStep1.tsx
+++ b/src/components/expenses/wizard/WizardStep1.tsx
@@ -97,6 +97,7 @@ export function WizardStep1({
               <SelectItem value="EUR">EUR</SelectItem>
               <SelectItem value="USD">USD</SelectItem>
               <SelectItem value="GBP">GBP</SelectItem>
+              <SelectItem value="THB">THB</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -38,13 +38,15 @@ export function DashboardPage() {
     )
   }
 
-  // Calculate balances (including settlements)
+  // Calculate balances (including settlements, with currency conversion)
   const balanceCalculation = calculateBalances(
     expenses,
     participants,
     families,
     currentTrip.tracking_mode,
-    settlements
+    settlements,
+    currentTrip.default_currency,
+    currentTrip.exchange_rates
   )
 
   const handleExportPDF = () => {
@@ -78,7 +80,7 @@ export function DashboardPage() {
             <div className="text-2xl font-bold text-foreground tabular-nums">
               {new Intl.NumberFormat('en-US', {
                 style: 'currency',
-                currency: 'EUR',
+                currency: currentTrip.default_currency,
               }).format(balanceCalculation.totalExpenses)}
             </div>
             <div className="text-xs text-muted-foreground mt-1">
@@ -114,7 +116,7 @@ export function DashboardPage() {
             <div className="text-2xl font-bold text-foreground tabular-nums">
               {new Intl.NumberFormat('en-US', {
                 style: 'currency',
-                currency: 'EUR',
+                currency: currentTrip.default_currency,
               }).format(
                 Math.abs(balanceCalculation.balances
                   .filter(b => b.balance < 0)
@@ -165,7 +167,7 @@ export function DashboardPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {balanceCalculation.balances.map(balance => (
-              <BalanceCard key={balance.id} balance={balance} currency="EUR" />
+              <BalanceCard key={balance.id} balance={balance} currency={currentTrip.default_currency} />
             ))}
           </div>
         )}
@@ -213,6 +215,7 @@ export function DashboardPage() {
                 expenses={expenses}
                 participants={participants}
                 limit={5}
+                currency={currentTrip.default_currency}
               />
             </Suspense>
 
@@ -228,7 +231,7 @@ export function DashboardPage() {
                   </CardContent>
                 </Card>
               }>
-                <ExpenseByCategoryChart expenses={expenses} />
+                <ExpenseByCategoryChart expenses={expenses} currency={currentTrip.default_currency} />
               </Suspense>
 
               {/* Cost per Participant Chart */}
@@ -241,7 +244,7 @@ export function DashboardPage() {
                   </CardContent>
                 </Card>
               }>
-                <CostPerParticipantChart balances={balanceCalculation.balances} />
+                <CostPerParticipantChart balances={balanceCalculation.balances} currency={currentTrip.default_currency} />
               </Suspense>
             </div>
           </div>

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -71,7 +71,9 @@ export function ExpensesPage() {
       participants,
       families,
       currentTrip.tracking_mode,
-      settlements
+      settlements,
+      currentTrip.default_currency,
+      currentTrip.exchange_rates
     ).balances
 
     exportExpensesToExcel(currentTrip, expenses, participants, families, balances, settlements)
@@ -225,7 +227,10 @@ export function ExpensesPage() {
                     Showing {filteredExpenses.length} of {expenses.length} expenses
                   </p>
                   <p className="text-sm font-medium text-foreground tabular-nums">
-                    Total: €{filteredExpenses.reduce((sum, exp) => sum + exp.amount, 0).toFixed(2)}
+                    Total: {new Intl.NumberFormat('en-US', {
+                      style: 'currency',
+                      currency: currentTrip.default_currency,
+                    }).format(filteredExpenses.reduce((sum, exp) => sum + exp.amount, 0))}
                   </p>
                 </div>
                 {filteredExpenses.map(expense => (

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -39,19 +39,21 @@ export function SettlementsPage() {
     )
   }
 
-  // Calculate balances (including settlements)
+  // Calculate balances (including settlements, with currency conversion)
   const balanceCalculation = calculateBalances(
     expenses,
     participants,
     families,
     currentTrip.tracking_mode,
-    settlements
+    settlements,
+    currentTrip.default_currency,
+    currentTrip.exchange_rates
   )
 
   // Calculate optimal settlement
   const optimalSettlement = calculateOptimalSettlement(
     balanceCalculation.balances,
-    'EUR' // TODO: Get from trip settings
+    currentTrip.default_currency
   )
 
   const handleRecordSettlement = (transaction: SettlementTransaction) => {
@@ -117,7 +119,7 @@ export function SettlementsPage() {
               <div className="text-2xl font-bold text-foreground tabular-nums">
                 {new Intl.NumberFormat('en-US', {
                   style: 'currency',
-                  currency: 'EUR',
+                  currency: currentTrip.default_currency,
                 }).format(
                   balanceCalculation.balances
                     .filter(b => b.balance < 0)

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -7,6 +7,8 @@ export interface Trip {
   start_date: string // ISO date string (YYYY-MM-DD)
   end_date: string // ISO date string (YYYY-MM-DD)
   tracking_mode: TrackingMode
+  default_currency: string
+  exchange_rates: Record<string, number>
   created_at: string
 }
 
@@ -16,6 +18,7 @@ export interface CreateTripInput {
   end_date: string
   tracking_mode: TrackingMode
   trip_code?: string // Optional: will be auto-generated if not provided
+  default_currency?: string
 }
 
 export interface UpdateTripInput {
@@ -23,4 +26,6 @@ export interface UpdateTripInput {
   start_date?: string
   end_date?: string
   tracking_mode?: TrackingMode
+  default_currency?: string
+  exchange_rates?: Record<string, number>
 }

--- a/supabase/migrations/011_trip_currency_settings.sql
+++ b/supabase/migrations/011_trip_currency_settings.sql
@@ -1,0 +1,3 @@
+-- Add currency settings to trips
+ALTER TABLE trips ADD COLUMN default_currency TEXT NOT NULL DEFAULT 'EUR';
+ALTER TABLE trips ADD COLUMN exchange_rates JSONB NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## Summary
- Adds THB (Thai Baht) to all currency selectors across the app
- Adds trip-level `default_currency` and `exchange_rates` settings with a new Currency Settings UI on the Manage Trip page
- All balances, settlements, and charts now convert amounts to the trip's base currency using configured exchange rates
- Includes database migration (`011_trip_currency_settings.sql`)

## Test plan
- [ ] Create a new trip — verify default currency selector appears
- [ ] Go to Manage Trip > Currency Settings, set default to EUR, add THB rate (e.g. 38.5)
- [ ] Add expenses in both EUR and THB
- [ ] Verify Dashboard balances are all in EUR with THB amounts converted
- [ ] Verify Settlements page shows optimal settlement in EUR
- [ ] Verify expense forms default to trip's currency, not hardcoded EUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)