### PR TITLE
Rebrand to Split, fix alignment, auth-gate feedback, screenshot attachment

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Trip Splitter Pro</title>
+    <title>Split</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -163,9 +163,9 @@ export function Layout() {
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.3 }}
               >
-                <img src="/logo.png" alt="Trip Splitter Pro" className="h-9 w-9 rounded-full" />
+                <img src="/logo.png" alt="Split" className="h-9 w-9 rounded-full" />
                 <h1 className="text-2xl font-bold text-foreground">
-                  Trip Splitter Pro
+                  Split
                 </h1>
               </motion.div>
             )}

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -70,9 +70,9 @@ export function QuickLayout() {
                 </>
               ) : (
                 <div className="flex items-center gap-2">
-                  <img src="/logo.png" alt="Trip Splitter Pro" className="h-8 w-8 rounded-full" />
+                  <img src="/logo.png" alt="Split" className="h-8 w-8 rounded-full" />
                   <h1 className="text-lg font-semibold text-foreground">
-                    Trip Splitter
+                    Split
                   </h1>
                 </div>
               )}

--- a/src/components/ReportIssueButton.tsx
+++ b/src/components/ReportIssueButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Bug } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
 import { ReportIssueDialog } from '@/components/ReportIssueDialog'
 
 interface ReportIssueButtonProps {
@@ -7,7 +8,10 @@ interface ReportIssueButtonProps {
 }
 
 export function ReportIssueButton({ onGradient = false }: ReportIssueButtonProps) {
+  const { user } = useAuth()
   const [open, setOpen] = useState(false)
+
+  if (!user) return null
 
   return (
     <>

--- a/src/components/ShareTripDialog.tsx
+++ b/src/components/ShareTripDialog.tsx
@@ -64,7 +64,7 @@ export function ShareTripDialog({ tripCode, tripName, trigger }: ShareTripDialog
   }
 
   const handleShareVia = (method: 'whatsapp' | 'email' | 'sms') => {
-    const message = `Join our trip "${tripName}" on Trip Splitter: ${shareUrl}`
+    const message = `Join our trip "${tripName}" on Split: ${shareUrl}`
 
     let url = ''
     switch (method) {
@@ -87,7 +87,7 @@ export function ShareTripDialog({ tripCode, tripName, trigger }: ShareTripDialog
       try {
         await navigator.share({
           title: `Join ${tripName}`,
-          text: `Join our trip "${tripName}" on Trip Splitter`,
+          text: `Join our trip "${tripName}" on Split`,
           url: shareUrl,
         })
       } catch (err) {

--- a/src/components/TopExpensesList.tsx
+++ b/src/components/TopExpensesList.tsx
@@ -60,7 +60,7 @@ export function TopExpensesList({ expenses, participants, limit = 5, currency = 
           {topExpenses.map((expense, index) => (
             <div
               key={expense.id}
-              className="flex items-center justify-between p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+              className="flex items-start justify-between p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
             >
               <div className="flex items-center gap-3 flex-1 min-w-0">
                 <div className="flex-shrink-0 w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center">
@@ -70,15 +70,15 @@ export function TopExpensesList({ expenses, participants, limit = 5, currency = 
                   <p className="font-semibold text-foreground truncate">
                     {expense.description}
                   </p>
-                  <p className="text-xs text-muted-foreground">
-                    Paid by {expense.payerName} • {new Date(expense.expense_date).toLocaleDateString()}
+                  <p className="text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                    <span>Paid by {expense.payerName} • {new Date(expense.expense_date).toLocaleDateString()}</span>
+                    <Badge variant="outline" className="text-xs">
+                      {expense.category}
+                    </Badge>
                   </p>
                 </div>
               </div>
-              <div className="flex items-center gap-2 ml-3 flex-shrink-0">
-                <Badge variant="outline" className="text-xs">
-                  {expense.category}
-                </Badge>
+              <div className="ml-3 flex-shrink-0">
                 <div className="text-right">
                   <span className="font-bold text-foreground tabular-nums text-lg">
                     {new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
## Summary
- Rebrand all user-facing text from "Trip Splitter Pro" to "Split" (title, headers, share messages)
- Fix Top Expenses list alignment on narrow viewports — moved category badge inline with metadata to prevent overlap
- Hide the report issue button for anonymous users (auth-gated)
- Add screenshot attachment support in feedback dialog with image preview, remove, and base64 embedding in GitHub issue body

## Test plan
- [ ] Verify all headers/titles show "Split" instead of "Trip Splitter Pro"
- [ ] Check Top Expenses list on narrow mobile viewport — no overlap between badge and amount
- [ ] Log out and confirm the bug icon is hidden; log in and confirm it appears
- [ ] Open feedback dialog, attach a screenshot, verify preview shows with X to remove
- [ ] Submit feedback with screenshot and verify it appears in the GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)