### PR TITLE
Fix mobile layout issues (#70, #68, #67)

### DIFF
--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -93,8 +93,8 @@ function SettlementTransactionCard({
 
   return (
     <Card>
-      <div className="p-4 flex items-start justify-between">
-        <div className="flex-1">
+      <div className="p-4 flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
           {/* Step Number */}
           <div className="flex items-center mb-2">
             <span className="flex items-center justify-center w-6 h-6 bg-accent text-accent-foreground text-xs font-bold rounded-full mr-2">
@@ -104,7 +104,7 @@ function SettlementTransactionCard({
           </div>
 
           {/* Transaction Details */}
-          <div className="flex items-center gap-2 text-sm">
+          <div className="flex items-center gap-2 text-sm flex-wrap">
             <div className="flex items-center gap-1">
               <span className="font-medium text-foreground">
                 {transaction.fromName}
@@ -114,7 +114,7 @@ function SettlementTransactionCard({
               )}
             </div>
 
-            <span className="text-muted-foreground">→</span>
+            <span className="text-muted-foreground flex-shrink-0">→</span>
 
             <div className="flex items-center gap-1">
               <span className="font-medium text-foreground">
@@ -150,7 +150,7 @@ function SettlementTransactionCard({
           <Button
             onClick={onRecord}
             size="sm"
-            className="ml-4"
+            className="flex-shrink-0"
           >
             <Check size={14} className="mr-1" />
             Record

--- a/src/components/TopExpensesList.tsx
+++ b/src/components/TopExpensesList.tsx
@@ -62,12 +62,12 @@ export function TopExpensesList({ expenses, participants, limit = 5, currency = 
               key={expense.id}
               className="flex items-start justify-between p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
             >
-              <div className="flex items-center gap-3 flex-1 min-w-0">
+              <div className="flex items-start gap-3 flex-1 min-w-0">
                 <div className="flex-shrink-0 w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center">
                   <span className="text-sm font-bold text-accent">#{index + 1}</span>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="font-semibold text-foreground truncate">
+                  <p className="font-semibold text-foreground">
                     {expense.description}
                   </p>
                   <p className="text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">

--- a/src/components/quick/TransactionItem.tsx
+++ b/src/components/quick/TransactionItem.tsx
@@ -30,7 +30,7 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
         return {
           label: 'You paid',
           icon: <DollarSign size={16} className="text-primary" />,
-          amountText: formatDualCurrency(tx.roleAmount, tx.currency),
+          amountText: `Total: ${formatDualCurrency(tx.roleAmount, tx.currency)}`,
           subText: tx.myShare !== undefined ? `Your share: ${formatDualCurrency(tx.myShare, tx.currency)}` : null,
           amountClass: 'text-foreground font-semibold',
           bgClass: 'bg-primary/5',


### PR DESCRIPTION
## Summary
- **#70**: Fix settlement card "Record" button being cut off on mobile — uses `min-w-0`, `flex-wrap`, `flex-shrink-0`, and `gap` instead of fixed `ml-4` margin
- **#68**: Allow long expense names to wrap naturally in Top Expenses list instead of truncating with ellipsis
- **#67**: Add "Total:" prefix to the bold amount in quick history for `you_paid` expenses so it's clear alongside "Your share:" below

## Test plan
- [ ] On mobile: settlement cards with long names + Family badges show the Record button fully visible
- [ ] On mobile: Top Expenses list wraps long expense descriptions instead of truncating
- [ ] Quick history: expenses you paid show "Total: €X" on the amount line with "Your share: €Y" below

Fixes #70, #68, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)