### PR TITLE
Fix currency balance display to use narrow symbols

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -479,7 +479,7 @@ export function ExpenseForm({
                 <p className="text-xs text-muted-foreground mt-1">
                   Current balance:{' '}
                   <span className={getBalanceColorClass(suggestedPayer.balance)}>
-                    {formatBalance(suggestedPayer.balance, currency)}
+                    {formatBalance(suggestedPayer.balance, currentTrip?.default_currency || 'EUR')}
                   </span>
                 </p>
               </div>

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -333,7 +333,7 @@ function MobileWizard({
                     }
                   : null
               }
-              currency={currency}
+              currency={currentTrip?.default_currency || 'EUR'}
               disabled={isSubmitting}
             />
           )}

--- a/src/components/expenses/wizard/WizardStep2.tsx
+++ b/src/components/expenses/wizard/WizardStep2.tsx
@@ -40,9 +40,14 @@ export function WizardStep2({
   disabled = false,
 }: WizardStep2Props) {
   const formatBalance = (balance: number, curr: string) => {
-    const absBalance = Math.abs(balance)
-    const sign = balance < 0 ? '-' : ''
-    return `${sign}${curr} ${absBalance.toFixed(2)}`
+    const formatted = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: curr,
+      currencyDisplay: 'narrowSymbol',
+    }).format(Math.abs(balance))
+    if (balance < 0) return `-${formatted}`
+    if (balance > 0) return `+${formatted}`
+    return formatted
   }
 
   const handleSuggestionClick = () => {

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -469,6 +469,7 @@ export function formatBalance(balance: number, currency: string = 'EUR'): string
   const formatted = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: currency,
+    currencyDisplay: 'narrowSymbol',
   }).format(Math.abs(balance))
 
   if (balance > 0) {


### PR DESCRIPTION
## Summary
- Use `currencyDisplay: 'narrowSymbol'` so THB shows as ฿ instead of the clunky `THB` code prefix (e.g. `-฿1,559.79` instead of `-THB 1,559.79`)
- Fix suggested payer balance to always display in the trip's default currency, not the expense form's currently selected currency

## Test plan
- [ ] Open expense form on a THB trip — suggested payer balance should show `฿` symbol
- [ ] Change expense currency to USD — suggested payer balance should still show in trip's default currency

🤖 Generated with [Claude Code](https://claude.com/claude-code)