### PR TITLE
Default to Quick mode on mobile, Full mode on desktop

### DIFF
--- a/src/lib/userPreferencesStorage.ts
+++ b/src/lib/userPreferencesStorage.ts
@@ -12,8 +12,12 @@ export interface UserPreferencesLocal {
   defaultTripId: string | null
 }
 
+function getDefaultMode(): AppMode {
+  return typeof window !== 'undefined' && window.innerWidth < 1024 ? 'quick' : 'full'
+}
+
 const defaults: UserPreferencesLocal = {
-  preferredMode: 'full',
+  preferredMode: getDefaultMode(),
   defaultTripId: null,
 }
 

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -18,9 +18,9 @@ export function ConditionalHomePage() {
   useEffect(() => {
     if (authLoading || prefsLoading || tripsLoading) return
 
-    if (user && mode === 'quick') {
+    if (mode === 'quick') {
       // If user has a default trip set, go directly to that group
-      if (defaultTripId) {
+      if (user && defaultTripId) {
         const defaultTrip = trips.find(t => t.id === defaultTripId)
         if (defaultTrip) {
           navigate(`/t/${defaultTrip.trip_code}/quick`, { replace: true })


### PR DESCRIPTION
## Summary
- Detect screen width at page load to set the default mode for first-time users: Quick mode on mobile (< 1024px), Full mode on desktop (>= 1024px)
- Allow non-authenticated users to be redirected to `/quick` when mode is set to quick (previously required sign-in)
- Once a user explicitly toggles or Supabase syncs, their stored preference takes over

## Test plan
- [ ] Open on mobile (or narrow browser < 1024px) with cleared localStorage → lands on Quick mode
- [ ] Open on desktop (>= 1024px) with cleared localStorage → lands on Full mode
- [ ] Toggle to opposite mode → preference saved, survives page refresh
- [ ] Sign in → Supabase sync respects the stored preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)