### PR TITLE
Fix quick view back nav, mobile default mode, Google button

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Link, useParams } from 'react-router-dom'
+import { Outlet, Link, useParams, useLocation } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -14,10 +14,14 @@ import { Toaster } from '@/components/ui/toaster'
 
 export function QuickLayout() {
   const { tripCode } = useParams<{ tripCode: string }>()
+  const location = useLocation()
   const { currentTrip } = useCurrentTrip()
   const { user } = useAuth()
 
   const isInTrip = !!tripCode
+  // On sub-pages (e.g. history), back goes to trip detail; on trip detail, back goes to /quick
+  const isSubPage = isInTrip && location.pathname !== `/t/${tripCode}/quick`
+  const backTo = isSubPage ? `/t/${tripCode}/quick` : '/quick'
 
   return (
     <div className="min-h-screen bg-background">
@@ -28,7 +32,7 @@ export function QuickLayout() {
             <div className="flex items-center gap-3 min-w-0">
               {isInTrip ? (
                 <>
-                  <Link to="/quick" className="text-muted-foreground hover:text-foreground">
+                  <Link to={backTo} className="text-muted-foreground hover:text-foreground">
                     <ArrowLeft size={20} />
                   </Link>
                   <h1 className="text-lg font-semibold text-foreground truncate">

--- a/src/components/auth/SignInButton.tsx
+++ b/src/components/auth/SignInButton.tsx
@@ -16,6 +16,7 @@ export function SignInButton() {
       }}
       size="medium"
       type="icon"
+      shape="circle"
       theme="outline"
     />
   )

--- a/src/lib/userPreferencesStorage.ts
+++ b/src/lib/userPreferencesStorage.ts
@@ -16,12 +16,11 @@ function getDefaultMode(): AppMode {
   return typeof window !== 'undefined' && window.innerWidth < 1024 ? 'quick' : 'full'
 }
 
-const defaults: UserPreferencesLocal = {
-  preferredMode: getDefaultMode(),
-  defaultTripId: null,
-}
-
 export function getLocalPreferences(): UserPreferencesLocal {
+  const defaults: UserPreferencesLocal = {
+    preferredMode: getDefaultMode(),
+    defaultTripId: null,
+  }
   try {
     const stored = localStorage.getItem(PREFERENCES_KEY)
     if (!stored) return defaults


### PR DESCRIPTION
## Summary
- **Back navigation**: QuickLayout back arrow now navigates to the trip detail page from sub-pages (e.g. history) instead of always jumping to `/quick`
- **Mobile default mode**: Compute default mode dynamically on each `getLocalPreferences()` call instead of once at module load time — fixes first mobile load not detecting viewport correctly
- **Google button**: Add `shape="circle"` to GoogleLogin for a cleaner look on mobile

## Test plan
- [ ] On quick view history page, tap back arrow → returns to trip detail (not quick home)
- [ ] First mobile load with cleared localStorage → lands on Quick mode
- [ ] Google sign-in button renders as a circle on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)