### PR TITLE
Fix Google Sign-In button overflowing mobile header

### DIFF
--- a/src/components/auth/SignInButton.tsx
+++ b/src/components/auth/SignInButton.tsx
@@ -15,7 +15,7 @@ export function SignInButton() {
         console.error('Google Sign-In failed')
       }}
       size="medium"
-      type="standard"
+      type="icon"
       theme="outline"
     />
   )


### PR DESCRIPTION
## Summary
- Changed `GoogleLogin` component `type` from `"standard"` to `"icon"` in `SignInButton.tsx`
- Renders a compact circular Google "G" button (~40px) instead of the wide text button (~200px)
- Fixes header overflow on mobile, especially in QuickLayout which is capped at `max-w-lg`

## Test plan
- [ ] Mobile: Google "G" icon button fits cleanly in header alongside title and ModeToggle
- [ ] Click button → Google sign-in flow works as before
- [ ] Desktop: icon button still looks clean in the larger header

🤖 Generated with [Claude Code](https://claude.com/claude-code)