### PR TITLE
Quick expense UX improvements

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -65,7 +65,7 @@ export function ExpenseForm({
   const [selectedParticipants, setSelectedParticipants] = useState<string[]>([])
   const [selectedFamilies, setSelectedFamilies] = useState<string[]>([])
   const [splitMode, setSplitMode] = useState<SplitMode>('equal')
-  const [accountForFamilySize, setAccountForFamilySize] = useState(false) // Default to false (families as units)
+  const [accountForFamilySize, setAccountForFamilySize] = useState(true)
 
   // Custom split values for percentage/amount modes
   const [participantSplitValues, setParticipantSplitValues] = useState<Record<string, string>>({})
@@ -88,13 +88,16 @@ export function ExpenseForm({
     : null
   const suggestedPayer = balanceCalculation?.suggestedNextPayer
 
-  // Auto-select all participants/families on mount if not editing
+  // Auto-select all participants/families on mount if not editing and trip setting allows it
+  const defaultSplitAll = currentTrip?.default_split_all ?? true
   useEffect(() => {
-    if (!initialValues && participants.length > 0 && selectedParticipants.length === 0) {
-      setSelectedParticipants(participants.map(p => p.id))
-    }
-    if (!initialValues && families.length > 0 && selectedFamilies.length === 0) {
-      setSelectedFamilies(families.map(f => f.id))
+    if (!initialValues?.distribution && defaultSplitAll) {
+      if (participants.length > 0 && selectedParticipants.length === 0) {
+        setSelectedParticipants(participants.map(p => p.id))
+      }
+      if (families.length > 0 && selectedFamilies.length === 0) {
+        setSelectedFamilies(families.map(f => f.id))
+      }
     }
   }, [participants, families])
 

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -109,7 +109,7 @@ function MobileWizard({
     initialValues?.expense_date || new Date().toISOString().split('T')[0]
   )
   const [comment, setComment] = useState(initialValues?.comment || '')
-  const [accountForFamilySize, setAccountForFamilySize] = useState(false)
+  const [accountForFamilySize, setAccountForFamilySize] = useState(true)
 
   const adults = getAdultParticipants()
   const isIndividualsMode = currentTrip?.tracking_mode === 'individuals'
@@ -125,13 +125,16 @@ function MobileWizard({
     : null
   const suggestedPayer = balanceCalculation?.suggestedNextPayer
 
-  // Auto-select all participants/families on mount
+  // Auto-select all participants/families on mount if trip setting allows it
+  const defaultSplitAll = currentTrip?.default_split_all ?? true
   useEffect(() => {
-    if (open && participants.length > 0 && selectedParticipants.length === 0) {
-      setSelectedParticipants(participants.map((p) => p.id))
-    }
-    if (open && families.length > 0 && selectedFamilies.length === 0) {
-      setSelectedFamilies(families.map((f) => f.id))
+    if (open && !initialValues?.distribution && defaultSplitAll) {
+      if (participants.length > 0 && selectedParticipants.length === 0) {
+        setSelectedParticipants(participants.map((p) => p.id))
+      }
+      if (families.length > 0 && selectedFamilies.length === 0) {
+        setSelectedFamilies(families.map((f) => f.id))
+      }
     }
   }, [open, participants, families])
 

--- a/src/components/quick/TransactionItem.tsx
+++ b/src/components/quick/TransactionItem.tsx
@@ -31,6 +31,7 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
           label: 'You paid',
           icon: <DollarSign size={16} className="text-primary" />,
           amountText: formatDualCurrency(tx.roleAmount, tx.currency),
+          subText: tx.myShare !== undefined ? `Your share: ${formatDualCurrency(tx.myShare, tx.currency)}` : null,
           amountClass: 'text-foreground font-semibold',
           bgClass: 'bg-primary/5',
         }
@@ -39,6 +40,7 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
           label: `${tx.payerName} paid`,
           icon: <DollarSign size={16} className="text-muted-foreground" />,
           amountText: `Your share: ${formatDualCurrency(tx.roleAmount, tx.currency)}`,
+          subText: null,
           amountClass: 'text-muted-foreground',
           bgClass: 'bg-muted/30',
         }
@@ -47,6 +49,7 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
           label: `You paid ${tx.recipientName}`,
           icon: <ArrowUpRight size={16} className="text-red-500" />,
           amountText: formatDualCurrency(tx.roleAmount, tx.currency),
+          subText: null,
           amountClass: 'text-red-600 dark:text-red-400 font-semibold',
           bgClass: 'bg-red-50 dark:bg-red-950/20',
         }
@@ -55,6 +58,7 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
           label: `${tx.payerName} paid you`,
           icon: <ArrowDownLeft size={16} className="text-green-500" />,
           amountText: formatDualCurrency(tx.roleAmount, tx.currency),
+          subText: null,
           amountClass: 'text-green-600 dark:text-green-400 font-semibold',
           bgClass: 'bg-green-50 dark:bg-green-950/20',
         }
@@ -82,6 +86,11 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
         <p className={`text-sm tabular-nums ${display.amountClass}`}>
           {display.amountText}
         </p>
+        {display.subText && (
+          <p className="text-xs text-muted-foreground tabular-nums">
+            {display.subText}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -108,14 +108,20 @@ export function ManageTripPage() {
     }
   }
 
-  const handleToggleFeature = async (feature: 'enable_meals' | 'enable_shopping', value: boolean) => {
+  const featureLabels: Record<string, string> = {
+    enable_meals: 'Meal planning',
+    enable_shopping: 'Shopping list',
+    default_split_all: 'Split between everyone',
+  }
+
+  const handleToggleFeature = async (feature: 'enable_meals' | 'enable_shopping' | 'default_split_all', value: boolean) => {
     setIsTogglingFeature(true)
     try {
       const success = await updateTrip(currentTrip.id, { [feature]: value })
       if (success) {
         toast({
           title: 'Feature updated',
-          description: `${feature === 'enable_meals' ? 'Meal planning' : 'Shopping list'} ${value ? 'enabled' : 'disabled'}.`,
+          description: `${featureLabels[feature]} ${value ? 'enabled' : 'disabled'}.`,
         })
       } else {
         toast({
@@ -287,6 +293,17 @@ export function ManageTripPage() {
             <Switch
               checked={currentTrip.enable_shopping}
               onCheckedChange={(checked) => handleToggleFeature('enable_shopping', checked)}
+              disabled={isTogglingFeature}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>Split Between Everyone</Label>
+              <p className="text-xs text-muted-foreground">New expenses default to splitting between all participants</p>
+            </div>
+            <Switch
+              checked={currentTrip.default_split_all ?? true}
+              onCheckedChange={(checked) => handleToggleFeature('default_split_all', checked)}
               disabled={isTogglingFeature}
             />
           </div>

--- a/src/services/transactionHistoryBuilder.ts
+++ b/src/services/transactionHistoryBuilder.ts
@@ -12,6 +12,7 @@ export interface TransactionItem {
   currency: string
   role: 'you_paid' | 'your_share' | 'you_settled' | 'you_received'
   roleAmount: number
+  myShare?: number
   payerName: string | null
   recipientName: string | null
 }
@@ -61,6 +62,7 @@ export function buildTransactionHistory(
         currency: expense.currency,
         role: 'you_paid',
         roleAmount: expense.amount,
+        myShare,
         payerName: null,
         recipientName: null,
       })

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -11,6 +11,7 @@ export interface Trip {
   exchange_rates: Record<string, number>
   enable_meals: boolean
   enable_shopping: boolean
+  default_split_all: boolean
   created_by?: string
   created_at: string
 }
@@ -35,4 +36,5 @@ export interface UpdateTripInput {
   exchange_rates?: Record<string, number>
   enable_meals?: boolean
   enable_shopping?: boolean
+  default_split_all?: boolean
 }

--- a/supabase/migrations/014_trip_split_defaults.sql
+++ b/supabase/migrations/014_trip_split_defaults.sql
@@ -1,0 +1,3 @@
+-- Add default_split_all column to trips table
+-- When true (default), new expenses auto-select all participants/families
+ALTER TABLE trips ADD COLUMN default_split_all BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
## Summary
- Show "Your share: €X" below the total amount for expenses you paid in transaction history
- Default "Account for family size" toggle to ON (proportional splitting by family size)
- Add trip-level "Split Between Everyone" toggle in Manage Trip > Features
- Fix auto-select bug on desktop/tablet where participants weren't pre-selected when QuickExpenseSheet provided initialValues

## Test plan
- [ ] Quick mode → transaction history → expenses you paid show both total and "Your share: €X"
- [ ] Quick mode → expenses others paid still show "Your share: €X" only (unchanged)
- [ ] New expense form → "Account for family size" checkbox is ON by default
- [ ] Manage Trip → Features → "Split Between Everyone" toggle visible, defaults to ON
- [ ] Toggle OFF → new expense form opens with no participants pre-selected
- [ ] Toggle ON → new expense form opens with all participants/families pre-selected
- [ ] Works on both desktop (ExpenseForm) and mobile (MobileWizard)
- [ ] Edit expense → selections restored from saved distribution (not overwritten by auto-select)
- [ ] Run migration `014_trip_split_defaults.sql` on Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)