### PR TITLE
Add Google OAuth, Quick Mode UI, and user preferences

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,19 @@
 import { BrowserRouter } from 'react-router-dom'
 import { AppRoutes } from './routes'
 import { TripProvider } from './contexts/TripContext'
+import { AuthProvider } from './contexts/AuthContext'
+import { UserPreferencesProvider } from './contexts/UserPreferencesContext'
 
 function App() {
   return (
     <BrowserRouter>
-      <TripProvider>
-        <AppRoutes />
-      </TripProvider>
+      <AuthProvider>
+        <TripProvider>
+          <UserPreferencesProvider>
+            <AppRoutes />
+          </UserPreferencesProvider>
+        </TripProvider>
+      </AuthProvider>
     </BrowserRouter>
   )
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useAuth } from '@/contexts/AuthContext'
 import { ParticipantProvider } from '@/contexts/ParticipantContext'
 import { ExpenseProvider } from '@/contexts/ExpenseContext'
 import { SettlementProvider } from '@/contexts/SettlementContext'
@@ -13,6 +14,9 @@ import { MealProvider } from '@/contexts/MealContext'
 import { ShoppingProvider } from '@/contexts/ShoppingContext'
 import { Toaster } from '@/components/ui/toaster'
 import { TripBanner } from '@/components/TripBanner'
+import { SignInButton } from '@/components/auth/SignInButton'
+import { UserMenu } from '@/components/auth/UserMenu'
+import { ModeToggle } from '@/components/quick/ModeToggle'
 import {
   Sheet,
   SheetContent,
@@ -38,6 +42,7 @@ const iconMap = {
 export function Layout() {
   const location = useLocation()
   const { currentTrip, tripCode } = useCurrentTrip()
+  const { user } = useAuth()
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
 
   // Desktop navigation - all items visible
@@ -120,6 +125,10 @@ export function Layout() {
                 Trip Splitter Pro
               </motion.h1>
             )}
+            <div className="flex items-center gap-2 flex-shrink-0">
+              {user && <ModeToggle />}
+              {user ? <UserMenu /> : <SignInButton />}
+            </div>
           </div>
         </div>
       </header>

--- a/src/components/LinkParticipantDialog.tsx
+++ b/src/components/LinkParticipantDialog.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { UserCheck } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+
+interface LinkParticipantDialogProps {
+  trigger?: React.ReactNode
+  onLinked?: () => void
+}
+
+export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDialogProps) {
+  const { user } = useAuth()
+  const { participants, families, linkUserToParticipant } = useParticipantContext()
+  const { isLinked } = useMyParticipant()
+  const [open, setOpen] = useState(false)
+  const [linking, setLinking] = useState(false)
+
+  if (!user || isLinked) return null
+
+  // Only show adults as linkable options
+  const adultParticipants = participants.filter(p => p.is_adult && !p.user_id)
+
+  const handleLink = async (participantId: string) => {
+    setLinking(true)
+    const success = await linkUserToParticipant(participantId, user.id)
+    setLinking(false)
+
+    if (success) {
+      setOpen(false)
+      onLinked?.()
+    }
+  }
+
+  const getFamilyName = (familyId: string | null) => {
+    if (!familyId) return null
+    return families.find(f => f.id === familyId)?.family_name || null
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button variant="outline" size="sm" className="gap-2">
+            <UserCheck size={16} />
+            This is me
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Which participant are you?</DialogTitle>
+          <DialogDescription>
+            Link yourself to a participant so we can show your personal balance and pre-fill forms.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 mt-4">
+          {adultParticipants.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No unlinked participants available. All participants are already claimed.
+            </p>
+          ) : (
+            adultParticipants.map(participant => {
+              const familyName = getFamilyName(participant.family_id)
+              return (
+                <button
+                  key={participant.id}
+                  onClick={() => handleLink(participant.id)}
+                  disabled={linking}
+                  className="w-full text-left px-4 py-3 rounded-lg border border-border hover:bg-accent/50 hover:border-accent transition-colors disabled:opacity-50"
+                >
+                  <span className="font-medium">{participant.name}</span>
+                  {familyName && (
+                    <span className="text-sm text-muted-foreground ml-2">
+                      ({familyName})
+                    </span>
+                  )}
+                </button>
+              )
+            })
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,0 +1,69 @@
+import { Outlet, Link, useParams } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { ParticipantProvider } from '@/contexts/ParticipantContext'
+import { ExpenseProvider } from '@/contexts/ExpenseContext'
+import { SettlementProvider } from '@/contexts/SettlementContext'
+import { MealProvider } from '@/contexts/MealContext'
+import { ShoppingProvider } from '@/contexts/ShoppingContext'
+import { UserMenu } from '@/components/auth/UserMenu'
+import { ModeToggle } from '@/components/quick/ModeToggle'
+import { Toaster } from '@/components/ui/toaster'
+
+export function QuickLayout() {
+  const { tripCode } = useParams<{ tripCode: string }>()
+  const { currentTrip } = useCurrentTrip()
+  const { user } = useAuth()
+
+  const isInTrip = !!tripCode
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Simplified header */}
+      <header className="bg-card border-b border-border soft-shadow-sm fixed top-0 left-0 right-0 z-50">
+        <div className="max-w-lg mx-auto px-4 py-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3 min-w-0">
+              {isInTrip ? (
+                <>
+                  <Link to="/quick" className="text-muted-foreground hover:text-foreground">
+                    <ArrowLeft size={20} />
+                  </Link>
+                  <h1 className="text-lg font-semibold text-foreground truncate">
+                    {currentTrip?.name || 'Loading...'}
+                  </h1>
+                </>
+              ) : (
+                <h1 className="text-lg font-semibold text-foreground">
+                  Trip Splitter
+                </h1>
+              )}
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <ModeToggle />
+              {user && <UserMenu />}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="pt-16">
+        <ParticipantProvider>
+          <ExpenseProvider>
+            <SettlementProvider>
+              <MealProvider>
+                <ShoppingProvider>
+                  <Outlet />
+                </ShoppingProvider>
+              </MealProvider>
+            </SettlementProvider>
+          </ExpenseProvider>
+        </ParticipantProvider>
+      </main>
+
+      <Toaster />
+    </div>
+  )
+}

--- a/src/components/TripRouteGuard.tsx
+++ b/src/components/TripRouteGuard.tsx
@@ -1,8 +1,11 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useAuth } from '@/contexts/AuthContext'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { LinkParticipantDialog } from '@/components/LinkParticipantDialog'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2 } from 'lucide-react'
+import { Loader2, UserCheck } from 'lucide-react'
 
 interface TripRouteGuardProps {
   children: React.ReactNode
@@ -12,9 +15,12 @@ interface TripRouteGuardProps {
  * Route guard that checks if the trip exists
  * If not, redirects to 404 page
  * Shows loading state while trip is being loaded
+ * Shows link participant banner for authenticated users who haven't linked
  */
 export function TripRouteGuard({ children }: TripRouteGuardProps) {
   const { currentTrip, tripCode, loading } = useCurrentTrip()
+  const { user } = useAuth()
+  const { isLinked } = useMyParticipant()
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -41,5 +47,18 @@ export function TripRouteGuard({ children }: TripRouteGuardProps) {
     )
   }
 
-  return <>{children}</>
+  return (
+    <>
+      {user && !isLinked && (
+        <div className="mb-4 p-3 rounded-lg border border-border bg-accent/30 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <UserCheck size={16} />
+            <span>Link yourself to a participant to unlock Quick Mode features</span>
+          </div>
+          <LinkParticipantDialog />
+        </div>
+      )}
+      {children}
+    </>
+  )
 }

--- a/src/components/auth/SignInButton.tsx
+++ b/src/components/auth/SignInButton.tsx
@@ -1,0 +1,20 @@
+import { useAuth } from '@/contexts/AuthContext'
+import { Button } from '@/components/ui/button'
+import { LogIn } from 'lucide-react'
+
+export function SignInButton() {
+  const { signInWithGoogle, loading } = useAuth()
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={signInWithGoogle}
+      disabled={loading}
+      className="gap-2"
+    >
+      <LogIn size={16} />
+      <span className="hidden sm:inline">Sign in</span>
+    </Button>
+  )
+}

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,0 +1,60 @@
+import { useAuth } from '@/contexts/AuthContext'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { LogOut } from 'lucide-react'
+
+export function UserMenu() {
+  const { userProfile, signOut } = useAuth()
+
+  if (!userProfile) return null
+
+  const initials = userProfile.display_name
+    .split(' ')
+    .map(n => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="gap-2 px-2">
+          {userProfile.avatar_url ? (
+            <img
+              src={userProfile.avatar_url}
+              alt={userProfile.display_name}
+              className="w-7 h-7 rounded-full"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div className="w-7 h-7 rounded-full bg-primary/10 flex items-center justify-center text-xs font-medium text-primary">
+              {initials}
+            </div>
+          )}
+          <span className="hidden sm:inline text-sm font-medium max-w-[120px] truncate">
+            {userProfile.display_name}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <div className="px-2 py-1.5">
+          <p className="text-sm font-medium">{userProfile.display_name}</p>
+          {userProfile.email && (
+            <p className="text-xs text-muted-foreground">{userProfile.email}</p>
+          )}
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={signOut} className="gap-2 text-destructive focus:text-destructive">
+          <LogOut size={16} />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/quick/GroupActions.tsx
+++ b/src/components/quick/GroupActions.tsx
@@ -1,0 +1,69 @@
+import { muteTrip } from '@/lib/mutedTripsStorage'
+import { removeFromMyTrips } from '@/lib/myTripsStorage'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { VolumeX, LogOut } from 'lucide-react'
+
+interface GroupActionsProps {
+  tripCode: string
+  tripName: string
+  onMuted?: () => void
+  onLeft?: () => void
+}
+
+export function GroupActions({ tripCode, tripName, onMuted, onLeft }: GroupActionsProps) {
+  return (
+    <div className="flex gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="gap-1.5 text-muted-foreground"
+        onClick={() => {
+          muteTrip(tripCode)
+          onMuted?.()
+        }}
+      >
+        <VolumeX size={14} />
+        Mute
+      </Button>
+
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground">
+            <LogOut size={14} />
+            Leave
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Leave "{tripName}"?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the trip from your list. You can rejoin later via the share link.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                removeFromMyTrips(tripCode)
+                onLeft?.()
+              }}
+            >
+              Leave
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -1,0 +1,57 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import { useUserPreferences } from '@/contexts/UserPreferencesContext'
+import { Zap, Settings2 } from 'lucide-react'
+
+export function ModeToggle() {
+  const navigate = useNavigate()
+  const { tripCode } = useParams<{ tripCode: string }>()
+  const { mode, setMode } = useUserPreferences()
+
+  const handleModeChange = async (newMode: 'quick' | 'full') => {
+    if (newMode === mode) return
+    await setMode(newMode)
+
+    // Navigate to the appropriate view
+    if (newMode === 'quick') {
+      if (tripCode) {
+        navigate(`/t/${tripCode}/quick`)
+      } else {
+        navigate('/quick')
+      }
+    } else {
+      // Full mode
+      if (tripCode) {
+        navigate(`/t/${tripCode}/dashboard`)
+      } else {
+        navigate('/')
+      }
+    }
+  }
+
+  return (
+    <div className="flex items-center bg-muted rounded-lg p-0.5">
+      <button
+        onClick={() => handleModeChange('quick')}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+          mode === 'quick'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+      >
+        <Zap size={14} />
+        Quick
+      </button>
+      <button
+        onClick={() => handleModeChange('full')}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+          mode === 'full'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+      >
+        <Settings2 size={14} />
+        Full
+      </button>
+    </div>
+  )
+}

--- a/src/components/quick/QuickActionButton.tsx
+++ b/src/components/quick/QuickActionButton.tsx
@@ -1,0 +1,27 @@
+import { LucideIcon } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+interface QuickActionButtonProps {
+  icon: LucideIcon
+  label: string
+  description: string
+  onClick: () => void
+}
+
+export function QuickActionButton({ icon: Icon, label, description, onClick }: QuickActionButtonProps) {
+  return (
+    <motion.button
+      onClick={onClick}
+      className="w-full flex items-center gap-4 p-4 rounded-xl border border-border bg-card hover:bg-accent/50 hover:border-accent transition-colors text-left"
+      whileTap={{ scale: 0.98 }}
+    >
+      <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0">
+        <Icon size={22} className="text-primary" />
+      </div>
+      <div className="min-w-0">
+        <p className="font-semibold text-foreground">{label}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </motion.button>
+  )
+}

--- a/src/components/quick/QuickBalanceHero.tsx
+++ b/src/components/quick/QuickBalanceHero.tsx
@@ -1,0 +1,48 @@
+import { ParticipantBalance, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { motion } from 'framer-motion'
+
+interface QuickBalanceHeroProps {
+  balance: ParticipantBalance | null
+}
+
+export function QuickBalanceHero({ balance }: QuickBalanceHeroProps) {
+  if (!balance) {
+    return (
+      <div className="text-center py-8 mb-6">
+        <p className="text-muted-foreground">No balance data available</p>
+      </div>
+    )
+  }
+
+  const isSettled = balance.balance === 0
+  const isPositive = balance.balance > 0
+
+  return (
+    <motion.div
+      className="text-center py-8 mb-6"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.3 }}
+    >
+      <p className="text-sm text-muted-foreground mb-2">
+        {isSettled
+          ? 'All settled up!'
+          : isPositive
+            ? 'You are owed'
+            : 'You owe'
+        }
+      </p>
+      <p className={`text-4xl font-bold tabular-nums ${getBalanceColorClass(balance.balance)}`}>
+        {isSettled
+          ? formatBalance(0)
+          : formatBalance(Math.abs(balance.balance))
+        }
+      </p>
+      {balance.isFamily && (
+        <p className="text-xs text-muted-foreground mt-2">
+          Family: {balance.name}
+        </p>
+      )}
+    </motion.div>
+  )
+}

--- a/src/components/quick/QuickExpenseSheet.tsx
+++ b/src/components/quick/QuickExpenseSheet.tsx
@@ -1,0 +1,47 @@
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useExpenseContext } from '@/contexts/ExpenseContext'
+import { ExpenseWizard } from '@/components/expenses/ExpenseWizard'
+import { CreateExpenseInput } from '@/types/expense'
+import { useToast } from '@/hooks/use-toast'
+
+interface QuickExpenseSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function QuickExpenseSheet({ open, onOpenChange }: QuickExpenseSheetProps) {
+  const { currentTrip } = useCurrentTrip()
+  const { myParticipant } = useMyParticipant()
+  const { createExpense } = useExpenseContext()
+  const { toast } = useToast()
+
+  if (!currentTrip) return null
+
+  // Pre-fill: payer is the current user, split among all
+  const initialValues: Partial<CreateExpenseInput> = {
+    trip_id: currentTrip.id,
+    paid_by: myParticipant?.id || '',
+    currency: 'EUR',
+    expense_date: new Date().toISOString().split('T')[0],
+  }
+
+  const handleSubmit = async (input: CreateExpenseInput) => {
+    const result = await createExpense(input)
+    if (result) {
+      toast({
+        title: 'Expense added',
+        description: `${input.description} - ${input.currency} ${input.amount.toFixed(2)}`,
+      })
+    }
+  }
+
+  return (
+    <ExpenseWizard
+      open={open}
+      onOpenChange={onOpenChange}
+      onSubmit={handleSubmit}
+      initialValues={initialValues}
+    />
+  )
+}

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -1,0 +1,44 @@
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useSettlementContext } from '@/contexts/SettlementContext'
+import { SettlementForm } from '@/components/SettlementForm'
+import { CreateSettlementInput } from '@/types/settlement'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { useToast } from '@/hooks/use-toast'
+
+interface QuickSettlementSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementSheetProps) {
+  const { currentTrip } = useCurrentTrip()
+  const { createSettlement } = useSettlementContext()
+  const { toast } = useToast()
+
+  if (!currentTrip) return null
+
+  const handleSubmit = async (input: CreateSettlementInput) => {
+    const result = await createSettlement(input)
+    if (result) {
+      toast({
+        title: 'Payment recorded',
+        description: `${input.currency} ${input.amount.toFixed(2)} payment logged`,
+      })
+      onOpenChange(false)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[85vh] overflow-y-auto">
+        <SheetHeader className="mb-4">
+          <SheetTitle>Log a payment</SheetTitle>
+        </SheetHeader>
+        <SettlementForm
+          onSubmit={handleSubmit}
+          onCancel={() => onOpenChange(false)}
+        />
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/quick/TransactionItem.tsx
+++ b/src/components/quick/TransactionItem.tsx
@@ -1,0 +1,78 @@
+import { TransactionItem as TxItem } from '@/services/transactionHistoryBuilder'
+import { DollarSign, ArrowUpRight, ArrowDownLeft } from 'lucide-react'
+
+interface TransactionItemProps {
+  transaction: TxItem
+}
+
+export function TransactionItem({ transaction: tx }: TransactionItemProps) {
+  const formatAmount = (amount: number, currency: string) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(amount)
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr + 'T00:00:00')
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  }
+
+  const getRoleDisplay = () => {
+    switch (tx.role) {
+      case 'you_paid':
+        return {
+          label: 'You paid',
+          icon: <DollarSign size={16} className="text-primary" />,
+          amountText: formatAmount(tx.roleAmount, tx.currency),
+          amountClass: 'text-foreground font-semibold',
+          bgClass: 'bg-primary/5',
+        }
+      case 'your_share':
+        return {
+          label: `${tx.payerName} paid`,
+          icon: <DollarSign size={16} className="text-muted-foreground" />,
+          amountText: `Your share: ${formatAmount(tx.roleAmount, tx.currency)}`,
+          amountClass: 'text-muted-foreground',
+          bgClass: 'bg-muted/30',
+        }
+      case 'you_settled':
+        return {
+          label: `You paid ${tx.recipientName}`,
+          icon: <ArrowUpRight size={16} className="text-red-500" />,
+          amountText: formatAmount(tx.roleAmount, tx.currency),
+          amountClass: 'text-red-600 dark:text-red-400 font-semibold',
+          bgClass: 'bg-red-50 dark:bg-red-950/20',
+        }
+      case 'you_received':
+        return {
+          label: `${tx.payerName} paid you`,
+          icon: <ArrowDownLeft size={16} className="text-green-500" />,
+          amountText: formatAmount(tx.roleAmount, tx.currency),
+          amountClass: 'text-green-600 dark:text-green-400 font-semibold',
+          bgClass: 'bg-green-50 dark:bg-green-950/20',
+        }
+    }
+  }
+
+  const display = getRoleDisplay()
+
+  return (
+    <div className={`flex items-center justify-between px-4 py-3 rounded-lg ${display.bgClass}`}>
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="flex-shrink-0">{display.icon}</div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">
+            {tx.type === 'expense' ? tx.description : display.label}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {tx.type === 'expense' ? display.label : tx.description}
+            {' \u00B7 '}
+            {formatDate(tx.date)}
+          </p>
+        </div>
+      </div>
+      <div className="flex-shrink-0 ml-3 text-right">
+        <p className={`text-sm tabular-nums ${display.amountClass}`}>
+          {display.amountText}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,141 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { User, Session } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabase'
+import { UserProfile } from '@/types/auth'
+
+interface AuthContextType {
+  user: User | null
+  userProfile: UserProfile | null
+  session: Session | null
+  loading: boolean
+  signInWithGoogle: () => Promise<void>
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
+  const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // Upsert user profile from auth metadata
+  const upsertProfile = async (authUser: User) => {
+    const metadata = authUser.user_metadata
+    const profile: Omit<UserProfile, 'created_at' | 'updated_at'> = {
+      id: authUser.id,
+      display_name: metadata?.full_name || metadata?.name || authUser.email?.split('@')[0] || 'User',
+      email: authUser.email || null,
+      avatar_url: metadata?.avatar_url || metadata?.picture || null,
+    }
+
+    const { data, error } = await (supabase as any)
+      .from('user_profiles')
+      .upsert(profile, { onConflict: 'id' })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error upserting profile:', error)
+      // Return a local profile if DB fails (e.g., table doesn't exist yet)
+      return {
+        ...profile,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      } as UserProfile
+    }
+
+    return data as UserProfile
+  }
+
+  // Fetch existing profile
+  const fetchProfile = async (userId: string): Promise<UserProfile | null> => {
+    const { data, error } = await (supabase as any)
+      .from('user_profiles')
+      .select('*')
+      .eq('id', userId)
+      .single()
+
+    if (error) {
+      return null
+    }
+
+    return data as UserProfile
+  }
+
+  useEffect(() => {
+    // Get initial session
+    supabase.auth.getSession().then(async ({ data: { session: initialSession } }) => {
+      setSession(initialSession)
+      setUser(initialSession?.user ?? null)
+
+      if (initialSession?.user) {
+        const profile = await fetchProfile(initialSession.user.id)
+          || await upsertProfile(initialSession.user)
+        setUserProfile(profile)
+      }
+
+      setLoading(false)
+    })
+
+    // Listen for auth changes
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (event, newSession) => {
+        setSession(newSession)
+        setUser(newSession?.user ?? null)
+
+        if (newSession?.user) {
+          if (event === 'SIGNED_IN') {
+            // New sign-in: upsert profile
+            const profile = await upsertProfile(newSession.user)
+            setUserProfile(profile)
+          } else {
+            // Token refresh or other: fetch existing profile
+            const profile = await fetchProfile(newSession.user.id)
+            setUserProfile(profile)
+          }
+        } else {
+          setUserProfile(null)
+        }
+      }
+    )
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  const signInWithGoogle = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: window.location.origin,
+      },
+    })
+    if (error) {
+      console.error('Error signing in with Google:', error)
+    }
+  }
+
+  const signOut = async () => {
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      console.error('Error signing out:', error)
+    }
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, userProfile, session, loading, signInWithGoogle, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/contexts/AuthContext'
+import {
+  AppMode,
+  getLocalPreferences,
+  setLocalPreferences,
+} from '@/lib/userPreferencesStorage'
+
+interface UserPreferencesContextType {
+  mode: AppMode
+  defaultTripId: string | null
+  setMode: (mode: AppMode) => Promise<void>
+  setDefaultTripId: (tripId: string | null) => Promise<void>
+  loading: boolean
+}
+
+const UserPreferencesContext = createContext<UserPreferencesContextType | undefined>(undefined)
+
+export function UserPreferencesProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth()
+  const [mode, setModeState] = useState<AppMode>(() => getLocalPreferences().preferredMode)
+  const [defaultTripId, setDefaultTripIdState] = useState<string | null>(
+    () => getLocalPreferences().defaultTripId
+  )
+  const [loading, setLoading] = useState(false)
+
+  // Sync from Supabase when user signs in
+  useEffect(() => {
+    if (!user) return
+
+    const fetchPreferences = async () => {
+      setLoading(true)
+      const { data, error } = await (supabase as any)
+        .from('user_preferences')
+        .select('*')
+        .eq('user_id', user.id)
+        .single()
+
+      if (!error && data) {
+        const serverMode = data.preferred_mode as AppMode
+        const serverTripId = data.default_trip_id as string | null
+        setModeState(serverMode)
+        setDefaultTripIdState(serverTripId)
+        setLocalPreferences({ preferredMode: serverMode, defaultTripId: serverTripId })
+      }
+      setLoading(false)
+    }
+
+    fetchPreferences()
+  }, [user])
+
+  const upsertPreferences = useCallback(async (updates: Record<string, unknown>) => {
+    if (!user) return
+    await (supabase as any)
+      .from('user_preferences')
+      .upsert(
+        { user_id: user.id, ...updates, updated_at: new Date().toISOString() },
+        { onConflict: 'user_id' }
+      )
+  }, [user])
+
+  const setMode = useCallback(async (newMode: AppMode) => {
+    setModeState(newMode)
+    setLocalPreferences({ preferredMode: newMode })
+    await upsertPreferences({ preferred_mode: newMode })
+  }, [upsertPreferences])
+
+  const setDefaultTripId = useCallback(async (tripId: string | null) => {
+    setDefaultTripIdState(tripId)
+    setLocalPreferences({ defaultTripId: tripId })
+    await upsertPreferences({ default_trip_id: tripId })
+  }, [upsertPreferences])
+
+  return (
+    <UserPreferencesContext.Provider value={{ mode, defaultTripId, setMode, setDefaultTripId, loading }}>
+      {children}
+    </UserPreferencesContext.Provider>
+  )
+}
+
+export function useUserPreferences() {
+  const context = useContext(UserPreferencesContext)
+  if (context === undefined) {
+    throw new Error('useUserPreferences must be used within a UserPreferencesProvider')
+  }
+  return context
+}

--- a/src/hooks/useMyParticipant.ts
+++ b/src/hooks/useMyParticipant.ts
@@ -1,0 +1,20 @@
+import { useAuth } from '@/contexts/AuthContext'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+
+/**
+ * Finds the current authenticated user's participant record in the current trip.
+ * Returns null if user is not authenticated or not linked to any participant.
+ */
+export function useMyParticipant() {
+  const { user } = useAuth()
+  const { participants } = useParticipantContext()
+
+  if (!user) return { myParticipant: null, isLinked: false }
+
+  const myParticipant = participants.find(p => p.user_id === user.id) || null
+
+  return {
+    myParticipant,
+    isLinked: myParticipant !== null,
+  }
+}

--- a/src/hooks/useMyTripBalances.ts
+++ b/src/hooks/useMyTripBalances.ts
@@ -1,0 +1,105 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/contexts/AuthContext'
+import { useTripContext } from '@/contexts/TripContext'
+import { getMyTrips } from '@/lib/myTripsStorage'
+import { calculateBalances, ParticipantBalance } from '@/services/balanceCalculator'
+import { Trip } from '@/types/trip'
+import { Participant, Family } from '@/types/participant'
+import { Expense } from '@/types/expense'
+import { Settlement } from '@/types/settlement'
+
+export interface TripBalance {
+  trip: Trip
+  myBalance: ParticipantBalance | null
+  totalExpenses: number
+  loading: boolean
+}
+
+/**
+ * Fetches data for each "My Trip" and computes the user's personal balance.
+ * Only works for authenticated users who have linked themselves to participants.
+ */
+export function useMyTripBalances() {
+  const { user } = useAuth()
+  const { trips } = useTripContext()
+  const [tripBalances, setTripBalances] = useState<TripBalance[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!user || trips.length === 0) {
+      setTripBalances([])
+      setLoading(false)
+      return
+    }
+
+    const fetchBalances = async () => {
+      setLoading(true)
+
+      // Get user's "My Trips" from localStorage
+      const myTrips = getMyTrips()
+      const myTripCodes = new Set(myTrips.map(t => t.tripCode))
+
+      // Filter to trips that exist in both DB and My Trips
+      const relevantTrips = trips.filter(t => myTripCodes.has(t.trip_code))
+
+      const balances: TripBalance[] = await Promise.all(
+        relevantTrips.map(async (trip) => {
+          try {
+            // Parallel fetch all data for this trip
+            const [participantsRes, familiesRes, expensesRes, settlementsRes] = await Promise.all([
+              supabase.from('participants').select('*').eq('trip_id', trip.id),
+              supabase.from('families').select('*').eq('trip_id', trip.id),
+              supabase.from('expenses').select('*').eq('trip_id', trip.id),
+              supabase.from('settlements').select('*').eq('trip_id', trip.id),
+            ])
+
+            const participants = (participantsRes.data as Participant[]) || []
+            const families = (familiesRes.data as Family[]) || []
+            const expenses = (expensesRes.data as unknown as Expense[]) || []
+            const settlements = (settlementsRes.data as Settlement[]) || []
+
+            // Find user's participant in this trip
+            const myParticipant = participants.find(p => p.user_id === user.id)
+
+            if (!myParticipant) {
+              return { trip, myBalance: null, totalExpenses: 0, loading: false }
+            }
+
+            // Calculate balances (with currency conversion)
+            const calc = calculateBalances(
+              expenses,
+              participants,
+              families,
+              trip.tracking_mode,
+              settlements,
+              trip.default_currency,
+              trip.exchange_rates
+            )
+
+            // Find the user's balance entity
+            // In families mode, if user is in a family, find the family balance
+            let myBalance: ParticipantBalance | null = null
+            if (trip.tracking_mode === 'families' && myParticipant.family_id) {
+              myBalance = calc.balances.find(b => b.id === myParticipant.family_id) || null
+            } else {
+              myBalance = calc.balances.find(b => b.id === myParticipant.id) || null
+            }
+
+            return { trip, myBalance, totalExpenses: calc.totalExpenses, loading: false }
+          } catch (error) {
+            console.error(`Error fetching balance for trip ${trip.id}:`, error)
+            return { trip, myBalance: null, totalExpenses: 0, loading: false }
+          }
+        })
+      )
+
+      setTripBalances(balances)
+      setLoading(false)
+    }
+
+    fetchBalances()
+  }, [user, trips])
+
+  return { tripBalances, loading }
+}

--- a/src/lib/mutedTripsStorage.ts
+++ b/src/lib/mutedTripsStorage.ts
@@ -1,0 +1,40 @@
+/**
+ * Muted Trips Storage
+ * Tracks trips the user has muted (hidden from Quick Mode home)
+ */
+
+const MUTED_KEY = 'trip-splitter:muted-trips'
+
+export function getMutedTripCodes(): string[] {
+  try {
+    const stored = localStorage.getItem(MUTED_KEY)
+    return stored ? JSON.parse(stored) : []
+  } catch {
+    return []
+  }
+}
+
+export function muteTrip(tripCode: string): void {
+  try {
+    const muted = getMutedTripCodes()
+    if (!muted.includes(tripCode)) {
+      muted.push(tripCode)
+      localStorage.setItem(MUTED_KEY, JSON.stringify(muted))
+    }
+  } catch (error) {
+    console.error('Error muting trip:', error)
+  }
+}
+
+export function unmuteTrip(tripCode: string): void {
+  try {
+    const muted = getMutedTripCodes().filter(c => c !== tripCode)
+    localStorage.setItem(MUTED_KEY, JSON.stringify(muted))
+  } catch (error) {
+    console.error('Error unmuting trip:', error)
+  }
+}
+
+export function isTripMuted(tripCode: string): boolean {
+  return getMutedTripCodes().includes(tripCode)
+}

--- a/src/lib/userPreferencesStorage.ts
+++ b/src/lib/userPreferencesStorage.ts
@@ -1,0 +1,38 @@
+/**
+ * User Preferences localStorage fallback
+ * Used for instant reads and as fallback when user is not authenticated
+ */
+
+const PREFERENCES_KEY = 'trip-splitter:user-preferences'
+
+export type AppMode = 'quick' | 'full'
+
+export interface UserPreferencesLocal {
+  preferredMode: AppMode
+  defaultTripId: string | null
+}
+
+const defaults: UserPreferencesLocal = {
+  preferredMode: 'full',
+  defaultTripId: null,
+}
+
+export function getLocalPreferences(): UserPreferencesLocal {
+  try {
+    const stored = localStorage.getItem(PREFERENCES_KEY)
+    if (!stored) return defaults
+    return { ...defaults, ...JSON.parse(stored) }
+  } catch {
+    return defaults
+  }
+}
+
+export function setLocalPreferences(prefs: Partial<UserPreferencesLocal>): void {
+  try {
+    const current = getLocalPreferences()
+    const updated = { ...current, ...prefs }
+    localStorage.setItem(PREFERENCES_KEY, JSON.stringify(updated))
+  } catch (error) {
+    console.error('Error saving preferences to localStorage:', error)
+  }
+}

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { useUserPreferences } from '@/contexts/UserPreferencesContext'
+import { useTripContext } from '@/contexts/TripContext'
+import { HomePage } from './HomePage'
+
+/**
+ * Renders at `/` - redirects to Quick Mode if user has it set,
+ * otherwise shows the original HomePage (Full Mode).
+ */
+export function ConditionalHomePage() {
+  const navigate = useNavigate()
+  const { user, loading: authLoading } = useAuth()
+  const { mode, defaultTripId, loading: prefsLoading } = useUserPreferences()
+  const { trips, loading: tripsLoading } = useTripContext()
+
+  useEffect(() => {
+    if (authLoading || prefsLoading || tripsLoading) return
+
+    if (user && mode === 'quick') {
+      // If user has a default trip set, go directly to that group
+      if (defaultTripId) {
+        const defaultTrip = trips.find(t => t.id === defaultTripId)
+        if (defaultTrip) {
+          navigate(`/t/${defaultTrip.trip_code}/quick`, { replace: true })
+          return
+        }
+      }
+      // Otherwise go to Quick home
+      navigate('/quick', { replace: true })
+    }
+  }, [authLoading, prefsLoading, tripsLoading, user, mode, defaultTripId, trips, navigate])
+
+  // Show Full Mode home page by default
+  return <HomePage />
+}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useExpenseContext } from '@/contexts/ExpenseContext'
+import { useSettlementContext } from '@/contexts/SettlementContext'
+import { useUserPreferences } from '@/contexts/UserPreferencesContext'
+import { calculateBalances } from '@/services/balanceCalculator'
+import { LinkParticipantDialog } from '@/components/LinkParticipantDialog'
+import { QuickBalanceHero } from '@/components/quick/QuickBalanceHero'
+import { QuickActionButton } from '@/components/quick/QuickActionButton'
+import { QuickExpenseSheet } from '@/components/quick/QuickExpenseSheet'
+import { QuickSettlementSheet } from '@/components/quick/QuickSettlementSheet'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  DollarSign, CreditCard, FileText, Star, StarOff,
+  ExternalLink, Loader2
+} from 'lucide-react'
+
+export function QuickGroupDetailPage() {
+  const navigate = useNavigate()
+  const { currentTrip } = useCurrentTrip()
+  const { myParticipant, isLinked } = useMyParticipant()
+  const { participants, families, loading: participantsLoading } = useParticipantContext()
+  const { expenses, loading: expensesLoading } = useExpenseContext()
+  const { settlements, loading: settlementsLoading } = useSettlementContext()
+  const { defaultTripId, setDefaultTripId } = useUserPreferences()
+
+  const [expenseOpen, setExpenseOpen] = useState(false)
+  const [settlementOpen, setSettlementOpen] = useState(false)
+
+  const loading = participantsLoading || expensesLoading || settlementsLoading
+
+  if (!currentTrip) return null
+
+  const isDefaultTrip = defaultTripId === currentTrip.id
+
+  // Calculate balance (with currency conversion)
+  const balanceCalc = calculateBalances(
+    expenses,
+    participants,
+    families,
+    currentTrip.tracking_mode,
+    settlements,
+    currentTrip.default_currency,
+    currentTrip.exchange_rates
+  )
+
+  // Find user's balance
+  let myBalance = null
+  if (myParticipant) {
+    if (currentTrip.tracking_mode === 'families' && myParticipant.family_id) {
+      myBalance = balanceCalc.balances.find(b => b.id === myParticipant.family_id) || null
+    } else {
+      myBalance = balanceCalc.balances.find(b => b.id === myParticipant.id) || null
+    }
+  }
+
+  const handleToggleDefault = async () => {
+    if (isDefaultTrip) {
+      await setDefaultTripId(null)
+    } else {
+      await setDefaultTripId(currentTrip.id)
+    }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6">
+      {/* Balance hero */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : !isLinked ? (
+        <Card className="mb-6">
+          <CardContent className="pt-6 text-center">
+            <p className="text-muted-foreground mb-4">
+              Link yourself to a participant to see your balance
+            </p>
+            <LinkParticipantDialog />
+          </CardContent>
+        </Card>
+      ) : (
+        <QuickBalanceHero balance={myBalance} />
+      )}
+
+      {/* Action buttons */}
+      <div className="space-y-3 mb-6">
+        <QuickActionButton
+          icon={DollarSign}
+          label="Add an expense"
+          description="Split a bill with the group"
+          onClick={() => setExpenseOpen(true)}
+        />
+        <QuickActionButton
+          icon={CreditCard}
+          label="Log your payment"
+          description="Record a payment you made"
+          onClick={() => setSettlementOpen(true)}
+        />
+        <QuickActionButton
+          icon={FileText}
+          label="View expenses & payments"
+          description="See transaction history"
+          onClick={() => navigate(`/t/${currentTrip.trip_code}/quick/history`)}
+        />
+      </div>
+
+      {/* Bottom actions */}
+      <div className="space-y-3">
+        <button
+          onClick={handleToggleDefault}
+          className="w-full flex items-center justify-center gap-2 py-2.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {isDefaultTrip ? (
+            <>
+              <StarOff size={16} />
+              Remove as default view
+            </>
+          ) : (
+            <>
+              <Star size={16} />
+              Set as default view
+            </>
+          )}
+        </button>
+
+        <Button
+          variant="outline"
+          className="w-full gap-2"
+          onClick={() => navigate(`/t/${currentTrip.trip_code}/dashboard`)}
+        >
+          <ExternalLink size={16} />
+          See in Full Mode
+        </Button>
+      </div>
+
+      {/* Expense sheet */}
+      <QuickExpenseSheet
+        open={expenseOpen}
+        onOpenChange={setExpenseOpen}
+      />
+
+      {/* Settlement sheet */}
+      <QuickSettlementSheet
+        open={settlementOpen}
+        onOpenChange={setSettlementOpen}
+      />
+    </div>
+  )
+}

--- a/src/pages/QuickHistoryPage.tsx
+++ b/src/pages/QuickHistoryPage.tsx
@@ -1,0 +1,98 @@
+import { useState, useMemo } from 'react'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useExpenseContext } from '@/contexts/ExpenseContext'
+import { useSettlementContext } from '@/contexts/SettlementContext'
+import { buildTransactionHistory } from '@/services/transactionHistoryBuilder'
+import { TransactionItem } from '@/components/quick/TransactionItem'
+import { Card, CardContent } from '@/components/ui/card'
+import { Loader2, FileText } from 'lucide-react'
+
+type FilterType = 'all' | 'expenses' | 'payments'
+
+export function QuickHistoryPage() {
+  const { currentTrip } = useCurrentTrip()
+  const { myParticipant } = useMyParticipant()
+  const { participants, families, loading: participantsLoading } = useParticipantContext()
+  const { expenses, loading: expensesLoading } = useExpenseContext()
+  const { settlements, loading: settlementsLoading } = useSettlementContext()
+  const [filter, setFilter] = useState<FilterType>('all')
+
+  const loading = participantsLoading || expensesLoading || settlementsLoading
+
+  const transactions = useMemo(() => {
+    if (!currentTrip || !myParticipant) return []
+    return buildTransactionHistory(
+      expenses,
+      settlements,
+      participants,
+      families,
+      myParticipant,
+      currentTrip.tracking_mode
+    )
+  }, [expenses, settlements, participants, families, myParticipant, currentTrip])
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return transactions
+    if (filter === 'expenses') return transactions.filter(t => t.type === 'expense')
+    return transactions.filter(t => t.type === 'settlement')
+  }, [transactions, filter])
+
+  const filterButtons: { key: FilterType; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'expenses', label: 'Expenses' },
+    { key: 'payments', label: 'Payments' },
+  ]
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6">
+      <h2 className="text-xl font-bold text-foreground mb-4">Expenses & Payments</h2>
+
+      {/* Filters */}
+      <div className="flex gap-2 mb-4">
+        {filterButtons.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setFilter(key)}
+            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              filter === key
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Transaction list */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : !myParticipant ? (
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-muted-foreground">
+              Link yourself to a participant to see transaction history.
+            </p>
+          </CardContent>
+        </Card>
+      ) : filtered.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-center py-8">
+            <FileText size={32} className="mx-auto text-muted-foreground/50 mb-3" />
+            <p className="text-muted-foreground">No transactions yet</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-1">
+          {filtered.map(tx => (
+            <TransactionItem key={tx.id} transaction={tx} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/QuickHomeScreen.tsx
+++ b/src/pages/QuickHomeScreen.tsx
@@ -1,0 +1,142 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { useMyTripBalances } from '@/hooks/useMyTripBalances'
+import { formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { getMutedTripCodes } from '@/lib/mutedTripsStorage'
+import { GroupActions } from '@/components/quick/GroupActions'
+import { Card, CardContent } from '@/components/ui/card'
+import { Loader2, ChevronRight, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { motion } from 'framer-motion'
+
+export function QuickHomeScreen() {
+  const navigate = useNavigate()
+  const { userProfile } = useAuth()
+  const { tripBalances, loading } = useMyTripBalances()
+  const [mutedCodes, setMutedCodes] = useState(() => new Set(getMutedTripCodes()))
+
+  const firstName = userProfile?.display_name?.split(' ')[0] || 'there'
+
+  const visibleTrips = tripBalances.filter(tb => !mutedCodes.has(tb.trip.trip_code))
+
+  const handleMuted = useCallback((tripCode: string) => {
+    setMutedCodes(prev => new Set([...prev, tripCode]))
+  }, [])
+
+  const handleLeft = useCallback((tripCode: string) => {
+    // Trip will disappear on next load since it's removed from My Trips
+    // Force a re-render by updating muted set (trip won't show either way)
+    setMutedCodes(prev => new Set([...prev, tripCode]))
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-lg mx-auto px-4 py-8">
+        {/* User greeting */}
+        <div className="flex items-center gap-3 mb-8">
+          {userProfile?.avatar_url ? (
+            <img
+              src={userProfile.avatar_url}
+              alt={userProfile.display_name}
+              className="w-12 h-12 rounded-full"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center text-lg font-semibold text-primary">
+              {firstName[0]?.toUpperCase()}
+            </div>
+          )}
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">
+              Hi, {firstName}
+            </h1>
+            <p className="text-sm text-muted-foreground">Your groups</p>
+          </div>
+        </div>
+
+        {/* Groups list */}
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : visibleTrips.length === 0 ? (
+          <Card>
+            <CardContent className="pt-6">
+              <div className="text-center py-8">
+                <p className="text-muted-foreground mb-4">
+                  No groups yet. Create a trip or join one via a shared link.
+                </p>
+                <Button onClick={() => navigate('/create-trip')} className="gap-2">
+                  <Plus size={18} />
+                  Create Trip
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {visibleTrips.map(({ trip, myBalance }, i) => (
+              <motion.div
+                key={trip.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: i * 0.05 }}
+              >
+                <Card className="overflow-hidden">
+                  <div
+                    className="cursor-pointer hover:bg-accent/30 transition-colors"
+                    onClick={() => navigate(`/t/${trip.trip_code}/quick`)}
+                  >
+                    <CardContent className="py-4">
+                      <div className="flex items-center justify-between">
+                        <div className="min-w-0 flex-1">
+                          <h3 className="font-semibold text-foreground truncate">
+                            {trip.name}
+                          </h3>
+                          {myBalance ? (
+                            <p className={`text-lg font-bold tabular-nums ${getBalanceColorClass(myBalance.balance)}`}>
+                              {myBalance.balance === 0
+                                ? 'Settled up'
+                                : myBalance.balance > 0
+                                  ? `You are owed ${formatBalance(myBalance.balance)}`
+                                  : `You owe ${formatBalance(myBalance.balance).replace('-', '')}`
+                              }
+                            </p>
+                          ) : (
+                            <p className="text-sm text-muted-foreground">
+                              Link yourself to see your balance
+                            </p>
+                          )}
+                        </div>
+                        <ChevronRight size={20} className="text-muted-foreground flex-shrink-0 ml-3" />
+                      </div>
+                    </CardContent>
+                  </div>
+                  <div className="px-4 pb-2 flex justify-end">
+                    <GroupActions
+                      tripCode={trip.trip_code}
+                      tripName={trip.name}
+                      onMuted={() => handleMuted(trip.trip_code)}
+                      onLeft={() => handleLeft(trip.trip_code)}
+                    />
+                  </div>
+                </Card>
+              </motion.div>
+            ))}
+          </div>
+        )}
+
+        {/* Create trip button */}
+        {visibleTrips.length > 0 && (
+          <div className="mt-6 text-center">
+            <Button variant="outline" onClick={() => navigate('/create-trip')} className="gap-2">
+              <Plus size={16} />
+              Create New Trip
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,7 +1,8 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { Layout } from './components/Layout'
+import { QuickLayout } from './components/QuickLayout'
 import { TripRouteGuard } from './components/TripRouteGuard'
-import { HomePage } from './pages/HomePage'
+import { ConditionalHomePage } from './pages/ConditionalHomePage'
 import { TripsPage } from './pages/TripsPage'
 import { ManageTripPage } from './pages/ManageTripPage'
 import { ExpensesPage } from './pages/ExpensesPage'
@@ -11,6 +12,9 @@ import { DashboardPage } from './pages/DashboardPage'
 import { SettlementsPage } from './pages/SettlementsPage'
 import { AdminAllTripsPage } from './pages/AdminAllTripsPage'
 import { TripNotFoundPage } from './pages/TripNotFoundPage'
+import { QuickHomeScreen } from './pages/QuickHomeScreen'
+import { QuickGroupDetailPage } from './pages/QuickGroupDetailPage'
+import { QuickHistoryPage } from './pages/QuickHistoryPage'
 
 export function AppRoutes() {
   return (
@@ -19,8 +23,18 @@ export function AppRoutes() {
       <Route path="admin/all-trips" element={<AdminAllTripsPage />} />
       <Route path="trip-not-found/:tripCode" element={<TripNotFoundPage />} />
 
+      {/* Quick Mode routes */}
+      <Route path="/quick" element={<QuickLayout />}>
+        <Route index element={<QuickHomeScreen />} />
+      </Route>
+      <Route path="/t/:tripCode/quick" element={<QuickLayout />}>
+        <Route index element={<QuickGroupDetailPage />} />
+        <Route path="history" element={<QuickHistoryPage />} />
+      </Route>
+
+      {/* Full Mode routes */}
       <Route path="/" element={<Layout />}>
-        <Route index element={<HomePage />} />
+        <Route index element={<ConditionalHomePage />} />
         <Route path="create-trip" element={<TripsPage />} />
 
         {/* Trip routes - protected by TripRouteGuard */}

--- a/src/services/transactionHistoryBuilder.ts
+++ b/src/services/transactionHistoryBuilder.ts
@@ -1,0 +1,123 @@
+import { Expense } from '@/types/expense'
+import { Settlement } from '@/types/settlement'
+import { Participant, Family } from '@/types/participant'
+import { calculateExpenseShares } from '@/services/balanceCalculator'
+
+export interface TransactionItem {
+  id: string
+  type: 'expense' | 'settlement'
+  date: string
+  description: string
+  amount: number
+  currency: string
+  role: 'you_paid' | 'your_share' | 'you_settled' | 'you_received'
+  roleAmount: number
+  payerName: string | null
+  recipientName: string | null
+}
+
+/**
+ * Merges expenses and settlements into a unified chronological feed
+ * showing the user's role in each transaction.
+ */
+export function buildTransactionHistory(
+  expenses: Expense[],
+  settlements: Settlement[],
+  participants: Participant[],
+  families: Family[],
+  myParticipant: Participant,
+  trackingMode: 'individuals' | 'families'
+): TransactionItem[] {
+  const items: TransactionItem[] = []
+
+  const getParticipantName = (id: string) =>
+    participants.find(p => p.id === id)?.name || 'Unknown'
+
+  // Determine user's entity ID (family or individual)
+  const myEntityId = trackingMode === 'families' && myParticipant.family_id
+    ? myParticipant.family_id
+    : myParticipant.id
+
+  // Process expenses
+  for (const expense of expenses) {
+    const isPayer = expense.paid_by === myParticipant.id
+
+    // Calculate user's share
+    const shares = calculateExpenseShares(expense, participants, families, trackingMode)
+    const myShare = shares.get(myEntityId) || 0
+
+    // Only include if user paid or has a share
+    if (!isPayer && myShare === 0) continue
+
+    const payerName = getParticipantName(expense.paid_by)
+
+    if (isPayer) {
+      items.push({
+        id: `expense-${expense.id}`,
+        type: 'expense',
+        date: expense.expense_date,
+        description: expense.description,
+        amount: expense.amount,
+        currency: expense.currency,
+        role: 'you_paid',
+        roleAmount: expense.amount,
+        payerName: null,
+        recipientName: null,
+      })
+    } else {
+      items.push({
+        id: `expense-${expense.id}`,
+        type: 'expense',
+        date: expense.expense_date,
+        description: expense.description,
+        amount: expense.amount,
+        currency: expense.currency,
+        role: 'your_share',
+        roleAmount: myShare,
+        payerName,
+        recipientName: null,
+      })
+    }
+  }
+
+  // Process settlements
+  for (const settlement of settlements) {
+    const isFrom = settlement.from_participant_id === myParticipant.id
+    const isTo = settlement.to_participant_id === myParticipant.id
+
+    if (!isFrom && !isTo) continue
+
+    if (isFrom) {
+      items.push({
+        id: `settlement-${settlement.id}`,
+        type: 'settlement',
+        date: settlement.settlement_date,
+        description: settlement.note || 'Payment',
+        amount: settlement.amount,
+        currency: settlement.currency,
+        role: 'you_settled',
+        roleAmount: settlement.amount,
+        payerName: null,
+        recipientName: getParticipantName(settlement.to_participant_id),
+      })
+    } else {
+      items.push({
+        id: `settlement-${settlement.id}`,
+        type: 'settlement',
+        date: settlement.settlement_date,
+        description: settlement.note || 'Payment',
+        amount: settlement.amount,
+        currency: settlement.currency,
+        role: 'you_received',
+        roleAmount: settlement.amount,
+        payerName: getParticipantName(settlement.from_participant_id),
+        recipientName: null,
+      })
+    }
+  }
+
+  // Sort by date descending (newest first)
+  items.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+
+  return items
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,8 @@
+export interface UserProfile {
+  id: string
+  display_name: string
+  email: string | null
+  avatar_url: string | null
+  created_at: string
+  updated_at: string
+}

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -12,6 +12,7 @@ export interface Participant {
   family_id: string | null
   name: string
   is_adult: boolean
+  user_id?: string | null
 }
 
 export interface CreateFamilyInput {

--- a/supabase/migrations/008_user_profiles.sql
+++ b/supabase/migrations/008_user_profiles.sql
@@ -1,0 +1,35 @@
+-- User Profiles table
+-- Links Supabase Auth users to display profiles
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name TEXT NOT NULL,
+  email TEXT,
+  avatar_url TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE user_profiles ENABLE ROW LEVEL SECURITY;
+
+-- Policies (idempotent with DO blocks)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'Anyone can read profiles' AND tablename = 'user_profiles') THEN
+    CREATE POLICY "Anyone can read profiles" ON user_profiles FOR SELECT USING (true);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'Users can update own profile' AND tablename = 'user_profiles') THEN
+    CREATE POLICY "Users can update own profile" ON user_profiles FOR UPDATE USING (auth.uid() = id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'Users can insert own profile' AND tablename = 'user_profiles') THEN
+    CREATE POLICY "Users can insert own profile" ON user_profiles FOR INSERT WITH CHECK (auth.uid() = id);
+  END IF;
+END $$;
+
+-- Index on email for lookups
+CREATE INDEX IF NOT EXISTS idx_user_profiles_email ON user_profiles(email);

--- a/supabase/migrations/009_user_participant_link.sql
+++ b/supabase/migrations/009_user_participant_link.sql
@@ -1,0 +1,14 @@
+-- Add user_id column to participants table
+-- Links a Supabase Auth user to a participant record ("This is me")
+ALTER TABLE participants
+  ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- Unique constraint: one user per trip (a user can only claim one participant per trip)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_participants_user_trip
+  ON participants(user_id, trip_id)
+  WHERE user_id IS NOT NULL;
+
+-- Index for fast user lookups across trips
+CREATE INDEX IF NOT EXISTS idx_participants_user_id
+  ON participants(user_id)
+  WHERE user_id IS NOT NULL;

--- a/supabase/migrations/010_user_preferences.sql
+++ b/supabase/migrations/010_user_preferences.sql
@@ -1,0 +1,31 @@
+-- User preferences table
+-- Stores mode preference and default trip
+CREATE TABLE IF NOT EXISTS user_preferences (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  preferred_mode TEXT NOT NULL DEFAULT 'full' CHECK (preferred_mode IN ('quick', 'full')),
+  default_trip_id UUID REFERENCES trips(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE user_preferences ENABLE ROW LEVEL SECURITY;
+
+-- Policies (idempotent with DO blocks)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'Users can read own preferences' AND tablename = 'user_preferences') THEN
+    CREATE POLICY "Users can read own preferences" ON user_preferences FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'Users can insert own preferences' AND tablename = 'user_preferences') THEN
+    CREATE POLICY "Users can insert own preferences" ON user_preferences FOR INSERT WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'Users can update own preferences' AND tablename = 'user_preferences') THEN
+    CREATE POLICY "Users can update own preferences" ON user_preferences FOR UPDATE USING (auth.uid() = user_id);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- **Auth**: Google OAuth sign-in via Supabase with profile upsert and session management
- **Quick Mode**: Simplified mobile UI — personal balance hero, quick expense/settlement entry, transaction history
- **User Preferences**: Mode toggle (Quick/Full) persisted in localStorage + Supabase
- **Participant Linking**: "This is me" dialog to link auth user to a trip participant
- Currency conversion preserved — `calculateBalances()` calls include `defaultCurrency` + `exchangeRates`

## New files (28)
- 3 database migrations (user_profiles, participant user_id, user_preferences)
- AuthContext, UserPreferencesContext
- Quick Mode: 4 pages, 8 components, 2 hooks, 1 service
- Auth UI: SignInButton, UserMenu, LinkParticipantDialog

## Modified files (6)
- `participant.ts` — added `user_id` field
- `ParticipantContext.tsx` — added link/unlink methods
- `App.tsx` — wrapped with AuthProvider + UserPreferencesProvider
- `routes.tsx` — added Quick Mode routes, ConditionalHomePage
- `Layout.tsx` — added auth UI to header
- `TripRouteGuard.tsx` — added participant link banner

## Test plan
- [ ] Full mode works as before (currency conversion, CostBreakdownDialog, all pages)
- [ ] Sign in with Google works
- [ ] Mode toggle switches between Quick/Full
- [ ] Quick home shows trip balances (currency-converted)
- [ ] Quick group detail shows personal balance
- [ ] Link participant dialog works
- [ ] Guest access still works (no auth required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)