### PR TITLE
Add onboarding prompts and settlement bank detail hints

### DIFF
--- a/src/components/OnboardingPrompts.tsx
+++ b/src/components/OnboardingPrompts.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { X, LogIn, Landmark } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
+import { SignInButton } from '@/components/auth/SignInButton'
+import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
+import { Button } from '@/components/ui/button'
+
+const LOGIN_DISMISS_KEY = 'split-dismiss-login-prompt'
+const BANK_DETAILS_DISMISS_KEY = 'split-dismiss-bank-details-prompt'
+
+export function OnboardingPrompts() {
+  const { user, userProfile, loading } = useAuth()
+  const [loginDismissed, setLoginDismissed] = useState(
+    () => localStorage.getItem(LOGIN_DISMISS_KEY) === 'true'
+  )
+  const [bankDetailsDismissed, setBankDetailsDismissed] = useState(
+    () => localStorage.getItem(BANK_DETAILS_DISMISS_KEY) === 'true'
+  )
+  const [showBankDialog, setShowBankDialog] = useState(false)
+
+  // Don't render anything while auth is loading to avoid flash
+  if (loading) return null
+
+  // Login prompt for unauthenticated users
+  if (!user && !loginDismissed) {
+    return (
+      <div className="mb-6 p-4 rounded-lg border border-border bg-accent/30 flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <LogIn size={20} className="text-accent mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-foreground mb-1">Sign in for a better experience</p>
+            <p className="text-xs text-muted-foreground mb-3">
+              Quick Mode for faster expense entry, bank details in settlement plans, and link yourself to trips across devices.
+            </p>
+            <SignInButton type="standard" />
+          </div>
+        </div>
+        <button
+          onClick={() => {
+            localStorage.setItem(LOGIN_DISMISS_KEY, 'true')
+            setLoginDismissed(true)
+          }}
+          className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 p-1"
+          aria-label="Dismiss"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    )
+  }
+
+  // Bank details prompt for authenticated users without bank details
+  const hasBankDetails = userProfile?.bank_account_holder || userProfile?.bank_iban
+  if (user && !hasBankDetails && !bankDetailsDismissed) {
+    return (
+      <>
+        <div className="mb-6 p-4 rounded-lg border border-border bg-accent/30 flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <Landmark size={20} className="text-accent mt-0.5 flex-shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-foreground mb-1">Add your bank details</p>
+              <p className="text-xs text-muted-foreground mb-3">
+                Others will see your account info in settlement plans, making it easy to send payments.
+              </p>
+              <Button size="sm" onClick={() => setShowBankDialog(true)}>
+                Add Bank Details
+              </Button>
+            </div>
+          </div>
+          <button
+            onClick={() => {
+              localStorage.setItem(BANK_DETAILS_DISMISS_KEY, 'true')
+              setBankDetailsDismissed(true)
+            }}
+            className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 p-1"
+            aria-label="Dismiss"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <BankDetailsDialog open={showBankDialog} onOpenChange={setShowBankDialog} />
+      </>
+    )
+  }
+
+  return null
+}

--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -13,9 +13,10 @@ interface SettlementPlanProps {
   plan: OptimalSettlementPlan
   onRecordSettlement?: (transaction: SettlementTransaction) => void
   bankDetailsMap?: Record<string, BankDetails>
+  linkedParticipantIds?: Set<string>
 }
 
-export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap }: SettlementPlanProps) {
+export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap, linkedParticipantIds }: SettlementPlanProps) {
   if (plan.transactions.length === 0) {
     return (
       <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
@@ -60,6 +61,7 @@ export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap }: Set
             index={index + 1}
             onRecord={onRecordSettlement ? () => onRecordSettlement(transaction) : undefined}
             bankDetails={bankDetailsMap?.[transaction.toId]}
+            linkedParticipantIds={linkedParticipantIds}
           />
         ))}
       </div>
@@ -73,6 +75,7 @@ interface SettlementTransactionCardProps {
   index: number
   onRecord?: () => void
   bankDetails?: BankDetails
+  linkedParticipantIds?: Set<string>
 }
 
 function SettlementTransactionCard({
@@ -81,6 +84,7 @@ function SettlementTransactionCard({
   index,
   onRecord,
   bankDetails,
+  linkedParticipantIds,
 }: SettlementTransactionCardProps) {
   const formattedAmount = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -133,6 +137,11 @@ function SettlementTransactionCard({
               {bankDetails.holder && <p>Account: {bankDetails.holder}</p>}
               {bankDetails.iban && <p>IBAN: {bankDetails.iban}</p>}
             </div>
+          )}
+          {!bankDetails && linkedParticipantIds?.has(transaction.toId) && (
+            <p className="mt-2 text-xs text-muted-foreground italic">
+              Ask {transaction.toName} to add their bank details
+            </p>
           )}
         </div>
 

--- a/src/components/auth/SignInButton.tsx
+++ b/src/components/auth/SignInButton.tsx
@@ -1,7 +1,11 @@
 import { GoogleLogin } from '@react-oauth/google'
 import { useAuth } from '@/contexts/AuthContext'
 
-export function SignInButton() {
+interface SignInButtonProps {
+  type?: 'icon' | 'standard'
+}
+
+export function SignInButton({ type = 'icon' }: SignInButtonProps) {
   const { signInWithGoogle } = useAuth()
 
   return (
@@ -15,8 +19,8 @@ export function SignInButton() {
         console.error('Google Sign-In failed')
       }}
       size="medium"
-      type="icon"
-      shape="circle"
+      type={type}
+      shape={type === 'icon' ? 'circle' : undefined}
       theme="outline"
     />
   )

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { getMyTrips, removeFromMyTrips, type MyTripEntry } from '@/lib/myTripsStorage'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
+import { OnboardingPrompts } from '@/components/OnboardingPrompts'
 
 export function HomePage() {
   const navigate = useNavigate()
@@ -52,6 +53,8 @@ export function HomePage() {
             Split costs fairly among groups with real-time collaboration
           </p>
         </div>
+
+        <OnboardingPrompts />
 
         {/* Action Buttons */}
         <div className="flex gap-3 mb-8">

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -27,6 +27,7 @@ export function SettlementsPage() {
   const [prefilledNote, setPrefilledNote] = useState<string | undefined>(undefined)
   const customSettlementRef = useRef<HTMLDivElement>(null)
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
+  const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
 
   if (!currentTrip) {
     return (
@@ -71,6 +72,7 @@ export function SettlementsPage() {
 
       // Look up user_ids for these participants
       const recipientParticipants = participants.filter(p => recipientIds.includes(p.id) && p.user_id)
+      setLinkedParticipantIds(new Set(recipientParticipants.map(p => p.id)))
       if (recipientParticipants.length === 0) return
 
       const userIds = recipientParticipants.map(p => p.user_id!).filter(Boolean)
@@ -207,7 +209,7 @@ export function SettlementsPage() {
         {expenses.length > 0 && (
           <Card>
             <CardContent className="pt-6">
-              <SettlementPlan plan={optimalSettlement} onRecordSettlement={handleRecordSettlement} bankDetailsMap={bankDetailsMap} />
+              <SettlementPlan plan={optimalSettlement} onRecordSettlement={handleRecordSettlement} bankDetailsMap={bankDetailsMap} linkedParticipantIds={linkedParticipantIds} />
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary
- **Login prompt card** on home page for unauthenticated users — explains Quick Mode, bank details, and cross-device linking benefits
- **Bank details prompt card** for signed-in users without bank info — opens BankDetailsDialog directly
- **Settlement hint** when a recipient has a linked account but no bank details: "Ask [Name] to add their bank details"
- Both prompt cards are dismissible (localStorage) and show at most one at a time

## Test plan
- [ ] Open app unauthenticated → login prompt card visible on home page, dismissible with X
- [ ] Sign in → login card gone, bank details prompt appears (if no bank details set)
- [ ] Add bank details via prompt → card disappears automatically
- [ ] Dismiss bank details card → stays dismissed on reload (localStorage)
- [ ] Settlements: recipient with account but no bank details → hint shown
- [ ] Settlements: recipient with bank details → IBAN/holder shown as before
- [ ] Settlements: recipient without account → no extra message

🤖 Generated with [Claude Code](https://claude.com/claude-code)