### PR TITLE
Fix mobile redirect and integrate gradient header

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,7 +13,7 @@ import { SettlementProvider } from '@/contexts/SettlementContext'
 import { MealProvider } from '@/contexts/MealContext'
 import { ShoppingProvider } from '@/contexts/ShoppingContext'
 import { Toaster } from '@/components/ui/toaster'
-import { TripBanner } from '@/components/TripBanner'
+import { getTripGradientPattern } from '@/services/tripGradientService'
 import { SignInButton } from '@/components/auth/SignInButton'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { ModeToggle } from '@/components/quick/ModeToggle'
@@ -105,15 +105,44 @@ export function Layout() {
     return location.pathname === path
   }
 
+  const pattern = currentTrip ? getTripGradientPattern(currentTrip.name) : null
+  const onGradient = !!pattern
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="bg-card border-b border-border soft-shadow-sm fixed top-0 left-0 right-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+      <header className={`fixed top-0 left-0 right-0 z-50 ${pattern ? '' : 'bg-card border-b border-border soft-shadow-sm'}`}>
+        {/* Gradient background when in a trip */}
+        {pattern && (
+          <>
+            <div className="absolute inset-0" style={{ background: pattern.gradient }} />
+            {pattern.icons.slice(0, 2).map((icon, i) => {
+              const Icon = icon.Icon
+              return (
+                <Icon
+                  key={i}
+                  size={icon.size * 0.6}
+                  className="absolute text-white pointer-events-none"
+                  style={{
+                    left: `${icon.x}%`,
+                    top: `${icon.y}%`,
+                    transform: `translate(-50%, -50%) rotate(${icon.rotation}deg)`,
+                    opacity: icon.opacity * 0.8,
+                  }}
+                />
+              )
+            })}
+            <div className="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent" />
+          </>
+        )}
+
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center justify-between">
             {currentTrip ? (
-              <div className="flex-1 max-w-md">
-                <TripBanner tripName={currentTrip.name} compact />
+              <div className="flex-1 min-w-0">
+                <h1 className="text-white font-bold text-lg drop-shadow-md truncate">
+                  {currentTrip.name}
+                </h1>
               </div>
             ) : (
               <motion.div
@@ -129,8 +158,8 @@ export function Layout() {
               </motion.div>
             )}
             <div className="flex items-center gap-2 flex-shrink-0">
-              {user && <ModeToggle />}
-              {user ? <UserMenu /> : <SignInButton />}
+              <ModeToggle onGradient={onGradient} />
+              {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
             </div>
           </div>
         </div>

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -11,6 +11,7 @@ import { UserMenu } from '@/components/auth/UserMenu'
 import { SignInButton } from '@/components/auth/SignInButton'
 import { ModeToggle } from '@/components/quick/ModeToggle'
 import { Toaster } from '@/components/ui/toaster'
+import { getTripGradientPattern } from '@/services/tripGradientService'
 
 export function QuickLayout() {
   const { tripCode } = useParams<{ tripCode: string }>()
@@ -23,19 +24,46 @@ export function QuickLayout() {
   const isSubPage = isInTrip && location.pathname !== `/t/${tripCode}/quick`
   const backTo = isSubPage ? `/t/${tripCode}/quick` : '/quick'
 
+  const pattern = currentTrip ? getTripGradientPattern(currentTrip.name) : null
+  const onGradient = !!pattern
+
   return (
     <div className="min-h-screen bg-background">
       {/* Simplified header */}
-      <header className="bg-card border-b border-border soft-shadow-sm fixed top-0 left-0 right-0 z-50">
-        <div className="max-w-lg mx-auto px-4 py-3">
+      <header className={`fixed top-0 left-0 right-0 z-50 ${pattern ? '' : 'bg-card border-b border-border soft-shadow-sm'}`}>
+        {/* Gradient background when in a trip */}
+        {pattern && (
+          <>
+            <div className="absolute inset-0" style={{ background: pattern.gradient }} />
+            {pattern.icons.slice(0, 2).map((icon, i) => {
+              const Icon = icon.Icon
+              return (
+                <Icon
+                  key={i}
+                  size={icon.size * 0.6}
+                  className="absolute text-white pointer-events-none"
+                  style={{
+                    left: `${icon.x}%`,
+                    top: `${icon.y}%`,
+                    transform: `translate(-50%, -50%) rotate(${icon.rotation}deg)`,
+                    opacity: icon.opacity * 0.8,
+                  }}
+                />
+              )
+            })}
+            <div className="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent" />
+          </>
+        )}
+
+        <div className="relative max-w-lg mx-auto px-4 py-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3 min-w-0">
               {isInTrip ? (
                 <>
-                  <Link to={backTo} className="text-muted-foreground hover:text-foreground">
+                  <Link to={backTo} className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}>
                     <ArrowLeft size={20} />
                   </Link>
-                  <h1 className="text-lg font-semibold text-foreground truncate">
+                  <h1 className={`text-lg font-semibold truncate ${onGradient ? 'text-white drop-shadow-md' : 'text-foreground'}`}>
                     {currentTrip?.name || 'Loading...'}
                   </h1>
                 </>
@@ -49,8 +77,8 @@ export function QuickLayout() {
               )}
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
-              <ModeToggle />
-              {user ? <UserMenu /> : <SignInButton />}
+              <ModeToggle onGradient={onGradient} />
+              {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
             </div>
           </div>
         </div>

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -9,7 +9,11 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { LogOut } from 'lucide-react'
 
-export function UserMenu() {
+interface UserMenuProps {
+  onGradient?: boolean
+}
+
+export function UserMenu({ onGradient = false }: UserMenuProps) {
   const { user, userProfile, signOut } = useAuth()
 
   if (!user) return null
@@ -25,20 +29,26 @@ export function UserMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="gap-2 px-2">
+        <Button variant="ghost" size="sm" className={`gap-2 px-2 ${onGradient ? 'hover:bg-white/10' : ''}`}>
           {userProfile?.avatar_url ? (
             <img
               src={userProfile.avatar_url}
               alt={displayName}
-              className="w-7 h-7 rounded-full"
+              className={`w-7 h-7 rounded-full ${onGradient ? 'ring-2 ring-white/30' : ''}`}
               referrerPolicy="no-referrer"
             />
           ) : (
-            <div className="w-7 h-7 rounded-full bg-primary/10 flex items-center justify-center text-xs font-medium text-primary">
+            <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium ${
+              onGradient
+                ? 'bg-white/20 text-white'
+                : 'bg-primary/10 text-primary'
+            }`}>
               {initials}
             </div>
           )}
-          <span className="hidden sm:inline text-sm font-medium max-w-[120px] truncate">
+          <span className={`hidden sm:inline text-sm font-medium max-w-[120px] truncate ${
+            onGradient ? 'text-white' : ''
+          }`}>
             {displayName}
           </span>
         </Button>

--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -2,7 +2,11 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { Zap, Settings2 } from 'lucide-react'
 
-export function ModeToggle() {
+interface ModeToggleProps {
+  onGradient?: boolean
+}
+
+export function ModeToggle({ onGradient = false }: ModeToggleProps) {
   const navigate = useNavigate()
   const { tripCode } = useParams<{ tripCode: string }>()
   const { mode, setMode } = useUserPreferences()
@@ -28,14 +32,24 @@ export function ModeToggle() {
     }
   }
 
+  const containerClass = onGradient
+    ? 'flex items-center bg-white/20 rounded-lg p-0.5'
+    : 'flex items-center bg-muted rounded-lg p-0.5'
+
+  const activeClass = onGradient
+    ? 'bg-white/30 text-white shadow-sm'
+    : 'bg-background text-foreground shadow-sm'
+
+  const inactiveClass = onGradient
+    ? 'text-white/70 hover:text-white'
+    : 'text-muted-foreground hover:text-foreground'
+
   return (
-    <div className="flex items-center bg-muted rounded-lg p-0.5">
+    <div className={containerClass}>
       <button
         onClick={() => handleModeChange('quick')}
         className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-          mode === 'quick'
-            ? 'bg-background text-foreground shadow-sm'
-            : 'text-muted-foreground hover:text-foreground'
+          mode === 'quick' ? activeClass : inactiveClass
         }`}
       >
         <Zap size={14} />
@@ -44,9 +58,7 @@ export function ModeToggle() {
       <button
         onClick={() => handleModeChange('full')}
         className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-          mode === 'full'
-            ? 'bg-background text-foreground shadow-sm'
-            : 'text-muted-foreground hover:text-foreground'
+          mode === 'full' ? activeClass : inactiveClass
         }`}
       >
         <Settings2 size={14} />

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -15,20 +15,28 @@ export function ConditionalHomePage() {
   const { mode, defaultTripId, loading: prefsLoading } = useUserPreferences()
   const { trips, loading: tripsLoading } = useTripContext()
 
+  // Fast path: redirect unauthenticated quick-mode users immediately
+  // (no need to wait for trips to load)
+  useEffect(() => {
+    if (authLoading || prefsLoading) return
+
+    if (mode === 'quick' && (!user || !defaultTripId)) {
+      navigate('/quick', { replace: true })
+    }
+  }, [authLoading, prefsLoading, user, mode, defaultTripId, navigate])
+
+  // Default-trip shortcut: authenticated quick-mode users with a default trip
   useEffect(() => {
     if (authLoading || prefsLoading || tripsLoading) return
 
-    if (mode === 'quick') {
-      // If user has a default trip set, go directly to that group
-      if (user && defaultTripId) {
-        const defaultTrip = trips.find(t => t.id === defaultTripId)
-        if (defaultTrip) {
-          navigate(`/t/${defaultTrip.trip_code}/quick`, { replace: true })
-          return
-        }
+    if (mode === 'quick' && user && defaultTripId) {
+      const defaultTrip = trips.find(t => t.id === defaultTripId)
+      if (defaultTrip) {
+        navigate(`/t/${defaultTrip.trip_code}/quick`, { replace: true })
+      } else {
+        // Default trip not found, fall back to quick home
+        navigate('/quick', { replace: true })
       }
-      // Otherwise go to Quick home
-      navigate('/quick', { replace: true })
     }
   }, [authLoading, prefsLoading, tripsLoading, user, mode, defaultTripId, trips, navigate])
 


### PR DESCRIPTION
## Summary
- Split `ConditionalHomePage` redirect into a fast path that skips `tripsLoading`, so mobile Safari immediately redirects to `/quick` instead of briefly showing full mode
- Integrated trip gradient banner into full-width header for both `Layout` and `QuickLayout`, replacing the disconnected `TripBanner` box with controls floating separately
- `ModeToggle` is now always visible (removed auth guard) so unauthenticated users can switch modes
- Added `onGradient` prop to `ModeToggle` and `UserMenu` for white/transparent styling on gradient backgrounds

## Test plan
- [ ] Mobile first load (unauthenticated, cleared localStorage) → redirects to `/quick` immediately
- [ ] Desktop first load → stays on full mode
- [ ] ModeToggle visible for both signed-in and signed-out users
- [ ] When a trip is active, header shows full-width gradient with controls inside it
- [ ] When no trip is active, header shows standard branded look
- [ ] ModeToggle and avatar/sign-in button look correct on gradient backgrounds
- [ ] Build passes (`npm run type-check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)