### PR TITLE
Fix analytics charts to sort and sum by converted amounts

### DIFF
--- a/src/components/ExpenseByCategoryChart.tsx
+++ b/src/components/ExpenseByCategoryChart.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react'
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts'
 import type { Expense } from '@/types/expense'
+import { convertToBaseCurrency } from '@/services/balanceCalculator'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 interface ExpenseByCategoryChartProps {
   expenses: Expense[]
   currency?: string
+  exchangeRates?: Record<string, number>
 }
 
 const CATEGORY_COLORS = {
@@ -17,15 +19,15 @@ const CATEGORY_COLORS = {
   Other: 'hsl(0, 0%, 60%)', // Gray
 }
 
-export function ExpenseByCategoryChart({ expenses, currency = 'EUR' }: ExpenseByCategoryChartProps) {
+export function ExpenseByCategoryChart({ expenses, currency = 'EUR', exchangeRates = {} }: ExpenseByCategoryChartProps) {
   const chartData = useMemo(() => {
-    // Group expenses by category and sum amounts
+    // Group expenses by category and sum converted amounts
     const categoryTotals = expenses.reduce((acc, expense) => {
       const category = expense.category
       if (!acc[category]) {
         acc[category] = 0
       }
-      acc[category] += expense.amount
+      acc[category] += convertToBaseCurrency(expense.amount, expense.currency, currency, exchangeRates)
       return acc
     }, {} as Record<string, number>)
 

--- a/src/components/TopExpensesList.tsx
+++ b/src/components/TopExpensesList.tsx
@@ -18,7 +18,7 @@ export function TopExpensesList({ expenses, participants, limit = 5, currency = 
   const topExpenses = useMemo(() => {
     return expenses
       .slice()
-      .sort((a, b) => b.amount - a.amount)
+      .sort((a, b) => convertToBaseCurrency(b.amount, b.currency, currency, exchangeRates) - convertToBaseCurrency(a.amount, a.currency, currency, exchangeRates))
       .slice(0, limit)
       .map(expense => {
         const payer = participants.find(p => p.id === expense.paid_by)

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -232,7 +232,7 @@ export function DashboardPage() {
                   </CardContent>
                 </Card>
               }>
-                <ExpenseByCategoryChart expenses={expenses} currency={currentTrip.default_currency} />
+                <ExpenseByCategoryChart expenses={expenses} currency={currentTrip.default_currency} exchangeRates={currentTrip.exchange_rates} />
               </Suspense>
 
               {/* Cost per Participant Chart */}


### PR DESCRIPTION
## Summary
- Top 5 Expenses now sorts by converted base currency amount — THB 5,000 (€138.89) no longer ranks above €2,329.63
- Category pie chart sums converted amounts instead of raw values

🤖 Generated with [Claude Code](https://claude.com/claude-code)