### PR TITLE
Fix 406 errors on first sign-in

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -55,7 +55,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .from('user_profiles')
       .select('*')
       .eq('id', userId)
-      .single()
+      .maybeSingle()
 
     if (error) {
       return null

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -35,7 +35,7 @@ export function UserPreferencesProvider({ children }: { children: ReactNode }) {
         .from('user_preferences')
         .select('*')
         .eq('user_id', user.id)
-        .single()
+        .maybeSingle()
 
       if (!error && data) {
         const serverMode = data.preferred_mode as AppMode


### PR DESCRIPTION
## Summary
- Use `.maybeSingle()` instead of `.single()` for user_profiles and user_preferences lookups
- `.single()` throws 406 when no row exists (first sign-in); `.maybeSingle()` returns null gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)