### PR TITLE
Fix mobile issues: planner grid overlap, stays save, expense truncation

### DIFF
--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -117,7 +117,7 @@ export function ExpenseCard({ expense, onEdit, onDelete }: ExpenseCardProps) {
             <div className="flex items-start gap-3">
               <div className="mt-1">{getCategoryIcon(expense.category)}</div>
               <div className="flex-1 min-w-0 space-y-2">
-                <h3 className="text-base font-semibold text-foreground truncate">
+                <h3 className="text-base font-semibold text-foreground break-words">
                   {expense.description}
                 </h3>
 

--- a/src/components/PlannerGrid.tsx
+++ b/src/components/PlannerGrid.tsx
@@ -111,7 +111,7 @@ export function PlannerGrid({
         <div className="px-4 pb-4 overflow-x-auto">
           <div className="flex gap-3">
             {groups.map((group, groupIdx) => (
-              <div key={groupIdx} className="flex flex-col gap-1 min-w-0">
+              <div key={groupIdx} className="flex flex-col gap-1 shrink-0">
                 {/* Stay label */}
                 {group.stayName && (
                   <div className="flex items-center gap-1 px-1 mb-1">
@@ -138,7 +138,7 @@ export function PlannerGrid({
                         onClick={() => onDayClick(date)}
                         className={cn(
                           'flex flex-col items-center justify-center rounded-lg border px-2 py-1.5 transition-colors',
-                          'w-12 h-16 md:w-14 md:h-[72px]',
+                          'w-12 h-16 md:w-14 md:h-[72px] shrink-0',
                           'hover:bg-accent/50 cursor-pointer',
                           context === 'today' && 'ring-2 ring-primary bg-primary/5',
                           context === 'past' && 'opacity-60'

--- a/src/contexts/StayContext.tsx
+++ b/src/contexts/StayContext.tsx
@@ -71,15 +71,15 @@ export function StayProvider({ children }: { children: ReactNode }) {
         .from('stays' as any) as any)
         .insert([input])
         .select()
-        .single()
 
-      if (error) {
+      if (error || !data?.[0]) {
         console.error('Error creating stay:', error)
         return null
       }
 
-      setStays((prev) => [...prev, data as Stay].sort((a, b) => a.check_in_date.localeCompare(b.check_in_date)))
-      return data as Stay
+      const stay = data[0] as Stay
+      setStays((prev) => [...prev, stay].sort((a, b) => a.check_in_date.localeCompare(b.check_in_date)))
+      return stay
     } catch (error) {
       console.error('Error creating stay:', error)
       return null
@@ -96,20 +96,20 @@ export function StayProvider({ children }: { children: ReactNode }) {
         .update({ ...input, updated_at: new Date().toISOString() })
         .eq('id', id)
         .select()
-        .single()
 
-      if (error) {
+      if (error || !data?.[0]) {
         console.error('Error updating stay:', error)
         return null
       }
 
+      const updated = data[0] as Stay
       setStays((prev) =>
         prev
-          .map((stay) => (stay.id === id ? data : stay))
+          .map((stay) => (stay.id === id ? updated : stay))
           .sort((a, b) => a.check_in_date.localeCompare(b.check_in_date))
       )
 
-      return data
+      return updated
     } catch (error) {
       console.error('Error updating stay:', error)
       return null


### PR DESCRIPTION
## Summary
- **Fix #77:** Add `shrink-0` to PlannerGrid day cells and group containers so they maintain their width and scroll horizontally instead of overlapping on narrow screens
- **Fix #75:** Remove `.single()` from StayContext create/update to prevent Supabase throwing exceptions that leave the "Add" form stuck on "Saving..."
- **Fix #72:** Replace `truncate` with `break-words` on ExpenseCard description so long expense names wrap naturally instead of being cut off with ellipsis

## Test plan
- [ ] On mobile (iPhone Safari), verify PlannerGrid day cells don't overlap — grid scrolls horizontally
- [ ] Add a new accommodation and confirm it saves without getting stuck on "Saving..."
- [ ] Edit an existing accommodation and confirm it updates successfully
- [ ] Add an expense with a long name and verify it wraps to multiple lines instead of truncating

🤖 Generated with [Claude Code](https://claude.com/claude-code)