### PR TITLE
Rename Mute to Hide with show-hidden section

### DIFF
--- a/src/components/quick/GroupActions.tsx
+++ b/src/components/quick/GroupActions.tsx
@@ -1,4 +1,4 @@
-import { muteTrip } from '@/lib/mutedTripsStorage'
+import { hideTrip } from '@/lib/mutedTripsStorage'
 import { removeFromMyTrips } from '@/lib/myTripsStorage'
 import { Button } from '@/components/ui/button'
 import {
@@ -12,16 +12,16 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
-import { VolumeX, LogOut } from 'lucide-react'
+import { EyeOff, LogOut } from 'lucide-react'
 
 interface GroupActionsProps {
   tripCode: string
   tripName: string
-  onMuted?: () => void
+  onHidden?: () => void
   onLeft?: () => void
 }
 
-export function GroupActions({ tripCode, tripName, onMuted, onLeft }: GroupActionsProps) {
+export function GroupActions({ tripCode, tripName, onHidden, onLeft }: GroupActionsProps) {
   return (
     <div className="flex gap-2">
       <Button
@@ -29,12 +29,12 @@ export function GroupActions({ tripCode, tripName, onMuted, onLeft }: GroupActio
         size="sm"
         className="gap-1.5 text-muted-foreground"
         onClick={() => {
-          muteTrip(tripCode)
-          onMuted?.()
+          hideTrip(tripCode)
+          onHidden?.()
         }}
       >
-        <VolumeX size={14} />
-        Mute
+        <EyeOff size={14} />
+        Hide
       </Button>
 
       <AlertDialog>

--- a/src/lib/mutedTripsStorage.ts
+++ b/src/lib/mutedTripsStorage.ts
@@ -1,40 +1,36 @@
 /**
- * Muted Trips Storage
- * Tracks trips the user has muted (hidden from Quick Mode home)
+ * Hidden Trips Storage
+ * Tracks trips the user has hidden from Quick Mode home
  */
 
-const MUTED_KEY = 'trip-splitter:muted-trips'
+const STORAGE_KEY = 'trip-splitter:hidden-trips'
 
-export function getMutedTripCodes(): string[] {
+export function getHiddenTripCodes(): string[] {
   try {
-    const stored = localStorage.getItem(MUTED_KEY)
+    const stored = localStorage.getItem(STORAGE_KEY)
     return stored ? JSON.parse(stored) : []
   } catch {
     return []
   }
 }
 
-export function muteTrip(tripCode: string): void {
+export function hideTrip(tripCode: string): void {
   try {
-    const muted = getMutedTripCodes()
-    if (!muted.includes(tripCode)) {
-      muted.push(tripCode)
-      localStorage.setItem(MUTED_KEY, JSON.stringify(muted))
+    const hidden = getHiddenTripCodes()
+    if (!hidden.includes(tripCode)) {
+      hidden.push(tripCode)
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(hidden))
     }
   } catch (error) {
-    console.error('Error muting trip:', error)
+    console.error('Error hiding trip:', error)
   }
 }
 
-export function unmuteTrip(tripCode: string): void {
+export function showTrip(tripCode: string): void {
   try {
-    const muted = getMutedTripCodes().filter(c => c !== tripCode)
-    localStorage.setItem(MUTED_KEY, JSON.stringify(muted))
+    const hidden = getHiddenTripCodes().filter(c => c !== tripCode)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(hidden))
   } catch (error) {
-    console.error('Error unmuting trip:', error)
+    console.error('Error showing trip:', error)
   }
-}
-
-export function isTripMuted(tripCode: string): boolean {
-  return getMutedTripCodes().includes(tripCode)
 }


### PR DESCRIPTION
## Summary
- Rename "Mute" to "Hide" (with EyeOff icon) on Quick Mode trip cards
- Add collapsible "N hidden trips" section at bottom of Quick home screen
- Each hidden trip has a "Show" button (Eye icon) to bring it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)