### PR TITLE
Fix quick mode payer auto-select and add dual-currency display

### DIFF
--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -144,7 +144,7 @@ function MobileWizard({
         setShowAdvanced(false)
         setDescription('')
         setAmount('')
-        setPaidBy('')
+        setPaidBy(initialValues?.paid_by || '')
         setComment('')
         setError(null)
         // Don't reset category, currency, date - likely to be reused

--- a/src/pages/QuickHistoryPage.tsx
+++ b/src/pages/QuickHistoryPage.tsx
@@ -89,7 +89,12 @@ export function QuickHistoryPage() {
       ) : (
         <div className="space-y-1">
           {filtered.map(tx => (
-            <TransactionItem key={tx.id} transaction={tx} />
+            <TransactionItem
+              key={tx.id}
+              transaction={tx}
+              defaultCurrency={currentTrip?.default_currency}
+              exchangeRates={currentTrip?.exchange_rates}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Auto-select payer:** Reset `paidBy` to `initialValues?.paid_by` instead of `''` when the quick expense sheet closes and re-opens, so the authenticated user stays pre-selected as payer
- **Dual-currency display:** Transaction history now shows amounts converted to the trip's base currency with the original currency in parentheses (e.g. "€10.00 (฿385.00)") when currencies differ

## Test plan
- [ ] Open quick mode, add expense — payer is pre-selected as current user
- [ ] Close and re-open add expense — payer is still pre-selected
- [ ] View transaction history with multi-currency expenses — base currency shown with original in parentheses
- [ ] Single-currency expenses show no parenthetical

🤖 Generated with [Claude Code](https://claude.com/claude-code)