### PR TITLE
Fix calendar timezone shift in UTC+ timezones

### DIFF
--- a/src/components/PlannerGrid.tsx
+++ b/src/components/PlannerGrid.tsx
@@ -42,6 +42,13 @@ interface PlannerGridProps {
  * Organizes trip dates into Mon→Sun week rows.
  * Pads with null for days outside the trip range.
  */
+function formatLocalDate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 function getCalendarWeeks(dates: string[]): (string | null)[][] {
   if (dates.length === 0) return []
 
@@ -67,7 +74,7 @@ function getCalendarWeeks(dates: string[]): (string | null)[][] {
   while (current <= endSunday) {
     const week: (string | null)[] = []
     for (let i = 0; i < 7; i++) {
-      const iso = current.toISOString().split('T')[0]
+      const iso = formatLocalDate(current)
       week.push(tripDateSet.has(iso) ? iso : null)
       current.setDate(current.getDate() + 1)
     }


### PR DESCRIPTION
## Summary
- Fixes #89 — calendar days were shifted one column to the right for users in UTC+ timezones
- `toISOString()` converted local midnight to UTC, producing the previous day's date string (e.g., local Saturday midnight in UTC+7 → Friday 17:00 UTC)
- Replaced with `formatLocalDate()` helper that uses local date parts, matching the `getDay()`-based grid positioning

## Test plan
- [ ] Verify Feb 14 2026 (Saturday) appears in the Saturday column
- [ ] Test in UTC+ timezone (e.g., set TZ=Asia/Bangkok) to confirm no shift
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)