### PR TITLE
Add trip feature toggles, bank details, and configurable currencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@react-oauth/google": "^0.13.4",
@@ -2038,6 +2039,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@react-oauth/google": "^0.13.4",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -56,8 +56,14 @@ export function Layout() {
         { path: `/t/${tripCode}/manage`, label: 'Manage Trip', requiresTrip: true },
         { path: `/t/${tripCode}/expenses`, label: 'Expenses', requiresTrip: true },
         { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
-        { path: `/t/${tripCode}/meals`, label: 'Meals', requiresTrip: true },
-        { path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true },
+      )
+      if (currentTrip?.enable_meals) {
+        items.push({ path: `/t/${tripCode}/meals`, label: 'Meals', requiresTrip: true })
+      }
+      if (currentTrip?.enable_shopping) {
+        items.push({ path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true })
+      }
+      items.push(
         { path: `/t/${tripCode}/dashboard`, label: 'Dashboard', requiresTrip: true },
       )
     }
@@ -73,12 +79,17 @@ export function Layout() {
       ]
     }
 
-    return [
+    const items = [
       { path: `/t/${tripCode}/dashboard`, label: 'Overview', requiresTrip: true },
       { path: `/t/${tripCode}/expenses`, label: 'Expenses', requiresTrip: true },
-      { path: `/t/${tripCode}/meals`, label: 'Meals', requiresTrip: true },
-      { path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true },
     ]
+    if (currentTrip?.enable_meals) {
+      items.push({ path: `/t/${tripCode}/meals`, label: 'Meals', requiresTrip: true })
+    }
+    if (currentTrip?.enable_shopping) {
+      items.push({ path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true })
+    }
+    return items
   }
 
   // Overflow menu items (mobile only)

--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -65,6 +65,11 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote 
 
   const isIndividualsMode = currentTrip?.tracking_mode === 'individuals'
 
+  // Compute available currencies from trip settings
+  const availableCurrencies = currentTrip
+    ? [currentTrip.default_currency, ...Object.keys(currentTrip.exchange_rates || {})]
+    : ['EUR', 'USD', 'GBP', 'THB']
+
   // Get all adults for selection
   // Note: Settlements always use participant IDs (adults), even in families mode
   // In families mode, we show which family they belong to
@@ -266,10 +271,9 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote 
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="EUR">EUR</SelectItem>
-              <SelectItem value="USD">USD</SelectItem>
-              <SelectItem value="GBP">GBP</SelectItem>
-              <SelectItem value="THB">THB</SelectItem>
+              {availableCurrencies.map(c => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -4,12 +4,18 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 
+export interface BankDetails {
+  holder: string
+  iban: string
+}
+
 interface SettlementPlanProps {
   plan: OptimalSettlementPlan
   onRecordSettlement?: (transaction: SettlementTransaction) => void
+  bankDetailsMap?: Record<string, BankDetails>
 }
 
-export function SettlementPlan({ plan, onRecordSettlement }: SettlementPlanProps) {
+export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap }: SettlementPlanProps) {
   if (plan.transactions.length === 0) {
     return (
       <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
@@ -53,6 +59,7 @@ export function SettlementPlan({ plan, onRecordSettlement }: SettlementPlanProps
             currency={plan.currency}
             index={index + 1}
             onRecord={onRecordSettlement ? () => onRecordSettlement(transaction) : undefined}
+            bankDetails={bankDetailsMap?.[transaction.toId]}
           />
         ))}
       </div>
@@ -65,6 +72,7 @@ interface SettlementTransactionCardProps {
   currency: string
   index: number
   onRecord?: () => void
+  bankDetails?: BankDetails
 }
 
 function SettlementTransactionCard({
@@ -72,6 +80,7 @@ function SettlementTransactionCard({
   currency,
   index,
   onRecord,
+  bankDetails,
 }: SettlementTransactionCardProps) {
   const formattedAmount = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -117,6 +126,14 @@ function SettlementTransactionCard({
           <div className="mt-2">
             <span className="text-2xl font-bold text-accent tabular-nums">{formattedAmount}</span>
           </div>
+
+          {/* Bank Details */}
+          {bankDetails && (bankDetails.iban || bankDetails.holder) && (
+            <div className="mt-2 text-xs text-muted-foreground space-y-0.5">
+              {bankDetails.holder && <p>Account: {bankDetails.holder}</p>}
+              {bankDetails.iban && <p>IBAN: {bankDetails.iban}</p>}
+            </div>
+          )}
         </div>
 
         {/* Record Button */}

--- a/src/components/TripForm.tsx
+++ b/src/components/TripForm.tsx
@@ -4,13 +4,7 @@ import { CreateTripInput, TrackingMode } from '@/types/trip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
 import { fadeInUp } from '@/lib/animations'
 
 interface TripFormProps {
@@ -20,6 +14,7 @@ interface TripFormProps {
   submitLabel?: string
   isLoading?: boolean
   disableTrackingMode?: boolean
+  isEditMode?: boolean
 }
 
 export function TripForm({
@@ -28,13 +23,16 @@ export function TripForm({
   initialValues,
   submitLabel = 'Create Trip',
   isLoading: externalLoading,
-  disableTrackingMode = false
+  disableTrackingMode = false,
+  isEditMode = false,
 }: TripFormProps) {
   const [name, setName] = useState(initialValues?.name || '')
   const [startDate, setStartDate] = useState(initialValues?.start_date || new Date().toISOString().split('T')[0])
   const [endDate, setEndDate] = useState(initialValues?.end_date || new Date().toISOString().split('T')[0])
   const [trackingMode, setTrackingMode] = useState<TrackingMode>(initialValues?.tracking_mode || 'individuals')
   const [defaultCurrency, setDefaultCurrency] = useState(initialValues?.default_currency || 'EUR')
+  const [enableMeals, setEnableMeals] = useState(initialValues?.enable_meals ?? false)
+  const [enableShopping, setEnableShopping] = useState(initialValues?.enable_shopping ?? false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -61,7 +59,9 @@ export function TripForm({
         start_date: startDate,
         end_date: endDate,
         tracking_mode: trackingMode,
-        default_currency: defaultCurrency,
+        default_currency: defaultCurrency.trim().toUpperCase() || 'EUR',
+        enable_meals: enableMeals,
+        enable_shopping: enableShopping,
       })
     } catch (err) {
       setError('Failed to save trip. Please try again.')
@@ -130,25 +130,47 @@ export function TripForm({
 
       <div className="space-y-2">
         <Label htmlFor="defaultCurrency">Default Currency</Label>
-        <Select
+        <Input
+          id="defaultCurrency"
           value={defaultCurrency}
-          onValueChange={setDefaultCurrency}
+          onChange={(e) => setDefaultCurrency(e.target.value.toUpperCase().slice(0, 3))}
+          placeholder="EUR"
+          maxLength={3}
+          className="w-32 uppercase"
           disabled={isSubmitting}
-        >
-          <SelectTrigger id="defaultCurrency">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="EUR">EUR - Euro</SelectItem>
-            <SelectItem value="USD">USD - US Dollar</SelectItem>
-            <SelectItem value="GBP">GBP - British Pound</SelectItem>
-            <SelectItem value="THB">THB - Thai Baht</SelectItem>
-          </SelectContent>
-        </Select>
+        />
         <p className="text-xs text-muted-foreground">
           All balances and settlements will be shown in this currency
         </p>
       </div>
+
+      {!isEditMode && (
+        <div className="space-y-4">
+          <Label>Features</Label>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">Meal Planning</span>
+              <p className="text-xs text-muted-foreground">Plan meals and assign cooking responsibilities</p>
+            </div>
+            <Switch
+              checked={enableMeals}
+              onCheckedChange={setEnableMeals}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">Shopping List</span>
+              <p className="text-xs text-muted-foreground">Collaborative shopping list with real-time updates</p>
+            </div>
+            <Switch
+              checked={enableShopping}
+              onCheckedChange={setEnableShopping}
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+      )}
 
       <div className="space-y-3">
         <Label>Tracking Mode</Label>

--- a/src/components/auth/BankDetailsDialog.tsx
+++ b/src/components/auth/BankDetailsDialog.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useToast } from '@/hooks/use-toast'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+
+interface BankDetailsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function BankDetailsDialog({ open, onOpenChange }: BankDetailsDialogProps) {
+  const { userProfile, updateBankDetails } = useAuth()
+  const { toast } = useToast()
+
+  const [holder, setHolder] = useState(userProfile?.bank_account_holder || '')
+  const [iban, setIban] = useState(userProfile?.bank_iban || '')
+  const [saving, setSaving] = useState(false)
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      const success = await updateBankDetails(holder.trim(), iban.trim())
+      if (success) {
+        toast({
+          title: 'Bank details saved',
+          description: 'Your bank details have been updated.',
+        })
+        onOpenChange(false)
+      } else {
+        toast({
+          variant: 'destructive',
+          title: 'Save failed',
+          description: 'Failed to save bank details. Please try again.',
+        })
+      }
+    } catch {
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'An error occurred while saving bank details.',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Bank Details</DialogTitle>
+          <DialogDescription>
+            Add your bank details so others can see where to send payments in settlement plans.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 pt-2">
+          <div className="space-y-2">
+            <Label htmlFor="accountHolder">Account Holder Name</Label>
+            <Input
+              id="accountHolder"
+              value={holder}
+              onChange={(e) => setHolder(e.target.value)}
+              placeholder="e.g., John Smith"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="iban">IBAN</Label>
+            <Input
+              id="iban"
+              value={iban}
+              onChange={(e) => setIban(e.target.value)}
+              placeholder="e.g., DE89 3704 0044 0532 0130 00"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <Button onClick={handleSave} disabled={saving} className="flex-1">
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { Button } from '@/components/ui/button'
 import {
@@ -7,7 +8,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { LogOut } from 'lucide-react'
+import { LogOut, Landmark } from 'lucide-react'
+import { BankDetailsDialog } from './BankDetailsDialog'
 
 interface UserMenuProps {
   onGradient?: boolean
@@ -15,6 +17,7 @@ interface UserMenuProps {
 
 export function UserMenu({ onGradient = false }: UserMenuProps) {
   const { user, userProfile, signOut } = useAuth()
+  const [showBankDetails, setShowBankDetails] = useState(false)
 
   if (!user) return null
 
@@ -61,11 +64,18 @@ export function UserMenu({ onGradient = false }: UserMenuProps) {
           )}
         </div>
         <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => setShowBankDetails(true)} className="gap-2">
+          <Landmark size={16} />
+          Bank Details
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem onClick={signOut} className="gap-2 text-destructive focus:text-destructive">
           <LogOut size={16} />
           Sign out
         </DropdownMenuItem>
       </DropdownMenuContent>
+
+      <BankDetailsDialog open={showBankDetails} onOpenChange={setShowBankDetails} />
     </DropdownMenu>
   )
 }

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -77,6 +77,11 @@ export function ExpenseForm({
   const adults = getAdultParticipants()
   const isIndividualsMode = currentTrip?.tracking_mode === 'individuals'
 
+  // Compute available currencies from trip settings
+  const availableCurrencies = currentTrip
+    ? [currentTrip.default_currency, ...Object.keys(currentTrip.exchange_rates || {})]
+    : ['EUR', 'USD', 'GBP', 'THB']
+
   // Calculate balances to find suggested payer (including settlements)
   const balanceCalculation = currentTrip
     ? calculateBalances(expenses, participants, families, currentTrip.tracking_mode, settlements, currentTrip.default_currency, currentTrip.exchange_rates)
@@ -450,10 +455,9 @@ export function ExpenseForm({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="EUR">EUR</SelectItem>
-              <SelectItem value="USD">USD</SelectItem>
-              <SelectItem value="GBP">GBP</SelectItem>
-              <SelectItem value="THB">THB</SelectItem>
+              {availableCurrencies.map(c => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -114,6 +114,11 @@ function MobileWizard({
   const adults = getAdultParticipants()
   const isIndividualsMode = currentTrip?.tracking_mode === 'individuals'
 
+  // Compute available currencies from trip settings
+  const availableCurrencies = currentTrip
+    ? [currentTrip.default_currency, ...Object.keys(currentTrip.exchange_rates || {})]
+    : undefined
+
   // Calculate balances for smart payer suggestion
   const balanceCalculation = currentTrip
     ? calculateBalances(expenses, participants, families, currentTrip.tracking_mode, settlements, currentTrip.default_currency, currentTrip.exchange_rates)
@@ -315,6 +320,7 @@ function MobileWizard({
               onDescriptionChange={setDescription}
               onAmountChange={setAmount}
               onCurrencyChange={setCurrency}
+              availableCurrencies={availableCurrencies}
               disabled={isSubmitting}
             />
           )}

--- a/src/components/expenses/wizard/WizardStep1.tsx
+++ b/src/components/expenses/wizard/WizardStep1.tsx
@@ -18,6 +18,7 @@ interface WizardStep1Props {
   onDescriptionChange: (value: string) => void
   onAmountChange: (value: string) => void
   onCurrencyChange: (value: string) => void
+  availableCurrencies?: string[]
   disabled?: boolean
 }
 
@@ -28,8 +29,12 @@ export function WizardStep1({
   onDescriptionChange,
   onAmountChange,
   onCurrencyChange,
+  availableCurrencies,
   disabled = false,
 }: WizardStep1Props) {
+  const currencies = availableCurrencies && availableCurrencies.length > 0
+    ? availableCurrencies
+    : ['EUR', 'USD', 'GBP', 'THB']
   const descriptionRef = useRef<HTMLInputElement>(null)
 
   // Auto-focus description on mount
@@ -94,10 +99,9 @@ export function WizardStep1({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="EUR">EUR</SelectItem>
-              <SelectItem value="USD">USD</SelectItem>
-              <SelectItem value="GBP">GBP</SelectItem>
-              <SelectItem value="THB">THB</SelectItem>
+              {currencies.map(c => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/src/components/quick/QuickExpenseSheet.tsx
+++ b/src/components/quick/QuickExpenseSheet.tsx
@@ -22,7 +22,7 @@ export function QuickExpenseSheet({ open, onOpenChange }: QuickExpenseSheetProps
   const initialValues: Partial<CreateExpenseInput> = {
     trip_id: currentTrip.id,
     paid_by: myParticipant?.id || '',
-    currency: 'EUR',
+    currency: currentTrip.default_currency,
     expense_date: new Date().toISOString().split('T')[0],
   }
 

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitive.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitive.Root>
+))
+Switch.displayName = SwitchPrimitive.Root.displayName
+
+export { Switch }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -3,6 +3,8 @@ export interface UserProfile {
   display_name: string
   email: string | null
   avatar_url: string | null
+  bank_account_holder: string | null
+  bank_iban: string | null
   created_at: string
   updated_at: string
 }

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -9,6 +9,8 @@ export interface Trip {
   tracking_mode: TrackingMode
   default_currency: string
   exchange_rates: Record<string, number>
+  enable_meals: boolean
+  enable_shopping: boolean
   created_at: string
 }
 
@@ -19,6 +21,8 @@ export interface CreateTripInput {
   tracking_mode: TrackingMode
   trip_code?: string // Optional: will be auto-generated if not provided
   default_currency?: string
+  enable_meals?: boolean
+  enable_shopping?: boolean
 }
 
 export interface UpdateTripInput {
@@ -28,4 +32,6 @@ export interface UpdateTripInput {
   tracking_mode?: TrackingMode
   default_currency?: string
   exchange_rates?: Record<string, number>
+  enable_meals?: boolean
+  enable_shopping?: boolean
 }

--- a/supabase/migrations/012_trip_features_and_bank_details.sql
+++ b/supabase/migrations/012_trip_features_and_bank_details.sql
@@ -1,0 +1,7 @@
+-- Add feature toggles for meals and shopping per trip
+ALTER TABLE trips ADD COLUMN enable_meals BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE trips ADD COLUMN enable_shopping BOOLEAN NOT NULL DEFAULT false;
+
+-- Add bank details to user profiles
+ALTER TABLE user_profiles ADD COLUMN bank_account_holder TEXT;
+ALTER TABLE user_profiles ADD COLUMN bank_iban TEXT;


### PR DESCRIPTION
## Summary
- **Meal/shopping toggles**: per-trip feature flags (default off) that hide nav items when disabled
- **Bank details**: users can save IBAN + account holder in their profile; shown on settlement plan cards for recipients
- **Configurable currencies**: free-text currency codes with dynamic exchange rate rows replace the hardcoded EUR/USD/GBP/THB list

## Test plan
- [ ] Create a new trip — meals and shopping should be off, not visible in nav
- [ ] Toggle meals on in Manage Trip — Meals tab appears in nav
- [ ] Toggle shopping on — Shopping tab appears
- [ ] Set bank details in UserMenu — save and verify they persist
- [ ] Open settlement plan — recipient's bank info shows on the card
- [ ] In Manage Trip currency settings, add a custom currency (e.g. "NOK" rate 11.5) — it appears in expense form currency selector
- [ ] Change default currency from EUR to USD — works, expense form defaults to USD
- [ ] `npm run type-check && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)