### PR TITLE
Fix flash-of-wrong-content across all navigation flows

### DIFF
--- a/src/components/TripRouteGuard.tsx
+++ b/src/components/TripRouteGuard.tsx
@@ -23,7 +23,7 @@ interface TripRouteGuardProps {
 export function TripRouteGuard({ children }: TripRouteGuardProps) {
   const { currentTrip, tripCode, loading } = useCurrentTrip()
   const { user } = useAuth()
-  const { isLinked } = useMyParticipant()
+  const { isLinked, loading: participantsLoading } = useMyParticipant()
   const { error, refreshTrips } = useTripContext()
   const navigate = useNavigate()
 
@@ -76,7 +76,7 @@ export function TripRouteGuard({ children }: TripRouteGuardProps) {
 
   return (
     <>
-      {user && !isLinked && (
+      {user && !participantsLoading && !isLinked && (
         <div className="mb-4 p-3 rounded-lg border border-border bg-accent/30 flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <UserCheck size={16} />

--- a/src/contexts/ExpenseContext.tsx
+++ b/src/contexts/ExpenseContext.tsx
@@ -29,6 +29,7 @@ const ExpenseContext = createContext<ExpenseContextType | undefined>(undefined)
 export function ExpenseProvider({ children }: { children: ReactNode }) {
   const [expenses, setExpenses] = useState<Expense[]>([])
   const [loading, setLoading] = useState(false)
+  const [initialLoadDone, setInitialLoadDone] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const { currentTrip, tripCode } = useCurrentTrip()
@@ -38,6 +39,7 @@ export function ExpenseProvider({ children }: { children: ReactNode }) {
   const fetchExpenses = async () => {
     if (!currentTrip) {
       setExpenses([])
+      setInitialLoadDone(true)
       return
     }
 
@@ -60,6 +62,7 @@ export function ExpenseProvider({ children }: { children: ReactNode }) {
       console.error('Error fetching expenses:', err)
     } finally {
       setLoading(false)
+      setInitialLoadDone(true)
     }
   }
 
@@ -177,13 +180,14 @@ export function ExpenseProvider({ children }: { children: ReactNode }) {
   // Fetch expenses when current trip changes
   useEffect(() => {
     if (tripCode && currentTrip) {
+      setInitialLoadDone(false)
       fetchExpenses()
     }
   }, [tripCode, currentTrip?.id, trips.length])
 
   const value: ExpenseContextType = {
     expenses,
-    loading,
+    loading: loading || (!!currentTrip && !initialLoadDone),
     error,
     createExpense,
     updateExpense,

--- a/src/contexts/ParticipantContext.tsx
+++ b/src/contexts/ParticipantContext.tsx
@@ -35,6 +35,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
   const [participants, setParticipants] = useState<Participant[]>([])
   const [families, setFamilies] = useState<Family[]>([])
   const [loading, setLoading] = useState(false)
+  const [initialLoadDone, setInitialLoadDone] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const { currentTrip, tripCode } = useCurrentTrip()
@@ -45,6 +46,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
     if (!currentTrip) {
       setParticipants([])
       setFamilies([])
+      setInitialLoadDone(true)
       return
     }
 
@@ -81,6 +83,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       console.error('Error fetching participants/families:', err)
     } finally {
       setLoading(false)
+      setInitialLoadDone(true)
     }
   }
 
@@ -291,6 +294,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
   // Fetch data when current trip changes
   useEffect(() => {
     if (tripCode && currentTrip) {
+      setInitialLoadDone(false)
       fetchData()
     }
   }, [tripCode, currentTrip?.id, trips.length])
@@ -298,7 +302,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
   const value: ParticipantContextType = {
     participants,
     families,
-    loading,
+    loading: loading || (!!currentTrip && !initialLoadDone),
     error,
     createParticipant,
     updateParticipant,

--- a/src/contexts/SettlementContext.tsx
+++ b/src/contexts/SettlementContext.tsx
@@ -24,6 +24,7 @@ const SettlementContext = createContext<SettlementContextType | undefined>(undef
 export function SettlementProvider({ children }: { children: ReactNode }) {
   const [settlements, setSettlements] = useState<Settlement[]>([])
   const [loading, setLoading] = useState(false)
+  const [initialLoadDone, setInitialLoadDone] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const { currentTrip, tripCode } = useCurrentTrip()
@@ -33,6 +34,7 @@ export function SettlementProvider({ children }: { children: ReactNode }) {
   const fetchSettlements = async () => {
     if (!currentTrip) {
       setSettlements([])
+      setInitialLoadDone(true)
       return
     }
 
@@ -55,6 +57,7 @@ export function SettlementProvider({ children }: { children: ReactNode }) {
       console.error('Error fetching settlements:', err)
     } finally {
       setLoading(false)
+      setInitialLoadDone(true)
     }
   }
 
@@ -149,15 +152,17 @@ export function SettlementProvider({ children }: { children: ReactNode }) {
   // Fetch settlements when current trip changes
   useEffect(() => {
     if (tripCode && currentTrip) {
+      setInitialLoadDone(false)
       fetchSettlements()
     } else {
       setSettlements([])
+      setInitialLoadDone(true)
     }
   }, [tripCode, currentTrip?.id, trips.length])
 
   const value: SettlementContextType = {
     settlements,
-    loading,
+    loading: loading || (!!currentTrip && !initialLoadDone),
     error,
     createSettlement,
     updateSettlement,

--- a/src/hooks/useMyParticipant.ts
+++ b/src/hooks/useMyParticipant.ts
@@ -7,14 +7,15 @@ import { useParticipantContext } from '@/contexts/ParticipantContext'
  */
 export function useMyParticipant() {
   const { user } = useAuth()
-  const { participants } = useParticipantContext()
+  const { participants, loading } = useParticipantContext()
 
-  if (!user) return { myParticipant: null, isLinked: false }
+  if (!user) return { myParticipant: null, isLinked: false, loading }
 
   const myParticipant = participants.find(p => p.user_id === user.id) || null
 
   return {
     myParticipant,
     isLinked: myParticipant !== null,
+    loading,
   }
 }

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -40,6 +40,9 @@ export function ConditionalHomePage() {
     }
   }, [authLoading, prefsLoading, tripsLoading, user, mode, defaultTripId, trips, navigate])
 
+  // Don't render HomePage when we're about to redirect to quick mode
+  if (mode === 'quick') return null
+
   // Show Full Mode home page by default
   return <HomePage />
 }


### PR DESCRIPTION
## Summary
- Fix contexts (`ParticipantContext`, `ExpenseContext`, `SettlementContext`) reporting `loading: false` before first fetch starts by adding `initialLoadDone` state
- Prevent `ConditionalHomePage` from flashing the full HomePage when quick mode is active
- Guard the "Link yourself" banner in `TripRouteGuard` behind `participantsLoading` check
- Expose `loading` from `useMyParticipant` hook for consumer components

## Test plan
- [ ] Mobile fresh load (clear localStorage) → blank/spinner briefly, then `/quick` — never see full HomePage
- [ ] Desktop fresh load → Full Mode renders immediately with no flash
- [ ] Reload a trip page while signed in and linked → never see "Link yourself" banner flash
- [ ] QuickGroupDetailPage → spinner while loading, then balance (never link card if already linked)
- [ ] `npm run type-check && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)