### PR TITLE
Fix loading hang by adding timeout to trip fetch

### DIFF
--- a/src/components/TripRouteGuard.tsx
+++ b/src/components/TripRouteGuard.tsx
@@ -3,9 +3,11 @@ import { useNavigate } from 'react-router-dom'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useTripContext } from '@/contexts/TripContext'
 import { LinkParticipantDialog } from '@/components/LinkParticipantDialog'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, UserCheck } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Loader2, UserCheck, AlertCircle, RefreshCw } from 'lucide-react'
 
 interface TripRouteGuardProps {
   children: React.ReactNode
@@ -15,21 +17,23 @@ interface TripRouteGuardProps {
  * Route guard that checks if the trip exists
  * If not, redirects to 404 page
  * Shows loading state while trip is being loaded
+ * Shows error state with retry if fetch fails
  * Shows link participant banner for authenticated users who haven't linked
  */
 export function TripRouteGuard({ children }: TripRouteGuardProps) {
   const { currentTrip, tripCode, loading } = useCurrentTrip()
   const { user } = useAuth()
   const { isLinked } = useMyParticipant()
+  const { error, refreshTrips } = useTripContext()
   const navigate = useNavigate()
 
   useEffect(() => {
-    // Only check if trip exists after loading completes
-    if (!loading && tripCode && !currentTrip) {
+    // Only check if trip exists after loading completes without errors
+    if (!loading && !error && tripCode && !currentTrip) {
       // Trip code exists in URL but trip not found
       navigate(`/trip-not-found/${tripCode}`, { replace: true })
     }
-  }, [loading, currentTrip, tripCode, navigate])
+  }, [loading, error, currentTrip, tripCode, navigate])
 
   // Show loading while trips are being fetched
   if (loading) {
@@ -40,6 +44,29 @@ export function TripRouteGuard({ children }: TripRouteGuardProps) {
             <div className="flex flex-col items-center gap-4 text-center">
               <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
               <p className="text-muted-foreground">Loading trip...</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  // Show error with retry button if fetch failed
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Card className="w-full max-w-md">
+          <CardContent className="pt-6">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <AlertCircle className="h-8 w-8 text-destructive" />
+              <div>
+                <p className="font-medium text-foreground">Failed to load trip</p>
+                <p className="text-sm text-muted-foreground mt-1">{error}</p>
+              </div>
+              <Button onClick={refreshTrips} variant="outline" className="gap-2">
+                <RefreshCw size={16} />
+                Try again
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -22,20 +22,29 @@ export function TripProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  // Fetch all trips
+  // Fetch all trips with timeout to prevent indefinite hang
+  // (Supabase JS v2 blocks REST calls behind auth initialization which can hang)
   const fetchTrips = async () => {
     try {
       setLoading(true)
       setError(null)
 
-      const { data, error: fetchError } = await supabase
+      const timeoutMs = 15000
+      const query = supabase
         .from('trips')
         .select('*')
         .order('created_at', { ascending: false })
 
-      if (fetchError) throw fetchError
+      const result = await Promise.race([
+        query,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Connection timed out. The server may be unavailable — please try again.')), timeoutMs)
+        ),
+      ])
 
-      setTrips((data as unknown as Trip[]) || [])
+      if (result.error) throw result.error
+
+      setTrips((result.data as unknown as Trip[]) || [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch trips')
       console.error('Error fetching trips:', err)


### PR DESCRIPTION
## Summary
- Added 15s timeout to `fetchTrips()` via `Promise.race` to prevent the app from hanging indefinitely on "Loading trip..." — Supabase JS v2 blocks REST calls behind auth initialization (`navigator.locks`) which can hang
- `TripRouteGuard` now shows an error state with a "Try again" button instead of silently redirecting to trip-not-found on fetch failures
- Prevents false not-found redirects when the issue is a connection/timeout error

## Test plan
- [ ] Open a trip URL — should load normally when Supabase is reachable
- [ ] Simulate slow/unreachable Supabase — after 15s should show error with retry button
- [ ] Click "Try again" — should re-attempt the fetch
- [ ] Verify trip-not-found redirect still works for genuinely missing trip codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)