### PR TITLE
Fix feedback screenshot submission failing on mobile

### DIFF
--- a/supabase/migrations/015_feedback_screenshots_bucket.sql
+++ b/supabase/migrations/015_feedback_screenshots_bucket.sql
@@ -1,0 +1,13 @@
+-- Create a public storage bucket for feedback screenshots
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('feedback-screenshots', 'feedback-screenshots', true);
+
+-- Authenticated users can upload feedback screenshots
+CREATE POLICY "Authenticated users can upload feedback screenshots"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (bucket_id = 'feedback-screenshots');
+
+-- Anyone can view feedback screenshots (needed for GitHub markdown rendering)
+CREATE POLICY "Anyone can view feedback screenshots"
+ON storage.objects FOR SELECT TO public
+USING (bucket_id = 'feedback-screenshots');


### PR DESCRIPTION
## Summary
- Phone screenshots (2-10MB) were embedded as Base64 directly in GitHub issue bodies, exceeding both the Supabase Edge Function payload limit (~2MB) and GitHub Issues API body limit (~65K chars)
- Now compresses images client-side (max 1200px width, JPEG 80% quality) and uploads to a Supabase Storage public bucket, referencing the public URL in the issue body instead
- Adds migration `015` to create the `feedback-screenshots` storage bucket with appropriate RLS policies

## Test plan
- [ ] Submit feedback **without** a screenshot — works as before
- [ ] Submit feedback **with** a large phone screenshot — succeeds, image visible in GitHub issue
- [ ] Verify uploaded images are accessible via public URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)