### PR TITLE
Add sign-in button to Quick Mode layout

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -8,6 +8,7 @@ import { SettlementProvider } from '@/contexts/SettlementContext'
 import { MealProvider } from '@/contexts/MealContext'
 import { ShoppingProvider } from '@/contexts/ShoppingContext'
 import { UserMenu } from '@/components/auth/UserMenu'
+import { SignInButton } from '@/components/auth/SignInButton'
 import { ModeToggle } from '@/components/quick/ModeToggle'
 import { Toaster } from '@/components/ui/toaster'
 
@@ -42,7 +43,7 @@ export function QuickLayout() {
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
               <ModeToggle />
-              {user && <UserMenu />}
+              {user ? <UserMenu /> : <SignInButton />}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- QuickLayout was missing a sign-in button for unauthenticated users
- Now shows `SignInButton` when not signed in, matching Full Mode behavior

## Test plan
- [ ] Open Quick Mode while signed out — sign-in button should appear in header
- [ ] Sign in — button should be replaced with UserMenu avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)