### PR TITLE
Fix app loading flow and submit button freezing

### DIFF
--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -42,6 +42,11 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
   const [note, setNote] = useState(initialNote || '')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => { isMounted.current = false }
+  }, [])
 
   // Keyboard detection for mobile
   const formRef = useRef<HTMLFormElement>(null)
@@ -162,7 +167,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
     } catch (err) {
       setError('Failed to record settlement. Please try again.')
     } finally {
-      setLoading(false)
+      if (isMounted.current) setLoading(false)
     }
   }
 

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, FormEvent } from 'react'
+import { useState, useEffect, useRef, FormEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Lightbulb, ChevronDown, ChevronRight } from 'lucide-react'
 import { CreateExpenseInput, ExpenseCategory, ExpenseDistribution, SplitMode } from '@/types/expense'
@@ -73,6 +73,11 @@ export function ExpenseForm({
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => { isMounted.current = false }
+  }, [])
 
   const adults = getAdultParticipants()
   const isIndividualsMode = currentTrip?.tracking_mode === 'individuals'
@@ -213,6 +218,7 @@ export function ExpenseForm({
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    if (loading) return
     setError(null)
 
     if (!description.trim()) {
@@ -397,7 +403,7 @@ export function ExpenseForm({
     } catch (err) {
       setError('Failed to save expense. Please try again.')
     } finally {
-      setLoading(false)
+      if (isMounted.current) setLoading(false)
     }
   }
 

--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react'
-import { useNavigate, useParams, useLocation } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { Zap, Settings2 } from 'lucide-react'
 
@@ -9,19 +8,8 @@ interface ModeToggleProps {
 
 export function ModeToggle({ onGradient = false }: ModeToggleProps) {
   const navigate = useNavigate()
-  const location = useLocation()
   const { tripCode } = useParams<{ tripCode: string }>()
   const { mode, setMode } = useUserPreferences()
-
-  // Sync mode state with actual route to fix mismatches (e.g. direct URL access)
-  useEffect(() => {
-    const path = location.pathname
-    if (path.includes('/quick') && mode !== 'quick') {
-      setMode('quick')
-    } else if (tripCode && !path.includes('/quick') && mode !== 'full') {
-      setMode('full')
-    }
-  }, [location.pathname, tripCode]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleModeChange = async (newMode: 'quick' | 'full') => {
     if (newMode === mode) return

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-smooth focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-smooth focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation",
   {
     variants: {
       variant: {

--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/contexts/AuthContext'
 import { Trip, CreateTripInput, UpdateTripInput } from '@/types/trip'
 import { generateTripCode } from '@/lib/tripCodeGenerator'
 
@@ -18,6 +19,7 @@ interface TripContextType {
 const TripContext = createContext<TripContextType | undefined>(undefined)
 
 export function TripProvider({ children }: { children: ReactNode }) {
+  const { loading: authLoading } = useAuth()
   const [trips, setTrips] = useState<Trip[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -141,10 +143,11 @@ export function TripProvider({ children }: { children: ReactNode }) {
     await fetchTrips()
   }
 
-  // Fetch trips on mount
+  // Fetch trips after auth has resolved
   useEffect(() => {
+    if (authLoading) return
     fetchTrips()
-  }, [])
+  }, [authLoading])
 
   const value: TripContextType = {
     trips,

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -6,6 +6,7 @@ import { useTripContext } from '@/contexts/TripContext'
 import { getActiveTripId } from '@/lib/activeTripDetection'
 import { getMyTrips } from '@/lib/myTripsStorage'
 import { HomePage } from './HomePage'
+import { Loader2 } from 'lucide-react'
 
 /**
  * Renders at `/` - redirects to Quick Mode if user has it set,
@@ -20,8 +21,10 @@ export function ConditionalHomePage() {
   const { mode, loading: prefsLoading } = useUserPreferences()
   const { trips, loading: tripsLoading } = useTripContext()
 
+  const isLoading = authLoading || prefsLoading || tripsLoading
+
   useEffect(() => {
-    if (authLoading || prefsLoading || tripsLoading) return
+    if (isLoading) return
     if (mode !== 'quick') return
 
     // For quick mode, auto-detect active trip from user's linked trips
@@ -39,7 +42,16 @@ export function ConditionalHomePage() {
 
     // No active trip found, show the quick home screen
     navigate('/quick', { replace: true })
-  }, [authLoading, prefsLoading, tripsLoading, user, mode, trips, navigate])
+  }, [isLoading, user, mode, trips, navigate])
+
+  // Show spinner while any context is still loading
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
 
   // Don't render HomePage when we're about to redirect to quick mode
   if (mode === 'quick') return null


### PR DESCRIPTION
## Summary
- **Loading flow:** Fix race condition where `ConditionalHomePage` renders before preferences sync from Supabase, causing wrong page flash (full-mode trips list instead of quick mode active trip)
- **Loading flow:** Remove `ModeToggle` URL-sync effect that silently corrupted user preferences when visiting full-mode URLs
- **Loading flow:** Make `TripContext` wait for auth and `AuthContext` skip duplicate `INITIAL_SESSION` events
- **Submit freezing:** Add timeouts to `compressImage` (10s) and edge function calls (15s) to prevent permanent hangs on Android
- **Submit freezing:** Add double-submission guards and `isMounted` refs to all form submit handlers
- **Submit freezing:** Add `touch-manipulation` to Button component to prevent Android double-tap zoom duplicates

Closes #94

## Test plan
- [ ] On mobile, navigate to `/` while logged in with quick mode → should redirect to active trip, never flash trips list
- [ ] On desktop, navigate to `/` → should show full-mode homepage consistently
- [ ] Visit a full-mode URL while preference is quick → mode should NOT be overwritten
- [ ] On Android, rapidly double-tap expense submit → should not submit twice
- [ ] In ReportIssueDialog, attach large image on Android → should not freeze, timeout gracefully
- [ ] `npm run build` and `npm run type-check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)