### PR TITLE
Show diagonal split on accommodation change days

### DIFF
--- a/src/contexts/StayContext.tsx
+++ b/src/contexts/StayContext.tsx
@@ -12,6 +12,7 @@ interface StayContextValue {
   deleteStay: (id: string) => Promise<boolean>
   getStayById: (id: string) => Stay | undefined
   getStayForDate: (date: string) => Stay | undefined
+  getStaysForDate: (date: string) => Stay[]
   refreshStays: () => Promise<void>
 }
 
@@ -141,6 +142,10 @@ export function StayProvider({ children }: { children: ReactNode }) {
     return stays.find((s) => s.check_in_date <= date && date < s.check_out_date)
   }
 
+  const getStaysForDate = (date: string): Stay[] => {
+    return stays.filter((s) => s.check_in_date <= date && date <= s.check_out_date)
+  }
+
   const value: StayContextValue = {
     stays,
     loading,
@@ -149,6 +154,7 @@ export function StayProvider({ children }: { children: ReactNode }) {
     deleteStay,
     getStayById,
     getStayForDate,
+    getStaysForDate,
     refreshStays,
   }
 

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -14,7 +14,7 @@ export function PlannerPage() {
   const { currentTrip } = useCurrentTrip()
   const { meals, loading: mealsLoading, getMealsWithIngredients } = useMealContext()
   const { loading: activitiesLoading, getActivitiesForDate } = useActivityContext()
-  const { loading: staysLoading, getStayForDate } = useStayContext()
+  const { loading: staysLoading, getStayForDate, getStaysForDate } = useStayContext()
   const [mealsWithIngredients, setMealsWithIngredients] = useState<MealWithIngredients[]>([])
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
 
@@ -88,6 +88,7 @@ export function PlannerPage() {
           getMealsForDate={getMealsForDate}
           getActivitiesForDate={getActivitiesForDate}
           getStayForDate={getStayForDate}
+          getStaysForDate={getStaysForDate}
           onDayClick={handleGridDayClick}
         />
       )}


### PR DESCRIPTION
## Summary
- Adds `getStaysForDate()` to StayContext that returns both departing and arriving stays on overlap days (checkout date inclusive)
- Calendar cells on change days now render a diagonal gradient (135deg) with the departing stay color top-left and arriving stay color bottom-right
- Non-change days and home days render unchanged

Closes #91

## Test plan
- [ ] Create two stays with consecutive dates (Stay A checkout = Stay B checkin) and verify diagonal split appears
- [ ] Verify non-change days still show a single solid color
- [ ] Verify home days (no stay) still show gray background
- [ ] Verify stay legend still displays all stays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)