### PR TITLE
Fix Supabase auth initialization blocking all REST API calls

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -8,8 +8,48 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables')
 }
 
+const LOCK_TIMEOUT_MS = 10_000
+const FETCH_TIMEOUT_MS = 15_000
+
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {
     flowType: 'implicit',
+    lock: async <R>(name: string, acquireTimeout: number, callback: () => Promise<R>): Promise<R> => {
+      if (typeof navigator === 'undefined' || !navigator.locks) {
+        // Fallback: no Web Locks API (SSR, older browsers)
+        return callback()
+      }
+
+      const ac = new AbortController()
+      const timeout = acquireTimeout === -1 ? LOCK_TIMEOUT_MS : Math.min(acquireTimeout, LOCK_TIMEOUT_MS)
+      const timer = setTimeout(() => ac.abort(), timeout)
+
+      try {
+        return await navigator.locks.request(name, { signal: ac.signal }, async () => {
+          clearTimeout(timer)
+          return callback()
+        })
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          // Lock acquisition timed out — proceed without the lock.
+          // Safe for implicit flow (no refresh tokens to coordinate across tabs).
+          return callback()
+        }
+        throw err
+      }
+    },
+  },
+  global: {
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+      // Respect any existing signal from the caller
+      if (init?.signal) {
+        init.signal.addEventListener('abort', () => controller.abort())
+      }
+
+      return fetch(input, { ...init, signal: controller.signal }).finally(() => clearTimeout(timer))
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Add custom `auth.lock` with 10s timeout to prevent `navigator.locks` contention from hanging the app (e.g., when another tab holds the lock)
- Add custom `global.fetch` with 15s `AbortController` timeout so no HTTP call (including auth token refresh during init) can hang forever
- Remove the `Promise.race` timeout band-aid from `TripContext.fetchTrips()` — now redundant since the root cause is fixed at the Supabase client level

## Test plan
- [ ] Normal page load — trips load without timeout
- [ ] Open two tabs simultaneously — no lock contention hang
- [ ] Throttle network in DevTools to "Offline" — shows error within ~15s, "Try again" works when back online
- [ ] Sign in with Google OAuth — redirect works, session persists
- [ ] Sign out and reload — sign-in button appears, trips still load (RLS allows anonymous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)