### PR TITLE
Fix shared trip link mode redirect and toggle sync

### DIFF
--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -1,4 +1,5 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useEffect } from 'react'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { Zap, Settings2 } from 'lucide-react'
 
@@ -8,8 +9,19 @@ interface ModeToggleProps {
 
 export function ModeToggle({ onGradient = false }: ModeToggleProps) {
   const navigate = useNavigate()
+  const location = useLocation()
   const { tripCode } = useParams<{ tripCode: string }>()
   const { mode, setMode } = useUserPreferences()
+
+  // Sync mode state with actual route to fix mismatches (e.g. direct URL access)
+  useEffect(() => {
+    const path = location.pathname
+    if (path.includes('/quick') && mode !== 'quick') {
+      setMode('quick')
+    } else if (tripCode && !path.includes('/quick') && mode !== 'full') {
+      setMode('full')
+    }
+  }, [location.pathname, tripCode]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleModeChange = async (newMode: 'quick' | 'full') => {
     if (newMode === mode) return

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -15,6 +15,12 @@ import { TripNotFoundPage } from './pages/TripNotFoundPage'
 import { QuickHomeScreen } from './pages/QuickHomeScreen'
 import { QuickGroupDetailPage } from './pages/QuickGroupDetailPage'
 import { QuickHistoryPage } from './pages/QuickHistoryPage'
+import { useUserPreferences } from './contexts/UserPreferencesContext'
+
+function TripModeRedirect() {
+  const { mode } = useUserPreferences()
+  return <Navigate to={mode === 'quick' ? 'quick' : 'dashboard'} replace />
+}
 
 export function AppRoutes() {
   return (
@@ -22,6 +28,9 @@ export function AppRoutes() {
       {/* Special routes - outside Layout */}
       <Route path="admin/all-trips" element={<AdminAllTripsPage />} />
       <Route path="trip-not-found/:tripCode" element={<TripNotFoundPage />} />
+
+      {/* Mode-aware redirect for shared trip links */}
+      <Route path="t/:tripCode" element={<TripModeRedirect />} />
 
       {/* Quick Mode routes */}
       <Route path="/quick" element={<QuickLayout />}>
@@ -36,10 +45,6 @@ export function AppRoutes() {
       <Route path="/" element={<Layout />}>
         <Route index element={<ConditionalHomePage />} />
         <Route path="create-trip" element={<TripsPage />} />
-
-        {/* Trip routes - protected by TripRouteGuard */}
-        {/* Redirect base trip URL to dashboard */}
-        <Route path="t/:tripCode" element={<Navigate to="dashboard" replace />} />
         <Route path="t/:tripCode/manage" element={<TripRouteGuard><ManageTripPage /></TripRouteGuard>} />
         <Route path="t/:tripCode/expenses" element={<TripRouteGuard><ExpensesPage /></TripRouteGuard>} />
         <Route path="t/:tripCode/settlements" element={<TripRouteGuard><SettlementsPage /></TripRouteGuard>} />


### PR DESCRIPTION
## Summary
- Shared trip links (`/t/:tripCode`) now redirect to quick or full mode based on user preference instead of always going to full mode (dashboard)
- ModeToggle syncs its state with the actual route on mount, fixing the issue where the toggle appeared stuck when mode state didn't match the current layout

## Test plan
- [ ] Open a shared trip link in incognito on mobile — should redirect to `/t/.../quick`
- [ ] Toggle between Quick and Full — both directions should work and highlight correctly
- [ ] Open `/t/.../dashboard` directly — toggle should show "Full" as active
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)