### PR TITLE
Fix dashboard header alignment and quick mode navigation

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState } from 'react'
-import { Lightbulb, Receipt, FileDown } from 'lucide-react'
+import { Lightbulb, Receipt, FileDown, Share2 } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
@@ -59,13 +59,22 @@ export function DashboardPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-start justify-between">
+      <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold text-foreground">Dashboard</h2>
           <p className="text-sm text-muted-foreground mt-1">{currentTrip.name}</p>
         </div>
         <div className="flex gap-2">
-          <ShareTripDialog tripCode={tripCode!} tripName={currentTrip.name} />
+          <ShareTripDialog
+            tripCode={tripCode!}
+            tripName={currentTrip.name}
+            trigger={
+              <Button variant="outline" size="sm" className="gap-2">
+                <Share2 size={16} />
+                Share Trip
+              </Button>
+            }
+          />
           {expenses.length > 0 && (
             <Button onClick={handleExportPDF} variant="outline" size="sm" className="gap-2">
               <FileDown size={16} />

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -15,7 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
   DollarSign, CreditCard, FileText,
-  ExternalLink, Loader2
+  ExternalLink, ArrowLeftRight, Loader2
 } from 'lucide-react'
 
 export function QuickGroupDetailPage() {
@@ -98,6 +98,14 @@ export function QuickGroupDetailPage() {
 
       {/* Bottom actions */}
       <div className="space-y-3">
+        <Button
+          variant="outline"
+          className="w-full gap-2"
+          onClick={() => navigate('/quick')}
+        >
+          <ArrowLeftRight size={16} />
+          My Trips
+        </Button>
         <Button
           variant="outline"
           className="w-full gap-2"


### PR DESCRIPTION
## Summary
- **#66**: Dashboard header buttons now wrap below the title on mobile instead of cramming into one row. Both Share Trip and Export Summary buttons use consistent `size="sm"` styling.
- **#61**: Added a "My Trips" button in quick mode so users can easily navigate to the trip list to create or switch trips.

## Test plan
- [ ] On mobile viewport: Dashboard header buttons wrap below the title
- [ ] On desktop: buttons stay on the same row
- [ ] In Quick Mode on a trip: "My Trips" button visible, navigates to `/quick`
- [ ] Share Trip and Export Summary buttons have matching heights

Closes #66, closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)