### PR TITLE
Add activity planner (Day Planner)

### DIFF
--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { Trash2, MapPin, User } from 'lucide-react'
+import { useActivityContext } from '@/contexts/ActivityContext'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import type { Activity } from '@/types/activity'
+import { ActivityForm } from './ActivityForm'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface ActivityCardProps {
+  activity: Activity
+}
+
+export function ActivityCard({ activity }: ActivityCardProps) {
+  const { deleteActivity } = useActivityContext()
+  const { participants } = useParticipantContext()
+  const [showEditForm, setShowEditForm] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
+  const responsiblePerson = activity.responsible_participant_id
+    ? participants.find((p) => p.id === activity.responsible_participant_id)
+    : null
+
+  const handleDelete = async () => {
+    const success = await deleteActivity(activity.id)
+    if (success) {
+      setShowDeleteConfirm(false)
+    }
+  }
+
+  return (
+    <>
+      <motion.div
+        whileHover={{ y: -2 }}
+        transition={{ duration: 0.2 }}
+      >
+        <Card
+          className="p-3 hover:shadow-md transition-shadow cursor-pointer bg-violet-50 dark:bg-violet-950/20 border-violet-200 dark:border-violet-900"
+          onClick={() => setShowEditForm(true)}
+        >
+          <div className="flex items-start justify-between mb-1">
+            <h4 className="font-semibold text-foreground">{activity.title}</h4>
+            <div className="flex items-center gap-1 ml-2" onClick={(e) => e.stopPropagation()}>
+              <Button
+                onClick={() => setShowDeleteConfirm(true)}
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+              >
+                <Trash2 size={14} />
+              </Button>
+            </div>
+          </div>
+
+          {activity.description && (
+            <p className="text-sm text-muted-foreground mb-1">{activity.description}</p>
+          )}
+
+          {activity.location && (
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground mb-1">
+              <MapPin size={14} />
+              <span>{activity.location}</span>
+            </div>
+          )}
+
+          {responsiblePerson && (
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <User size={14} />
+              <span>{responsiblePerson.name}</span>
+            </div>
+          )}
+        </Card>
+      </motion.div>
+
+      {/* Edit Form Dialog */}
+      <Dialog open={showEditForm} onOpenChange={setShowEditForm}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Edit Activity</DialogTitle>
+          </DialogHeader>
+          <ActivityForm
+            activity={activity}
+            date={activity.activity_date}
+            timeSlot={activity.time_slot}
+            onSuccess={() => setShowEditForm(false)}
+            onCancel={() => setShowEditForm(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete Activity?</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete "{activity.title}"?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              onClick={() => setShowDeleteConfirm(false)}
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleDelete}
+              variant="destructive"
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/ActivityForm.tsx
+++ b/src/components/ActivityForm.tsx
@@ -1,0 +1,231 @@
+import { useState, useRef } from 'react'
+import { motion } from 'framer-motion'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useActivityContext } from '@/contexts/ActivityContext'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
+import { useScrollIntoView } from '@/hooks/useScrollIntoView'
+import type { Activity, ActivityTimeSlot, CreateActivityInput, UpdateActivityInput } from '@/types/activity'
+import { TIME_SLOT_LABELS } from '@/types/activity'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { fadeInUp } from '@/lib/animations'
+
+interface ActivityFormProps {
+  activity?: Activity
+  date: string
+  timeSlot: ActivityTimeSlot
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+export function ActivityForm({
+  activity,
+  date,
+  timeSlot,
+  onSuccess,
+  onCancel,
+}: ActivityFormProps) {
+  const { currentTrip } = useCurrentTrip()
+  const { createActivity, updateActivity } = useActivityContext()
+  const participantContext = useParticipantContext()
+
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const formRef = useRef<HTMLFormElement>(null)
+  const keyboard = useKeyboardHeight()
+
+  useScrollIntoView(formRef, {
+    enabled: keyboard.isVisible,
+    offset: 20,
+  })
+
+  const [formData, setFormData] = useState({
+    title: activity?.title || '',
+    description: activity?.description || '',
+    location: activity?.location || '',
+    responsible_participant_id: activity?.responsible_participant_id || 'none',
+  })
+
+  if (!currentTrip) return null
+
+  if (!participantContext || participantContext.loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="text-sm text-muted-foreground">Loading participants...</div>
+      </div>
+    )
+  }
+
+  const { participants } = participantContext
+  const adults = participants.filter((p) => p.is_adult)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!formData.title.trim()) {
+      setError('Please enter an activity title')
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      const responsibleId = formData.responsible_participant_id === 'none'
+        ? undefined
+        : formData.responsible_participant_id || undefined
+
+      if (activity) {
+        const updateData: UpdateActivityInput = {
+          title: formData.title.trim(),
+          description: formData.description.trim() || undefined,
+          location: formData.location.trim() || undefined,
+          responsible_participant_id: responsibleId,
+        }
+
+        const result = await updateActivity(activity.id, updateData)
+        if (result) {
+          onSuccess()
+        } else {
+          setError('Failed to update activity')
+        }
+      } else {
+        const createData: CreateActivityInput = {
+          trip_id: currentTrip.id,
+          activity_date: date,
+          time_slot: timeSlot,
+          title: formData.title.trim(),
+          description: formData.description.trim() || undefined,
+          location: formData.location.trim() || undefined,
+          responsible_participant_id: responsibleId,
+        }
+
+        const result = await createActivity(createData)
+        if (result) {
+          onSuccess()
+        } else {
+          setError('Failed to create activity')
+        }
+      }
+    } catch (error) {
+      console.error('Error saving activity:', error)
+      setError('An error occurred while saving')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <motion.form
+      ref={formRef}
+      onSubmit={handleSubmit}
+      className="space-y-4"
+      variants={fadeInUp}
+      initial="initial"
+      animate="animate"
+    >
+      {error && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm"
+        >
+          {error}
+        </motion.div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="activity-title">Activity Title</Label>
+        <Input
+          type="text"
+          id="activity-title"
+          value={formData.title}
+          onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+          placeholder="e.g., Temple visit, Island hopping"
+          required
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="activity-description">Description (Optional)</Label>
+        <Textarea
+          id="activity-description"
+          value={formData.description}
+          onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+          placeholder="Notes, details, booking info..."
+          rows={3}
+          disabled={submitting}
+          required={false}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="activity-location">Location (Optional)</Label>
+        <Input
+          type="text"
+          id="activity-location"
+          value={formData.location}
+          onChange={(e) => setFormData({ ...formData, location: e.target.value })}
+          placeholder="e.g., Wat Pho, Phi Phi Island"
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="activity-responsible">Responsible Person (Optional)</Label>
+        <Select
+          value={formData.responsible_participant_id}
+          onValueChange={(value) => setFormData({ ...formData, responsible_participant_id: value })}
+          disabled={submitting}
+        >
+          <SelectTrigger id="activity-responsible">
+            <SelectValue placeholder="-- None --" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">-- None --</SelectItem>
+            {adults.map((participant) => (
+              <SelectItem key={participant.id} value={participant.id}>
+                {participant.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {TIME_SLOT_LABELS[timeSlot]} activity
+      </p>
+
+      <div className="flex gap-3 pt-2">
+        <Button
+          type="button"
+          onClick={onCancel}
+          variant="outline"
+          disabled={submitting}
+          className="flex-1"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={submitting}
+          className="flex-1"
+        >
+          {submitting ? 'Saving...' : activity ? 'Update Activity' : 'Add Activity'}
+        </Button>
+      </div>
+    </motion.form>
+  )
+}

--- a/src/components/DayAccordion.tsx
+++ b/src/components/DayAccordion.tsx
@@ -1,12 +1,14 @@
 import { MealWithIngredients, MealType } from '@/types/meal'
+import type { Activity } from '@/types/activity'
 import { DateContext } from '@/lib/dateUtils'
 import { AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion'
 import { DayBanner } from './DayBanner'
-import { MealGrid } from './MealGrid'
+import { TimeSlotGrid } from './TimeSlotGrid'
 
 export interface DayAccordionProps {
   date: string
   meals: MealWithIngredients[]
+  activities?: Activity[]
   dayNumber: number
   context: DateContext
   defaultExpanded?: boolean
@@ -17,9 +19,9 @@ export interface DayAccordionProps {
 export function DayAccordion({
   date,
   meals,
+  activities = [],
   dayNumber,
   context,
-  onAddMeal,
 }: DayAccordionProps) {
   return (
     <AccordionItem value={date} className="border-0 mb-4">
@@ -36,10 +38,10 @@ export function DayAccordion({
 
       <AccordionContent>
         <div className="pt-4">
-          <MealGrid
+          <TimeSlotGrid
             date={date}
             meals={meals}
-            onAddMeal={onAddMeal}
+            activities={activities}
           />
         </div>
       </AccordionContent>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, Link, useLocation } from 'react-router-dom'
 import { useState } from 'react'
 import {
-  Home, DollarSign, CreditCard, UtensilsCrossed,
+  Home, DollarSign, CreditCard, CalendarDays,
   ShoppingCart, BarChart3, Settings2, MoreHorizontal
 } from 'lucide-react'
 import { motion } from 'framer-motion'
@@ -11,6 +11,7 @@ import { ParticipantProvider } from '@/contexts/ParticipantContext'
 import { ExpenseProvider } from '@/contexts/ExpenseContext'
 import { SettlementProvider } from '@/contexts/SettlementContext'
 import { MealProvider } from '@/contexts/MealContext'
+import { ActivityProvider } from '@/contexts/ActivityContext'
 import { ShoppingProvider } from '@/contexts/ShoppingContext'
 import { Toaster } from '@/components/ui/toaster'
 import { getTripGradientPattern } from '@/services/tripGradientService'
@@ -34,7 +35,7 @@ const iconMap = {
   'Manage Trip': Settings2,
   'Expenses': DollarSign,
   'Settlements': CreditCard,
-  'Meals': UtensilsCrossed,
+  'Day Planner': CalendarDays,
   'Shopping': ShoppingCart,
   'Dashboard': BarChart3,
   'More': MoreHorizontal,
@@ -59,7 +60,7 @@ export function Layout() {
         { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
       )
       if (currentTrip?.enable_meals) {
-        items.push({ path: `/t/${tripCode}/meals`, label: 'Meals', requiresTrip: true })
+        items.push({ path: `/t/${tripCode}/planner`, label: 'Day Planner', requiresTrip: true })
       }
       if (currentTrip?.enable_shopping) {
         items.push({ path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true })
@@ -85,7 +86,7 @@ export function Layout() {
       { path: `/t/${tripCode}/expenses`, label: 'Expenses', requiresTrip: true },
     ]
     if (currentTrip?.enable_meals) {
-      items.push({ path: `/t/${tripCode}/meals`, label: 'Meals', requiresTrip: true })
+      items.push({ path: `/t/${tripCode}/planner`, label: 'Day Planner', requiresTrip: true })
     }
     if (currentTrip?.enable_shopping) {
       items.push({ path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true })
@@ -184,9 +185,11 @@ export function Layout() {
           <ExpenseProvider>
             <SettlementProvider>
               <MealProvider>
-                <ShoppingProvider>
-                  <Outlet />
-                </ShoppingProvider>
+                <ActivityProvider>
+                  <ShoppingProvider>
+                    <Outlet />
+                  </ShoppingProvider>
+                </ActivityProvider>
               </MealProvider>
             </SettlementProvider>
           </ExpenseProvider>

--- a/src/components/TimeSlotGrid.tsx
+++ b/src/components/TimeSlotGrid.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react'
+import { Sunrise, Sun, Moon, Plus } from 'lucide-react'
+import { MealWithIngredients, MealType, MEAL_TYPE_LABELS } from '@/types/meal'
+import type { Activity, ActivityTimeSlot } from '@/types/activity'
+import { TIME_SLOT_LABELS } from '@/types/activity'
+import { MealCard } from './MealCard'
+import { MealForm } from './MealForm'
+import { ActivityCard } from './ActivityCard'
+import { ActivityForm } from './ActivityForm'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Card } from '@/components/ui/card'
+
+export interface TimeSlotGridProps {
+  date: string
+  meals: MealWithIngredients[]
+  activities: Activity[]
+}
+
+// Mapping between time slots and meal types
+const TIME_SLOT_TO_MEAL: Record<ActivityTimeSlot, MealType> = {
+  morning: 'breakfast',
+  afternoon: 'lunch',
+  evening: 'dinner',
+}
+
+// Icons for time slots (reuse meal icons)
+const TIME_SLOT_ICONS = {
+  morning: Sunrise,
+  afternoon: Sun,
+  evening: Moon,
+}
+
+// Color classes for time slots (reuse meal colors)
+const TIME_SLOT_COLORS = {
+  morning: 'text-gold',
+  afternoon: 'text-primary',
+  evening: 'text-secondary',
+}
+
+// Background/border for time slot headers (reuse meal header styles)
+const TIME_SLOT_HEADER_BG = {
+  morning: 'bg-gold/10 border-gold/20',
+  afternoon: 'bg-primary/10 border-primary/20',
+  evening: 'bg-secondary/10 border-secondary/20',
+}
+
+const TIME_SLOTS: ActivityTimeSlot[] = ['morning', 'afternoon', 'evening']
+
+export function TimeSlotGrid({ date, meals, activities }: TimeSlotGridProps) {
+  const [showAddMealForm, setShowAddMealForm] = useState(false)
+  const [selectedMealType, setSelectedMealType] = useState<MealType | null>(null)
+  const [showAddActivityForm, setShowAddActivityForm] = useState(false)
+  const [selectedTimeSlot, setSelectedTimeSlot] = useState<ActivityTimeSlot | null>(null)
+
+  const getMealForSlot = (mealType: MealType): MealWithIngredients | undefined => {
+    return meals.find((m) => m.meal_type === mealType)
+  }
+
+  const getActivitiesForSlot = (timeSlot: ActivityTimeSlot): Activity[] => {
+    return activities.filter((a) => a.time_slot === timeSlot)
+  }
+
+  const formatDialogDate = (dateStr: string): string => {
+    const d = new Date(dateStr)
+    return d.toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
+
+  const handleAddMeal = (mealType: MealType) => {
+    setSelectedMealType(mealType)
+    setShowAddMealForm(true)
+  }
+
+  const handleAddActivity = (timeSlot: ActivityTimeSlot) => {
+    setSelectedTimeSlot(timeSlot)
+    setShowAddActivityForm(true)
+  }
+
+  const renderTimeSlotSection = (timeSlot: ActivityTimeSlot) => {
+    const mealType = TIME_SLOT_TO_MEAL[timeSlot]
+    const meal = getMealForSlot(mealType)
+    const slotActivities = getActivitiesForSlot(timeSlot)
+    const Icon = TIME_SLOT_ICONS[timeSlot]
+    const colorClass = TIME_SLOT_COLORS[timeSlot]
+    const headerBgClass = TIME_SLOT_HEADER_BG[timeSlot]
+
+    return (
+      <Card key={timeSlot} className="overflow-hidden border-2">
+        {/* Time Slot Header */}
+        <div className={`${headerBgClass} px-4 py-3 border-b-2 border-current`}>
+          <div className="flex items-center gap-2">
+            <Icon size={24} className={colorClass} />
+            <span className="text-base font-semibold">{TIME_SLOT_LABELS[timeSlot]}</span>
+          </div>
+        </div>
+
+        {/* Content: Activities (left) + Meal (right) — side-by-side on desktop, stacked on mobile */}
+        <div className="p-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* Activities Column */}
+            <div className="space-y-2">
+              <h5 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Activities</h5>
+              {slotActivities.length > 0 ? (
+                <div className="space-y-2">
+                  {slotActivities.map((activity) => (
+                    <ActivityCard key={activity.id} activity={activity} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground italic mb-2">No activities</p>
+              )}
+              <Button
+                onClick={() => handleAddActivity(timeSlot)}
+                variant="outline"
+                size="sm"
+                className="gap-2 w-full"
+              >
+                <Plus size={14} />
+                Add Activity
+              </Button>
+            </div>
+
+            {/* Meal Column */}
+            <div>
+              <h5 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">{MEAL_TYPE_LABELS[mealType]}</h5>
+              {meal ? (
+                <MealCard meal={meal} />
+              ) : (
+                <div className="flex flex-col items-center justify-center text-center py-6">
+                  <Icon size={32} className={`${colorClass} opacity-20 mb-2`} />
+                  <p className="text-sm text-muted-foreground mb-3">No meal planned</p>
+                  <Button
+                    onClick={() => handleAddMeal(mealType)}
+                    variant="outline"
+                    size="sm"
+                    className="gap-2"
+                  >
+                    <Plus size={14} />
+                    Add {MEAL_TYPE_LABELS[mealType]}
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <div className="space-y-6">
+        {TIME_SLOTS.map((timeSlot) => renderTimeSlotSection(timeSlot))}
+      </div>
+
+      {/* Add Meal Form Dialog */}
+      <Dialog open={showAddMealForm} onOpenChange={setShowAddMealForm}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              Add {selectedMealType ? MEAL_TYPE_LABELS[selectedMealType] : 'Meal'} - {formatDialogDate(date)}
+            </DialogTitle>
+          </DialogHeader>
+          <MealForm
+            initialDate={date}
+            initialMealType={selectedMealType || undefined}
+            onSuccess={() => setShowAddMealForm(false)}
+            onCancel={() => setShowAddMealForm(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Add Activity Form Dialog */}
+      <Dialog open={showAddActivityForm} onOpenChange={setShowAddActivityForm}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              Add Activity - {selectedTimeSlot ? TIME_SLOT_LABELS[selectedTimeSlot] : ''} - {formatDialogDate(date)}
+            </DialogTitle>
+          </DialogHeader>
+          {selectedTimeSlot && (
+            <ActivityForm
+              date={date}
+              timeSlot={selectedTimeSlot}
+              onSuccess={() => setShowAddActivityForm(false)}
+              onCancel={() => setShowAddActivityForm(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/contexts/ActivityContext.tsx
+++ b/src/contexts/ActivityContext.tsx
@@ -1,0 +1,172 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useTripContext } from './TripContext'
+import type { Activity, CreateActivityInput, UpdateActivityInput } from '@/types/activity'
+
+interface ActivityContextValue {
+  activities: Activity[]
+  loading: boolean
+  createActivity: (input: CreateActivityInput) => Promise<Activity | null>
+  updateActivity: (id: string, input: UpdateActivityInput) => Promise<Activity | null>
+  deleteActivity: (id: string) => Promise<boolean>
+  getActivityById: (id: string) => Activity | undefined
+  getActivitiesForDate: (date: string) => Activity[]
+  refreshActivities: () => Promise<void>
+}
+
+const ActivityContext = createContext<ActivityContextValue | undefined>(undefined)
+
+const TIME_SLOT_ORDER = { morning: 0, afternoon: 1, evening: 2 }
+
+function sortActivities(a: Activity, b: Activity): number {
+  const dateCompare = a.activity_date.localeCompare(b.activity_date)
+  if (dateCompare !== 0) return dateCompare
+  return (TIME_SLOT_ORDER[a.time_slot] ?? 0) - (TIME_SLOT_ORDER[b.time_slot] ?? 0)
+}
+
+export function ActivityProvider({ children }: { children: ReactNode }) {
+  const [activities, setActivities] = useState<Activity[]>([])
+  const [loading, setLoading] = useState(true)
+  const { currentTrip, tripCode } = useCurrentTrip()
+  const { trips } = useTripContext()
+
+  const fetchActivities = async () => {
+    if (!currentTrip) {
+      setActivities([])
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    try {
+      const { data, error } = await (supabase
+        .from('activities' as any) as any)
+        .select('*')
+        .eq('trip_id', currentTrip.id)
+        .order('activity_date', { ascending: true })
+
+      if (error) {
+        console.error('Error fetching activities:', error)
+        setActivities([])
+      } else {
+        setActivities(((data as Activity[]) || []).sort(sortActivities))
+      }
+    } catch (error) {
+      console.error('Error fetching activities:', error)
+      setActivities([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const refreshActivities = async () => {
+    await fetchActivities()
+  }
+
+  useEffect(() => {
+    if (tripCode && currentTrip) {
+      fetchActivities()
+    } else {
+      setActivities([])
+      setLoading(false)
+    }
+  }, [tripCode, currentTrip?.id, trips.length])
+
+  const createActivity = async (input: CreateActivityInput): Promise<Activity | null> => {
+    try {
+      const { data, error } = await (supabase
+        .from('activities' as any) as any)
+        .insert([input])
+        .select()
+        .single()
+
+      if (error) {
+        console.error('Error creating activity:', error)
+        return null
+      }
+
+      setActivities((prev) => [...prev, data as Activity].sort(sortActivities))
+      return data as Activity
+    } catch (error) {
+      console.error('Error creating activity:', error)
+      return null
+    }
+  }
+
+  const updateActivity = async (
+    id: string,
+    input: UpdateActivityInput
+  ): Promise<Activity | null> => {
+    try {
+      const { data, error } = await (supabase
+        .from('activities' as any) as any)
+        .update({ ...input, updated_at: new Date().toISOString() })
+        .eq('id', id)
+        .select()
+        .single()
+
+      if (error) {
+        console.error('Error updating activity:', error)
+        return null
+      }
+
+      setActivities((prev) =>
+        prev
+          .map((activity) => (activity.id === id ? data : activity))
+          .sort(sortActivities)
+      )
+
+      return data
+    } catch (error) {
+      console.error('Error updating activity:', error)
+      return null
+    }
+  }
+
+  const deleteActivity = async (id: string): Promise<boolean> => {
+    try {
+      const { error } = await (supabase.from('activities' as any) as any).delete().eq('id', id)
+
+      if (error) {
+        console.error('Error deleting activity:', error)
+        return false
+      }
+
+      setActivities((prev) => prev.filter((activity) => activity.id !== id))
+      return true
+    } catch (error) {
+      console.error('Error deleting activity:', error)
+      return false
+    }
+  }
+
+  const getActivityById = (id: string): Activity | undefined => {
+    return activities.find((activity) => activity.id === id)
+  }
+
+  const getActivitiesForDate = (date: string): Activity[] => {
+    return activities.filter((activity) => activity.activity_date === date)
+  }
+
+  const value: ActivityContextValue = {
+    activities,
+    loading,
+    createActivity,
+    updateActivity,
+    deleteActivity,
+    getActivityById,
+    getActivitiesForDate,
+    refreshActivities,
+  }
+
+  return <ActivityContext.Provider value={value}>{children}</ActivityContext.Provider>
+}
+
+export function useActivityContext() {
+  const context = useContext(ActivityContext)
+  if (context === undefined) {
+    throw new Error('useActivityContext must be used within an ActivityProvider')
+  }
+  return context
+}

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from 'react'
+import { CalendarDays, ChevronsDown, ChevronsUp } from 'lucide-react'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useMealContext } from '@/contexts/MealContext'
+import { useActivityContext } from '@/contexts/ActivityContext'
+import type { MealWithIngredients } from '@/types/meal'
+import { DayAccordion } from '@/components/DayAccordion'
+import { Accordion } from '@/components/ui/accordion'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { generateDateRange, getDayContext, getDayNumber } from '@/lib/dateUtils'
+
+export function PlannerPage() {
+  const { currentTrip } = useCurrentTrip()
+  const { meals, loading: mealsLoading, getMealsWithIngredients } = useMealContext()
+  const { loading: activitiesLoading, getActivitiesForDate } = useActivityContext()
+  const [mealsWithIngredients, setMealsWithIngredients] = useState<MealWithIngredients[]>([])
+  const [expandedDays, setExpandedDays] = useState<string[]>([])
+  const [allExpanded, setAllExpanded] = useState(false)
+
+  const loading = mealsLoading || activitiesLoading
+
+  useEffect(() => {
+    const loadMealsWithIngredients = async () => {
+      const data = await getMealsWithIngredients()
+      setMealsWithIngredients(data)
+    }
+
+    if (meals.length > 0) {
+      loadMealsWithIngredients()
+    } else {
+      setMealsWithIngredients([])
+    }
+  }, [meals])
+
+  // Set default expanded day (only when trip is active)
+  useEffect(() => {
+    if (!currentTrip) return
+
+    const tripDates = generateDateRange(currentTrip.start_date, currentTrip.end_date)
+    const todayDate = new Date().toISOString().split('T')[0]
+
+    if (tripDates.includes(todayDate)) {
+      setExpandedDays([todayDate])
+    } else {
+      setExpandedDays([])
+    }
+  }, [currentTrip])
+
+  if (!currentTrip) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-2xl font-bold text-foreground">Day Planner</h2>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-muted-foreground">
+              No trip selected. Please select a trip to start planning.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const tripDates = currentTrip ? generateDateRange(currentTrip.start_date, currentTrip.end_date) : []
+
+  const getMealsForDate = (date: string): MealWithIngredients[] => {
+    return mealsWithIngredients.filter((meal) => meal.meal_date === date)
+  }
+
+  const handleToggleAll = () => {
+    if (allExpanded) {
+      setExpandedDays([])
+      setAllExpanded(false)
+    } else {
+      setExpandedDays(tripDates)
+      setAllExpanded(true)
+    }
+  }
+
+  const handleAccordionChange = (value: string[]) => {
+    setExpandedDays(value)
+    setAllExpanded(value.length === tripDates.length)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">Day Planner</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            {currentTrip.name} &bull; {tripDates.length} days
+          </p>
+        </div>
+
+        {!loading && tripDates.length > 0 && (
+          <Button
+            onClick={handleToggleAll}
+            variant="outline"
+            size="sm"
+            className="gap-2"
+          >
+            {allExpanded ? (
+              <>
+                <ChevronsUp size={16} />
+                Collapse All
+              </>
+            ) : (
+              <>
+                <ChevronsDown size={16} />
+                Expand All
+              </>
+            )}
+          </Button>
+        )}
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-muted-foreground text-center py-8">Loading planner...</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Accordion Day Planner Calendar */}
+      {!loading && tripDates.length > 0 && (
+        <Accordion
+          type="multiple"
+          value={expandedDays}
+          onValueChange={handleAccordionChange}
+          className="space-y-4"
+        >
+          {tripDates.map((date) => {
+            const mealsForDate = getMealsForDate(date)
+            const activitiesForDate = getActivitiesForDate(date)
+            const dayNumber = getDayNumber(date, currentTrip.start_date)
+            const context = getDayContext(date)
+
+            return (
+              <DayAccordion
+                key={date}
+                date={date}
+                meals={mealsForDate}
+                activities={activitiesForDate}
+                dayNumber={dayNumber}
+                context={context}
+                tripStartDate={currentTrip.start_date}
+                onAddMeal={() => {
+                  // Handled within TimeSlotGrid component
+                }}
+              />
+            )
+          })}
+        </Accordion>
+      )}
+
+      {/* Empty State */}
+      {!loading && tripDates.length === 0 && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center py-8">
+              <CalendarDays size={48} className="mx-auto text-muted-foreground/50 mb-4" />
+              <p className="text-lg font-medium text-foreground mb-2">
+                No days planned yet
+              </p>
+              <p className="text-sm text-muted-foreground mb-4">
+                Start planning activities and meals for your trip by expanding a day
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,7 +6,7 @@ import { ConditionalHomePage } from './pages/ConditionalHomePage'
 import { TripsPage } from './pages/TripsPage'
 import { ManageTripPage } from './pages/ManageTripPage'
 import { ExpensesPage } from './pages/ExpensesPage'
-import { MealsPage } from './pages/MealsPage'
+import { PlannerPage } from './pages/PlannerPage'
 import { ShoppingPage } from './pages/ShoppingPage'
 import { DashboardPage } from './pages/DashboardPage'
 import { SettlementsPage } from './pages/SettlementsPage'
@@ -48,7 +48,8 @@ export function AppRoutes() {
         <Route path="t/:tripCode/manage" element={<TripRouteGuard><ManageTripPage /></TripRouteGuard>} />
         <Route path="t/:tripCode/expenses" element={<TripRouteGuard><ExpensesPage /></TripRouteGuard>} />
         <Route path="t/:tripCode/settlements" element={<TripRouteGuard><SettlementsPage /></TripRouteGuard>} />
-        <Route path="t/:tripCode/meals" element={<TripRouteGuard><MealsPage /></TripRouteGuard>} />
+        <Route path="t/:tripCode/planner" element={<TripRouteGuard><PlannerPage /></TripRouteGuard>} />
+        <Route path="t/:tripCode/meals" element={<Navigate to="../planner" replace />} />
         <Route path="t/:tripCode/shopping" element={<TripRouteGuard><ShoppingPage /></TripRouteGuard>} />
         <Route path="t/:tripCode/dashboard" element={<TripRouteGuard><DashboardPage /></TripRouteGuard>} />
       </Route>

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,0 +1,37 @@
+export type ActivityTimeSlot = 'morning' | 'afternoon' | 'evening'
+
+export interface Activity {
+  id: string
+  trip_id: string
+  activity_date: string // YYYY-MM-DD
+  time_slot: ActivityTimeSlot
+  title: string
+  description?: string | null
+  location?: string | null
+  responsible_participant_id?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateActivityInput {
+  trip_id: string
+  activity_date: string
+  time_slot: ActivityTimeSlot
+  title: string
+  description?: string
+  location?: string
+  responsible_participant_id?: string
+}
+
+export interface UpdateActivityInput {
+  title?: string
+  description?: string
+  location?: string
+  responsible_participant_id?: string
+}
+
+export const TIME_SLOT_LABELS: Record<ActivityTimeSlot, string> = {
+  morning: 'Morning',
+  afternoon: 'Afternoon',
+  evening: 'Evening',
+}

--- a/supabase/migrations/016_activities.sql
+++ b/supabase/migrations/016_activities.sql
@@ -1,0 +1,21 @@
+-- Activity planner table
+CREATE TABLE activities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+  activity_date DATE NOT NULL,
+  time_slot TEXT NOT NULL CHECK (time_slot IN ('morning', 'afternoon', 'evening')),
+  title TEXT NOT NULL,
+  description TEXT,
+  location TEXT,
+  responsible_participant_id UUID REFERENCES participants(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_activities_trip_id ON activities(trip_id);
+CREATE INDEX idx_activities_date ON activities(activity_date);
+
+-- No UNIQUE constraint on (trip_id, activity_date, time_slot) — multiple activities per slot allowed
+
+ALTER TABLE activities ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all operations on activities" ON activities FOR ALL USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Adds activity planning alongside meals in a new **Day Planner** view with Morning/Afternoon/Evening time blocks
- Activities and meals display side-by-side per time block (stacked on mobile)
- Multiple activities per time slot, one meal per slot (breakfast/lunch/dinner mapped to morning/afternoon/evening)
- Renames Meals nav to "Day Planner" with CalendarDays icon; old `/meals` URL redirects to `/planner`
- New DB migration `016_activities.sql` (already applied)

## Test plan
- [ ] Navigate to Day Planner page — time-of-day sections with activity + meal columns render
- [ ] Create/edit/delete activities in each time slot
- [ ] Multiple activities per slot work correctly
- [ ] Existing meals still display and function as before
- [ ] Mobile: activities and meals stack vertically per time block
- [ ] Desktop: side-by-side layout
- [ ] Old `/meals` URL redirects to `/planner`
- [ ] Nav shows "Day Planner" with calendar icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)