### PR TITLE
Fix expense total conversion and show EUR equivalent

### DIFF
--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -13,6 +13,8 @@ import {
 } from 'lucide-react'
 import { Expense } from '@/types/expense'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { convertToBaseCurrency } from '@/services/balanceCalculator'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
@@ -25,6 +27,11 @@ interface ExpenseCardProps {
 
 export function ExpenseCard({ expense, onEdit, onDelete }: ExpenseCardProps) {
   const { participants, families } = useParticipantContext()
+  const { currentTrip } = useCurrentTrip()
+
+  const defaultCurrency = currentTrip?.default_currency || 'EUR'
+  const exchangeRates = currentTrip?.exchange_rates || {}
+  const isForeignCurrency = expense.currency !== defaultCurrency
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {
@@ -144,8 +151,15 @@ export function ExpenseCard({ expense, onEdit, onDelete }: ExpenseCardProps) {
           </div>
 
           <div className="flex flex-col items-end gap-2 ml-4">
-            <div className="text-xl font-bold text-foreground whitespace-nowrap tabular-nums">
-              {formatAmount(expense.amount, expense.currency)}
+            <div className="text-right">
+              <div className="text-xl font-bold text-foreground whitespace-nowrap tabular-nums">
+                {formatAmount(expense.amount, expense.currency)}
+              </div>
+              {isForeignCurrency && exchangeRates[expense.currency] && (
+                <div className="text-xs text-muted-foreground tabular-nums">
+                  ({formatAmount(convertToBaseCurrency(expense.amount, expense.currency, defaultCurrency, exchangeRates), defaultCurrency)})
+                </div>
+              )}
             </div>
             <div className="flex gap-1">
               <Button

--- a/src/components/TopExpensesList.tsx
+++ b/src/components/TopExpensesList.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { TrendingUp } from 'lucide-react'
 import type { Expense } from '@/types/expense'
 import type { Participant } from '@/types/participant'
+import { convertToBaseCurrency } from '@/services/balanceCalculator'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 
@@ -10,9 +11,10 @@ interface TopExpensesListProps {
   participants: Participant[]
   limit?: number
   currency?: string
+  exchangeRates?: Record<string, number>
 }
 
-export function TopExpensesList({ expenses, participants, limit = 5, currency = 'EUR' }: TopExpensesListProps) {
+export function TopExpensesList({ expenses, participants, limit = 5, currency = 'EUR', exchangeRates = {} }: TopExpensesListProps) {
   const topExpenses = useMemo(() => {
     return expenses
       .slice()
@@ -77,12 +79,22 @@ export function TopExpensesList({ expenses, participants, limit = 5, currency = 
                 <Badge variant="outline" className="text-xs">
                   {expense.category}
                 </Badge>
-                <span className="font-bold text-foreground tabular-nums text-lg">
-                  {new Intl.NumberFormat('en-US', {
-                    style: 'currency',
-                    currency: expense.currency || currency,
-                  }).format(expense.amount)}
-                </span>
+                <div className="text-right">
+                  <span className="font-bold text-foreground tabular-nums text-lg">
+                    {new Intl.NumberFormat('en-US', {
+                      style: 'currency',
+                      currency: expense.currency || currency,
+                    }).format(expense.amount)}
+                  </span>
+                  {expense.currency && expense.currency !== currency && exchangeRates[expense.currency] && (
+                    <div className="text-xs text-muted-foreground tabular-nums">
+                      ({new Intl.NumberFormat('en-US', {
+                        style: 'currency',
+                        currency: currency,
+                      }).format(convertToBaseCurrency(expense.amount, expense.currency, currency, exchangeRates))})
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           ))}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -216,6 +216,7 @@ export function DashboardPage() {
                 participants={participants}
                 limit={5}
                 currency={currentTrip.default_currency}
+                exchangeRates={currentTrip.exchange_rates}
               />
             </Suspense>
 

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -4,7 +4,7 @@ import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
-import { calculateBalances } from '@/services/balanceCalculator'
+import { calculateBalances, convertToBaseCurrency } from '@/services/balanceCalculator'
 import { exportExpensesToExcel } from '@/services/excelExport'
 import { ExpenseWizard } from '@/components/expenses/ExpenseWizard'
 import { ExpenseCard } from '@/components/ExpenseCard'
@@ -230,7 +230,7 @@ export function ExpensesPage() {
                     Total: {new Intl.NumberFormat('en-US', {
                       style: 'currency',
                       currency: currentTrip.default_currency,
-                    }).format(filteredExpenses.reduce((sum, exp) => sum + exp.amount, 0))}
+                    }).format(filteredExpenses.reduce((sum, exp) => sum + convertToBaseCurrency(exp.amount, exp.currency, currentTrip.default_currency, currentTrip.exchange_rates), 0))}
                   </p>
                 </div>
                 {filteredExpenses.map(expense => (


### PR DESCRIPTION
## Summary
- Fix expenses list total to convert each expense to base currency before summing (was naively adding THB amounts as EUR)
- Show converted amount in parentheses on expense cards when currency differs from trip default, e.g. `THB 5,000.00 (€129.87)`
- Same treatment in Top 5 Expenses list on dashboard

## Test plan
- [ ] Expenses page total should show correct converted sum
- [ ] THB expense cards should show `(€xx.xx)` below the THB amount
- [ ] EUR expense cards should NOT show a parenthesized amount
- [ ] Top 5 Expenses on dashboard should show the same parenthesized conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)