### PR TITLE
Fix OAuth by switching to implicit auth flow

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -8,4 +8,8 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables')
 }
 
-export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    flowType: 'implicit',
+  },
+})


### PR DESCRIPTION
## Summary
- Switch Supabase auth from PKCE to implicit flow
- PKCE code exchange was failing silently after OAuth redirect — session never established
- Implicit flow passes tokens directly in URL hash, works reliably for client-side SPAs

## Change
One line in `src/lib/supabase.ts`: add `auth: { flowType: 'implicit' }` to client config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)