### PR TITLE
Redesign planner grid as primary view with bottom sheet

### DIFF
--- a/src/components/DayDetailSheet.tsx
+++ b/src/components/DayDetailSheet.tsx
@@ -1,0 +1,85 @@
+import { Building2 } from 'lucide-react'
+import { getDayNumber, getDayContext } from '@/lib/dateUtils'
+import { Badge } from '@/components/ui/badge'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+import { TimeSlotGrid } from './TimeSlotGrid'
+import type { MealWithIngredients } from '@/types/meal'
+import type { Activity } from '@/types/activity'
+
+interface DayDetailSheetProps {
+  date: string | null
+  onOpenChange: (open: boolean) => void
+  meals: MealWithIngredients[]
+  activities: Activity[]
+  tripStartDate: string
+  stayName?: string
+}
+
+function formatSheetDate(date: string): string {
+  const d = new Date(date + 'T00:00:00')
+  return d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+const CONTEXT_STYLES = {
+  today: 'bg-positive/10 border-positive/30 text-positive-dark',
+  tomorrow: 'bg-accent/10 border-accent/30 text-accent',
+  past: 'bg-muted border-border text-muted-foreground',
+  future: 'bg-card border-border text-foreground',
+}
+
+export function DayDetailSheet({
+  date,
+  onOpenChange,
+  meals,
+  activities,
+  tripStartDate,
+  stayName,
+}: DayDetailSheetProps) {
+  if (!date) return null
+
+  const dayNumber = getDayNumber(date, tripStartDate)
+  const context = getDayContext(date)
+
+  return (
+    <Sheet open={!!date} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[85vh] overflow-y-auto">
+        <SheetHeader className="mb-4">
+          <SheetTitle className="text-left">
+            {formatSheetDate(date)}
+          </SheetTitle>
+          <SheetDescription asChild>
+            <div className="flex items-center gap-2 flex-wrap">
+              <Badge variant="outline" className="bg-primary/10 border-primary/30 text-primary font-bold">
+                Day {dayNumber}
+              </Badge>
+              <Badge
+                variant="outline"
+                className={`${CONTEXT_STYLES[context]} capitalize`}
+              >
+                {context}
+              </Badge>
+              {stayName && (
+                <Badge variant="outline" className="gap-1">
+                  <Building2 size={12} />
+                  {stayName}
+                </Badge>
+              )}
+            </div>
+          </SheetDescription>
+        </SheetHeader>
+
+        <TimeSlotGrid date={date} meals={meals} activities={activities} />
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,16 +1,14 @@
-import { useState, useEffect, useRef } from 'react'
-import { CalendarDays, ChevronsDown, ChevronsUp } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { CalendarDays } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMealContext } from '@/contexts/MealContext'
 import { useActivityContext } from '@/contexts/ActivityContext'
 import { useStayContext } from '@/contexts/StayContext'
 import type { MealWithIngredients } from '@/types/meal'
-import { DayAccordion } from '@/components/DayAccordion'
-import { Accordion } from '@/components/ui/accordion'
 import { PlannerGrid } from '@/components/PlannerGrid'
-import { Button } from '@/components/ui/button'
+import { DayDetailSheet } from '@/components/DayDetailSheet'
 import { Card, CardContent } from '@/components/ui/card'
-import { generateDateRange, getDayContext, getDayNumber } from '@/lib/dateUtils'
+import { generateDateRange } from '@/lib/dateUtils'
 
 export function PlannerPage() {
   const { currentTrip } = useCurrentTrip()
@@ -18,9 +16,7 @@ export function PlannerPage() {
   const { loading: activitiesLoading, getActivitiesForDate } = useActivityContext()
   const { loading: staysLoading, getStayForDate } = useStayContext()
   const [mealsWithIngredients, setMealsWithIngredients] = useState<MealWithIngredients[]>([])
-  const [expandedDays, setExpandedDays] = useState<string[]>([])
-  const [allExpanded, setAllExpanded] = useState(false)
-  const dayRefs = useRef<Record<string, HTMLDivElement | null>>({})
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
 
   const loading = mealsLoading || activitiesLoading || staysLoading
 
@@ -37,20 +33,6 @@ export function PlannerPage() {
     }
   }, [meals])
 
-  // Set default expanded day (only when trip is active)
-  useEffect(() => {
-    if (!currentTrip) return
-
-    const tripDates = generateDateRange(currentTrip.start_date, currentTrip.end_date)
-    const todayDate = new Date().toISOString().split('T')[0]
-
-    if (tripDates.includes(todayDate)) {
-      setExpandedDays([todayDate])
-    } else {
-      setExpandedDays([])
-    }
-  }, [currentTrip])
-
   if (!currentTrip) {
     return (
       <div className="space-y-4">
@@ -66,65 +48,28 @@ export function PlannerPage() {
     )
   }
 
-  const tripDates = currentTrip ? generateDateRange(currentTrip.start_date, currentTrip.end_date) : []
+  const tripDates = generateDateRange(currentTrip.start_date, currentTrip.end_date)
 
   const getMealsForDate = (date: string): MealWithIngredients[] => {
     return mealsWithIngredients.filter((meal) => meal.meal_date === date)
   }
 
-  const handleToggleAll = () => {
-    if (allExpanded) {
-      setExpandedDays([])
-      setAllExpanded(false)
-    } else {
-      setExpandedDays(tripDates)
-      setAllExpanded(true)
-    }
-  }
-
-  const handleAccordionChange = (value: string[]) => {
-    setExpandedDays(value)
-    setAllExpanded(value.length === tripDates.length)
-  }
-
   const handleGridDayClick = (date: string) => {
-    setExpandedDays(prev => prev.includes(date) ? prev : [...prev, date])
-    setTimeout(() => {
-      dayRefs.current[date]?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }, 250)
+    setSelectedDate(date)
   }
+
+  const selectedMeals = selectedDate ? getMealsForDate(selectedDate) : []
+  const selectedActivities = selectedDate ? getActivitiesForDate(selectedDate) : []
+  const selectedStay = selectedDate ? getStayForDate(selectedDate) : undefined
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold text-foreground">Day Planner</h2>
-          <p className="text-sm text-muted-foreground mt-1">
-            {currentTrip.name} &bull; {tripDates.length} days
-          </p>
-        </div>
-
-        {!loading && tripDates.length > 0 && (
-          <Button
-            onClick={handleToggleAll}
-            variant="outline"
-            size="sm"
-            className="gap-2"
-          >
-            {allExpanded ? (
-              <>
-                <ChevronsUp size={16} />
-                Collapse All
-              </>
-            ) : (
-              <>
-                <ChevronsDown size={16} />
-                Expand All
-              </>
-            )}
-          </Button>
-        )}
+      <div>
+        <h2 className="text-2xl font-bold text-foreground">Day Planner</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          {currentTrip.name} &bull; {tripDates.length} days
+        </p>
       </div>
 
       {/* Loading State */}
@@ -136,50 +81,26 @@ export function PlannerPage() {
         </Card>
       )}
 
-      {/* Grid Overview + Accordion Day Planner Calendar */}
+      {/* Grid Overview */}
       {!loading && tripDates.length > 0 && (
-        <>
-          <PlannerGrid
-            tripDates={tripDates}
-            tripStartDate={currentTrip.start_date}
-            getMealsForDate={getMealsForDate}
-            getActivitiesForDate={getActivitiesForDate}
-            getStayForDate={getStayForDate}
-            onDayClick={handleGridDayClick}
-          />
-          <Accordion
-            type="multiple"
-            value={expandedDays}
-            onValueChange={handleAccordionChange}
-            className="space-y-4"
-          >
-            {tripDates.map((date) => {
-              const mealsForDate = getMealsForDate(date)
-              const activitiesForDate = getActivitiesForDate(date)
-              const dayNumber = getDayNumber(date, currentTrip.start_date)
-              const context = getDayContext(date)
-              const stay = getStayForDate(date)
-
-              return (
-                <div key={date} ref={el => { dayRefs.current[date] = el }} className="scroll-mt-24">
-                  <DayAccordion
-                    date={date}
-                    meals={mealsForDate}
-                    activities={activitiesForDate}
-                    dayNumber={dayNumber}
-                    context={context}
-                    tripStartDate={currentTrip.start_date}
-                    stayName={stay?.name}
-                    onAddMeal={() => {
-                      // Handled within TimeSlotGrid component
-                    }}
-                  />
-                </div>
-              )
-            })}
-          </Accordion>
-        </>
+        <PlannerGrid
+          tripDates={tripDates}
+          getMealsForDate={getMealsForDate}
+          getActivitiesForDate={getActivitiesForDate}
+          getStayForDate={getStayForDate}
+          onDayClick={handleGridDayClick}
+        />
       )}
+
+      {/* Day Detail Sheet */}
+      <DayDetailSheet
+        date={selectedDate}
+        onOpenChange={(open) => { if (!open) setSelectedDate(null) }}
+        meals={selectedMeals}
+        activities={selectedActivities}
+        tripStartDate={currentTrip.start_date}
+        stayName={selectedStay?.name}
+      />
 
       {/* Empty State */}
       {!loading && tripDates.length === 0 && (
@@ -191,7 +112,7 @@ export function PlannerPage() {
                 No days planned yet
               </p>
               <p className="text-sm text-muted-foreground mb-4">
-                Start planning activities and meals for your trip by expanding a day
+                Start planning activities and meals for your trip by tapping a day
               </p>
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- Replace accordion day list with always-visible planner grid as the primary view
- Grid cells show calendar dates (e.g., "14") instead of trip day numbers (e.g., "5")
- Color-coded accommodation groups (6-color palette: amber, sky, rose, emerald, violet, indigo)
- Taller cells with activity count badges and time-slot dots
- New bottom sheet (`DayDetailSheet`) opens on cell tap with full meal/activity management via existing `TimeSlotGrid`

## Test plan
- [ ] PlannerGrid shows calendar dates, not trip day numbers
- [ ] Each accommodation group has a distinct color
- [ ] Clicking a day cell opens a bottom sheet with meals/activities
- [ ] Can add/edit/delete meals and activities from inside the sheet
- [ ] No accordion or scroll-heavy day list on the page
- [ ] Horizontal scroll works on mobile for long trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)