### PR TITLE
Redesign planner grid as week-based calendar (#86)

### DIFF
--- a/src/components/PlannerGrid.tsx
+++ b/src/components/PlannerGrid.tsx
@@ -1,4 +1,3 @@
-import { Building2, Home } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getDayContext } from '@/lib/dateUtils'
 import { Card } from '@/components/ui/card'
@@ -21,13 +20,15 @@ const DOT_FILLED_COLORS: Record<ActivityTimeSlot, string> = {
 }
 
 const STAY_COLORS = [
-  { bg: 'bg-amber-50', border: 'border-amber-200', text: 'text-amber-700', cellBorder: 'border-amber-200' },
-  { bg: 'bg-sky-50', border: 'border-sky-200', text: 'text-sky-700', cellBorder: 'border-sky-200' },
-  { bg: 'bg-rose-50', border: 'border-rose-200', text: 'text-rose-700', cellBorder: 'border-rose-200' },
-  { bg: 'bg-emerald-50', border: 'border-emerald-200', text: 'text-emerald-700', cellBorder: 'border-emerald-200' },
-  { bg: 'bg-violet-50', border: 'border-violet-200', text: 'text-violet-700', cellBorder: 'border-violet-200' },
-  { bg: 'bg-indigo-50', border: 'border-indigo-200', text: 'text-indigo-700', cellBorder: 'border-indigo-200' },
+  { bg: 'bg-amber-50', border: 'border-amber-200', text: 'text-amber-700', cellBorder: 'border-amber-200', dot: 'bg-amber-400' },
+  { bg: 'bg-sky-50', border: 'border-sky-200', text: 'text-sky-700', cellBorder: 'border-sky-200', dot: 'bg-sky-400' },
+  { bg: 'bg-rose-50', border: 'border-rose-200', text: 'text-rose-700', cellBorder: 'border-rose-200', dot: 'bg-rose-400' },
+  { bg: 'bg-emerald-50', border: 'border-emerald-200', text: 'text-emerald-700', cellBorder: 'border-emerald-200', dot: 'bg-emerald-400' },
+  { bg: 'bg-violet-50', border: 'border-violet-200', text: 'text-violet-700', cellBorder: 'border-violet-200', dot: 'bg-violet-400' },
+  { bg: 'bg-indigo-50', border: 'border-indigo-200', text: 'text-indigo-700', cellBorder: 'border-indigo-200', dot: 'bg-indigo-400' },
 ]
+
+const WEEKDAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
 
 interface PlannerGridProps {
   tripDates: string[]
@@ -37,41 +38,66 @@ interface PlannerGridProps {
   onDayClick: (date: string) => void
 }
 
-interface StayGroup {
-  stayId: string | null
-  stayName: string | null
-  dates: string[]
-}
+/**
+ * Organizes trip dates into Mon→Sun week rows.
+ * Pads with null for days outside the trip range.
+ */
+function getCalendarWeeks(dates: string[]): (string | null)[][] {
+  if (dates.length === 0) return []
 
-function groupDatesByStay(
-  dates: string[],
-  getStayForDate: (date: string) => Stay | undefined
-): StayGroup[] {
-  const groups: StayGroup[] = []
+  const tripDateSet = new Set(dates)
 
-  for (const date of dates) {
-    const stay = getStayForDate(date)
-    const stayId = stay?.id ?? null
-    const stayName = stay?.name ?? null
+  // Find the Monday of the week containing the first date
+  const firstDate = new Date(dates[0] + 'T00:00:00')
+  const dayOfWeek = firstDate.getDay() // 0=Sun, 1=Mon, ...
+  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
+  const startMonday = new Date(firstDate)
+  startMonday.setDate(firstDate.getDate() + mondayOffset)
 
-    const lastGroup = groups[groups.length - 1]
-    if (lastGroup && lastGroup.stayId === stayId) {
-      lastGroup.dates.push(date)
-    } else {
-      groups.push({ stayId, stayName, dates: [date] })
+  // Find the Sunday of the week containing the last date
+  const lastDate = new Date(dates[dates.length - 1] + 'T00:00:00')
+  const lastDayOfWeek = lastDate.getDay()
+  const sundayOffset = lastDayOfWeek === 0 ? 0 : 7 - lastDayOfWeek
+  const endSunday = new Date(lastDate)
+  endSunday.setDate(lastDate.getDate() + sundayOffset)
+
+  const weeks: (string | null)[][] = []
+  const current = new Date(startMonday)
+
+  while (current <= endSunday) {
+    const week: (string | null)[] = []
+    for (let i = 0; i < 7; i++) {
+      const iso = current.toISOString().split('T')[0]
+      week.push(tripDateSet.has(iso) ? iso : null)
+      current.setDate(current.getDate() + 1)
     }
+    weeks.push(week)
   }
 
-  return groups
+  return weeks
+}
+
+/**
+ * Maps unique stay IDs to color indices by scanning all trip dates.
+ */
+function getStayColorMap(
+  dates: string[],
+  getStayForDate: (date: string) => Stay | undefined
+): Map<string, number> {
+  const colorMap = new Map<string, number>()
+  let colorIdx = 0
+  for (const date of dates) {
+    const stay = getStayForDate(date)
+    if (stay && !colorMap.has(stay.id)) {
+      colorMap.set(stay.id, colorIdx % STAY_COLORS.length)
+      colorIdx++
+    }
+  }
+  return colorMap
 }
 
 function getCalendarDate(date: string): number {
   return new Date(date + 'T00:00:00').getDate()
-}
-
-function getWeekdayAbbr(date: string): string {
-  const d = new Date(date + 'T00:00:00')
-  return d.toLocaleDateString('en-US', { weekday: 'short' })
 }
 
 function slotHasContent(
@@ -86,18 +112,6 @@ function slotHasContent(
   )
 }
 
-function getStayColorIndex(groups: StayGroup[]): Map<string | null, number> {
-  const colorMap = new Map<string | null, number>()
-  let colorIdx = 0
-  for (const group of groups) {
-    if (group.stayId !== null && !colorMap.has(group.stayId)) {
-      colorMap.set(group.stayId, colorIdx % STAY_COLORS.length)
-      colorIdx++
-    }
-  }
-  return colorMap
-}
-
 export function PlannerGrid({
   tripDates,
   getMealsForDate,
@@ -105,102 +119,132 @@ export function PlannerGrid({
   getStayForDate,
   onDayClick,
 }: PlannerGridProps) {
-  const groups = groupDatesByStay(tripDates, getStayForDate)
-  const stayColorMap = getStayColorIndex(groups)
+  const weeks = getCalendarWeeks(tripDates)
+  const stayColorMap = getStayColorMap(tripDates, getStayForDate)
+
+  // Build legend: collect unique stays in order + track if there are home days
+  const legendStays: { id: string; name: string; colorIdx: number }[] = []
+  const seenStayIds = new Set<string>()
+  let hasHomeDays = false
+
+  for (const date of tripDates) {
+    const stay = getStayForDate(date)
+    if (stay) {
+      if (!seenStayIds.has(stay.id)) {
+        seenStayIds.add(stay.id)
+        legendStays.push({
+          id: stay.id,
+          name: stay.name,
+          colorIdx: stayColorMap.get(stay.id)!,
+        })
+      }
+    } else {
+      hasHomeDays = true
+    }
+  }
 
   return (
     <Card className="overflow-hidden">
       <div className="px-4 py-4">
-        <div className="grid grid-cols-5 md:grid-cols-7 gap-1">
-          {groups.map((group, groupIdx) => {
-            const colorIdx = group.stayId !== null ? stayColorMap.get(group.stayId) : undefined
+        {/* Weekday header */}
+        <div className="grid grid-cols-7 gap-1 mb-1">
+          {WEEKDAY_LABELS.map((d, i) => (
+            <div
+              key={i}
+              className="text-[10px] font-medium text-muted-foreground text-center"
+            >
+              {d}
+            </div>
+          ))}
+        </div>
+
+        {/* Calendar weeks */}
+        <div className="grid grid-cols-7 gap-1">
+          {weeks.flat().map((date, i) => {
+            if (!date) {
+              return (
+                <div
+                  key={`empty-${i}`}
+                  className="h-20 md:h-24 rounded-lg"
+                />
+              )
+            }
+
+            const stay = getStayForDate(date)
+            const colorIdx = stay ? stayColorMap.get(stay.id) : undefined
             const stayColor = colorIdx !== undefined ? STAY_COLORS[colorIdx] : null
 
-            return [
-              /* Stay header row — only for named stays */
-              group.stayName ? (
-                <div
-                  key={`stay-${groupIdx}`}
-                  className={cn(
-                    'col-span-full flex items-center gap-1 px-1.5 py-0.5 rounded',
-                    groupIdx > 0 && 'mt-2',
-                    stayColor ? `${stayColor.bg} ${stayColor.text}` : ''
-                  )}
-                >
-                  <Building2 size={12} className="shrink-0" />
-                  <span className="text-[10px] font-medium truncate">
-                    {group.stayName}
+            const calendarDate = getCalendarDate(date)
+            const context = getDayContext(date)
+            const meals = getMealsForDate(date)
+            const activities = getActivitiesForDate(date)
+            const activityCount = activities.length
+
+            return (
+              <button
+                key={date}
+                type="button"
+                onClick={() => onDayClick(date)}
+                className={cn(
+                  'flex flex-col items-center justify-center rounded-lg border px-2 py-1.5 transition-colors relative',
+                  'h-20 md:h-24',
+                  'hover:bg-accent/50 cursor-pointer',
+                  stayColor
+                    ? `${stayColor.bg} ${stayColor.cellBorder}`
+                    : 'bg-muted/30 border-border',
+                  context === 'today' && 'ring-2 ring-primary',
+                  context === 'past' && 'opacity-60'
+                )}
+              >
+                <span className="text-xs font-bold leading-none">{calendarDate}</span>
+                <div className="flex gap-1 mt-1.5">
+                  {TIME_SLOTS.map((slot) => {
+                    const filled = slotHasContent(slot, meals, activities)
+                    return (
+                      <div
+                        key={slot}
+                        className={cn(
+                          'w-2 h-2 rounded-full',
+                          filled ? DOT_FILLED_COLORS[slot] : 'bg-muted-foreground/20'
+                        )}
+                      />
+                    )
+                  })}
+                </div>
+                {activityCount > 0 && (
+                  <span className="absolute -top-1 -right-1 bg-primary text-primary-foreground text-[9px] font-bold w-4 h-4 rounded-full flex items-center justify-center">
+                    {activityCount}
                   </span>
-                </div>
-              ) : (
-                /* No stay — show "Home" label */
-                <div
-                  key={`stay-${groupIdx}`}
-                  className={cn(
-                    'col-span-full flex items-center gap-1 px-1.5 py-0.5 rounded',
-                    groupIdx > 0 && 'mt-2',
-                    'bg-muted text-muted-foreground'
-                  )}
-                >
-                  <Home size={12} className="shrink-0" />
-                  <span className="text-[10px] font-medium truncate">Home</span>
-                </div>
-              ),
-
-              /* Day cells */
-              ...group.dates.map((date) => {
-                const calendarDate = getCalendarDate(date)
-                const context = getDayContext(date)
-                const meals = getMealsForDate(date)
-                const activities = getActivitiesForDate(date)
-                const weekday = getWeekdayAbbr(date)
-                const activityCount = activities.length
-
-                return (
-                  <button
-                    key={date}
-                    type="button"
-                    onClick={() => onDayClick(date)}
-                    className={cn(
-                      'flex flex-col items-center justify-center rounded-lg border px-2 py-1.5 transition-colors relative',
-                      'h-20 md:h-24',
-                      'hover:bg-accent/50 cursor-pointer',
-                      stayColor
-                        ? `${stayColor.bg} ${stayColor.cellBorder}`
-                        : 'bg-muted/30 border-border',
-                      context === 'today' && 'ring-2 ring-primary',
-                      context === 'past' && 'opacity-60'
-                    )}
-                  >
-                    <span className="text-xs font-bold leading-none">{calendarDate}</span>
-                    <span className="text-[10px] text-muted-foreground leading-none mt-0.5">
-                      {weekday}
-                    </span>
-                    <div className="flex gap-1 mt-1.5">
-                      {TIME_SLOTS.map((slot) => {
-                        const filled = slotHasContent(slot, meals, activities)
-                        return (
-                          <div
-                            key={slot}
-                            className={cn(
-                              'w-2 h-2 rounded-full',
-                              filled ? DOT_FILLED_COLORS[slot] : 'bg-muted-foreground/20'
-                            )}
-                          />
-                        )
-                      })}
-                    </div>
-                    {activityCount > 0 && (
-                      <span className="absolute -top-1 -right-1 bg-primary text-primary-foreground text-[9px] font-bold w-4 h-4 rounded-full flex items-center justify-center">
-                        {activityCount}
-                      </span>
-                    )}
-                  </button>
-                )
-              }),
-            ]
+                )}
+              </button>
+            )
           })}
         </div>
+
+        {/* Stay legend */}
+        {(legendStays.length > 0 || hasHomeDays) && (
+          <div className="flex flex-wrap gap-x-3 gap-y-1 mt-3 pt-3 border-t">
+            {legendStays.map((stay) => (
+              <div key={stay.id} className="flex items-center gap-1">
+                <div
+                  className={cn(
+                    'w-2.5 h-2.5 rounded-full',
+                    STAY_COLORS[stay.colorIdx].dot
+                  )}
+                />
+                <span className="text-[10px] text-muted-foreground">
+                  {stay.name}
+                </span>
+              </div>
+            ))}
+            {hasHomeDays && (
+              <div className="flex items-center gap-1">
+                <div className="w-2.5 h-2.5 rounded-full bg-muted-foreground/30" />
+                <span className="text-[10px] text-muted-foreground">Home</span>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </Card>
   )


### PR DESCRIPTION
## Summary
- Replaced stay-grouped flat grid with a proper 7-column Mon→Sun calendar layout
- Removed stay header rows (Building2/Home labels) — cell background colors are sufficient
- Added weekday header row (M T W T F S S) and compact stay legend below the grid
- Empty placeholder cells pad days outside the trip range to maintain calendar alignment

## Test plan
- [ ] Planner grid renders as Mon→Sun calendar rows
- [ ] Days outside trip range show as empty cells
- [ ] Stay colors appear correctly on day cells
- [ ] Stay legend shows correct color→name mapping below grid
- [ ] Clicking a day opens the DayDetailSheet
- [ ] Today highlighting and past-day dimming work
- [ ] Activity count badges still appear

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)