### PR TITLE
Add comprehensive test suites with Vitest + Testing Library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,9 @@
         "zustand": "^5.0.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -56,12 +59,28 @@
         "eslint": "^9.15.0",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
+        "jsdom": "^28.1.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.15",
         "tsx": "^4.20.6",
         "typescript": "^5.6.3",
-        "vite": "^6.0.1"
+        "vite": "^6.0.1",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -103,6 +122,61 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -414,6 +488,151 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1019,6 +1238,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2635,6 +2872,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.84.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.84.0.tgz",
@@ -2714,6 +2958,104 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2757,6 +3099,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -2820,6 +3173,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3171,6 +3531,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3213,6 +3684,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/agentkeepalive": {
@@ -3312,6 +3793,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3393,6 +3894,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -3568,6 +4079,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3766,6 +4287,27 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3776,6 +4318,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -3905,6 +4473,58 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -3942,6 +4562,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -3962,6 +4589,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-node-es": {
@@ -3987,6 +4624,14 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4045,6 +4690,19 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -4062,6 +4720,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4382,6 +5047,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4406,6 +5081,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4822,6 +5507,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -4834,6 +5532,34 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -4880,6 +5606,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internmap": {
@@ -4957,6 +5693,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4990,6 +5733,85 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -5168,6 +5990,27 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5176,6 +6019,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5218,6 +6068,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5377,6 +6237,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5449,6 +6320,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5472,6 +6356,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/performance-now": {
@@ -5709,6 +6600,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6010,6 +6939,20 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -6021,6 +6964,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6157,6 +7110,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6208,6 +7174,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6229,6 +7202,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -6238,6 +7218,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -6260,6 +7247,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6334,6 +7334,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
@@ -6428,6 +7435,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6473,6 +7497,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6483,6 +7537,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -6561,6 +7628,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -6797,6 +7874,110 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -6811,6 +7992,16 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -6843,6 +8034,23 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wmf": {
       "version": "1.0.2",
@@ -6927,6 +8135,23 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
-    "migrate": "node scripts/migrate.js"
+    "migrate": "node scripts/migrate.js",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
@@ -49,6 +52,9 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -60,10 +66,12 @@
     "eslint": "^9.15.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
+    "jsdom": "^28.1.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
     "tsx": "^4.20.6",
     "typescript": "^5.6.3",
-    "vite": "^6.0.1"
+    "vite": "^6.0.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/contexts/ActivityContext.test.tsx
+++ b/src/contexts/ActivityContext.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ActivityProvider, useActivityContext } from './ActivityContext'
+import type { Activity } from '@/types/activity'
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  auth: {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
+
+const mockCurrentTrip = vi.hoisted(() => ({
+  currentTrip: null as any,
+  tripCode: null as string | null,
+  loading: false,
+}))
+
+vi.mock('@/hooks/useCurrentTrip', () => ({
+  useCurrentTrip: () => mockCurrentTrip,
+}))
+
+vi.mock('@/contexts/TripContext', () => ({
+  useTripContext: () => ({ trips: [] }),
+}))
+
+const activities: Activity[] = [
+  {
+    id: 'a1', trip_id: 'trip-1', activity_date: '2025-07-02',
+    time_slot: 'evening', title: 'Evening Tour',
+    created_at: '2025-07-01', updated_at: '2025-07-01',
+  },
+  {
+    id: 'a2', trip_id: 'trip-1', activity_date: '2025-07-01',
+    time_slot: 'afternoon', title: 'Afternoon Hike',
+    created_at: '2025-07-01', updated_at: '2025-07-01',
+  },
+  {
+    id: 'a3', trip_id: 'trip-1', activity_date: '2025-07-01',
+    time_slot: 'morning', title: 'Morning Yoga',
+    created_at: '2025-07-01', updated_at: '2025-07-01',
+  },
+]
+
+function TestConsumer() {
+  const { activities: acts, loading } = useActivityContext()
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="order">{acts.map(a => a.title).join(',')}</span>
+    </div>
+  )
+}
+
+describe('ActivityContext', () => {
+  beforeEach(() => {
+    mockCurrentTrip.currentTrip = null
+    mockCurrentTrip.tripCode = null
+    mockSupabase.from.mockReset()
+  })
+
+  it('sorts activities by date then TIME_SLOT_ORDER', async () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockCurrentTrip.tripCode = 'test-trip-Ab1234'
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => Promise.resolve({ data: activities, error: null }),
+        }),
+      }),
+    })
+
+    render(
+      <ActivityProvider>
+        <TestConsumer />
+      </ActivityProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('order').textContent).toBe(
+      'Morning Yoga,Afternoon Hike,Evening Tour'
+    )
+  })
+})

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { AuthProvider, useAuth } from './AuthContext'
+
+// Use vi.hoisted so the mock is available when vi.mock factory runs
+const mockSupabase = vi.hoisted(() => {
+  const fn = vi.fn
+  return {
+    from: fn().mockReturnValue(new Proxy(() => {}, {
+      get: () => () => new Proxy(() => {}, { get: () => () => Promise.resolve({ data: null, error: null }) }),
+      apply: () => Promise.resolve({ data: null, error: null }),
+    })),
+    auth: {
+      getSession: fn().mockResolvedValue({ data: { session: null } }),
+      getUser: fn().mockResolvedValue({ data: { user: null } }),
+      onAuthStateChange: fn().mockReturnValue({
+        data: { subscription: { unsubscribe: fn() } },
+      }),
+      signInWithIdToken: fn().mockResolvedValue({ error: null }),
+      signOut: fn().mockResolvedValue({ error: null }),
+    },
+    channel: fn(),
+    removeChannel: fn(),
+  }
+})
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: mockSupabase,
+}))
+
+function TestConsumer() {
+  const { user, userProfile, session, loading } = useAuth()
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="user">{user?.id ?? 'null'}</span>
+      <span data-testid="profile">{userProfile?.display_name ?? 'null'}</span>
+      <span data-testid="session">{session ? 'active' : 'null'}</span>
+    </div>
+  )
+}
+
+describe('AuthContext', () => {
+  let authChangeCallback: ((event: string, session: any) => void) | null = null
+
+  beforeEach(() => {
+    authChangeCallback = null
+    mockSupabase.auth.getSession.mockReset()
+    mockSupabase.auth.onAuthStateChange.mockReset()
+    mockSupabase.auth.signOut.mockReset()
+    mockSupabase.from.mockReset()
+
+    // Default: no session
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: null },
+    })
+
+    mockSupabase.auth.onAuthStateChange.mockImplementation((cb: any) => {
+      authChangeCallback = cb
+      return { data: { subscription: { unsubscribe: vi.fn() } } }
+    })
+
+    mockSupabase.auth.signOut.mockResolvedValue({ error: null })
+  })
+
+  it('starts loading=true and resolves to loading=false after getSession', async () => {
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    expect(screen.getByTestId('loading').textContent).toBe('true')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+    expect(screen.getByTestId('user').textContent).toBe('null')
+  })
+
+  it('skips INITIAL_SESSION event to prevent double fetch', async () => {
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    await act(async () => {
+      authChangeCallback?.('INITIAL_SESSION', null)
+    })
+
+    expect(screen.getByTestId('user').textContent).toBe('null')
+  })
+
+  it('handles SIGNED_IN event by setting user', async () => {
+    mockSupabase.from.mockReturnValue({
+      upsert: () => ({
+        select: () => ({
+          single: () =>
+            Promise.resolve({
+              data: {
+                id: 'user-1',
+                display_name: 'Alice',
+                email: 'alice@test.com',
+                avatar_url: null,
+                bank_account_holder: null,
+                bank_iban: null,
+                created_at: '2025-01-01',
+                updated_at: '2025-01-01',
+              },
+              error: null,
+            }),
+        }),
+      }),
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    const mockUser = {
+      id: 'user-1',
+      email: 'alice@test.com',
+      user_metadata: { full_name: 'Alice', avatar_url: null },
+    }
+
+    await act(async () => {
+      authChangeCallback?.('SIGNED_IN', {
+        user: mockUser,
+        access_token: 'token',
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('user-1')
+    })
+  })
+
+  it('clears user/session/profile on sign out', async () => {
+    const mockUser = {
+      id: 'user-1',
+      email: 'alice@test.com',
+      user_metadata: { full_name: 'Alice' },
+    }
+
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: {
+        session: { user: mockUser, access_token: 'token' },
+      },
+    })
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: {
+                id: 'user-1',
+                display_name: 'Alice',
+                email: 'alice@test.com',
+                avatar_url: null,
+                bank_account_holder: null,
+                bank_iban: null,
+                created_at: '2025-01-01',
+                updated_at: '2025-01-01',
+              },
+              error: null,
+            }),
+        }),
+      }),
+      upsert: () => ({
+        select: () => ({
+          single: () => Promise.resolve({ data: null, error: null }),
+        }),
+      }),
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('user-1')
+    })
+
+    await act(async () => {
+      authChangeCallback?.('SIGNED_OUT', null)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('null')
+      expect(screen.getByTestId('profile').textContent).toBe('null')
+      expect(screen.getByTestId('session').textContent).toBe('null')
+    })
+  })
+
+  it('unsubscribes on unmount', async () => {
+    const unsubscribe = vi.fn()
+    mockSupabase.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe } },
+    })
+
+    const { unmount } = render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    unmount()
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+})

--- a/src/contexts/ExpenseContext.test.tsx
+++ b/src/contexts/ExpenseContext.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ExpenseProvider, useExpenseContext } from './ExpenseContext'
+import { buildExpense } from '@/test/factories'
+import type { Expense } from '@/types/expense'
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  auth: {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
+
+const mockCurrentTrip = vi.hoisted(() => ({
+  currentTrip: null as any,
+  tripCode: null as string | null,
+  loading: false,
+}))
+
+vi.mock('@/hooks/useCurrentTrip', () => ({
+  useCurrentTrip: () => mockCurrentTrip,
+}))
+
+vi.mock('@/contexts/TripContext', () => ({
+  useTripContext: () => ({ trips: [] }),
+}))
+
+const sampleExpenses: Expense[] = [
+  buildExpense({ id: 'e1', description: 'Dinner', category: 'Food', comment: 'Great place' }),
+  buildExpense({ id: 'e2', description: 'Taxi', category: 'Transport' }),
+  buildExpense({ id: 'e3', description: 'Breakfast', category: 'Food', comment: null }),
+]
+
+function TestConsumer() {
+  const {
+    expenses, loading, getExpensesByCategory, searchExpenses,
+    getFoodExpenses, getExpenseById,
+  } = useExpenseContext()
+
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="count">{expenses.length}</span>
+      <span data-testid="food-count">{getFoodExpenses().length}</span>
+      <span data-testid="search-count">{searchExpenses('dinner').length}</span>
+      <span data-testid="transport-count">{getExpensesByCategory('Transport').length}</span>
+      <span data-testid="found">{getExpenseById('e1')?.description ?? 'null'}</span>
+    </div>
+  )
+}
+
+describe('ExpenseContext', () => {
+  beforeEach(() => {
+    mockCurrentTrip.currentTrip = null
+    mockCurrentTrip.tripCode = null
+    mockSupabase.from.mockReset()
+  })
+
+  it('clears expenses when no currentTrip', async () => {
+    render(
+      <ExpenseProvider>
+        <TestConsumer />
+      </ExpenseProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('0')
+    })
+  })
+
+  it('fetches and filters expenses when currentTrip is set', async () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockCurrentTrip.tripCode = 'test-trip-Ab1234'
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            order: () => Promise.resolve({ data: sampleExpenses, error: null }),
+          }),
+        }),
+      }),
+    })
+
+    render(
+      <ExpenseProvider>
+        <TestConsumer />
+      </ExpenseProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('3')
+    })
+
+    expect(screen.getByTestId('food-count').textContent).toBe('2')
+    expect(screen.getByTestId('search-count').textContent).toBe('1')
+    expect(screen.getByTestId('transport-count').textContent).toBe('1')
+    expect(screen.getByTestId('found').textContent).toBe('Dinner')
+  })
+})

--- a/src/contexts/ShoppingContext.test.tsx
+++ b/src/contexts/ShoppingContext.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { ShoppingProvider, useShoppingContext } from './ShoppingContext'
+import type { ShoppingItem } from '@/types/shopping'
+
+const mockChannelInstance = vi.hoisted(() => ({
+  on: vi.fn().mockReturnThis(),
+  subscribe: vi.fn().mockReturnThis(),
+}))
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  auth: {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  },
+  channel: vi.fn(() => mockChannelInstance),
+  removeChannel: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
+
+const mockCurrentTrip = vi.hoisted(() => ({
+  currentTrip: null as any,
+  tripCode: null as string | null,
+  loading: false,
+}))
+
+vi.mock('@/hooks/useCurrentTrip', () => ({
+  useCurrentTrip: () => mockCurrentTrip,
+}))
+
+vi.mock('@/contexts/TripContext', () => ({
+  useTripContext: () => ({ trips: [] }),
+}))
+
+const sampleItems: ShoppingItem[] = [
+  {
+    id: 's1', trip_id: 'trip-1', name: 'Apples', category: 'produce',
+    is_completed: false, created_at: '2025-07-01', updated_at: '2025-07-01',
+  },
+  {
+    id: 's2', trip_id: 'trip-1', name: 'Milk', category: 'dairy',
+    is_completed: false, created_at: '2025-07-01', updated_at: '2025-07-01',
+  },
+]
+
+function TestConsumer() {
+  const { shoppingItems, loading, toggleItemCompleted } = useShoppingContext()
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="count">{shoppingItems.length}</span>
+      <span data-testid="items">{JSON.stringify(shoppingItems.map(i => ({ id: i.id, done: i.is_completed })))}</span>
+      <button data-testid="toggle-s1" onClick={() => toggleItemCompleted('s1')}>Toggle</button>
+    </div>
+  )
+}
+
+describe('ShoppingContext', () => {
+  beforeEach(() => {
+    mockCurrentTrip.currentTrip = null
+    mockCurrentTrip.tripCode = null
+    mockSupabase.from.mockReset()
+    mockSupabase.channel.mockReset()
+    mockSupabase.removeChannel.mockReset()
+    mockChannelInstance.on.mockReturnThis()
+    mockChannelInstance.subscribe.mockReturnThis()
+    mockSupabase.channel.mockReturnValue(mockChannelInstance)
+  })
+
+  it('clears items and sets loading=false when no currentTrip', async () => {
+    render(
+      <ShoppingProvider>
+        <TestConsumer />
+      </ShoppingProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+      expect(screen.getByTestId('count').textContent).toBe('0')
+    })
+  })
+
+  it('fetches items and sets up real-time channel', async () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockCurrentTrip.tripCode = 'test-trip-Ab1234'
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            order: () => Promise.resolve({ data: sampleItems, error: null }),
+          }),
+        }),
+      }),
+    })
+
+    render(
+      <ShoppingProvider>
+        <TestConsumer />
+      </ShoppingProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+      expect(screen.getByTestId('count').textContent).toBe('2')
+    })
+
+    expect(mockSupabase.channel).toHaveBeenCalled()
+  })
+
+  it('toggleItemCompleted performs optimistic update', async () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockCurrentTrip.tripCode = 'test-trip-Ab1234'
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            order: () => Promise.resolve({ data: [...sampleItems], error: null }),
+          }),
+        }),
+      }),
+      update: () => ({
+        eq: () => ({
+          select: () => ({
+            single: () => Promise.resolve({
+              data: { ...sampleItems[0], is_completed: true },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    })
+
+    render(
+      <ShoppingProvider>
+        <TestConsumer />
+      </ShoppingProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('2')
+    })
+
+    mockSupabase.from.mockReturnValue({
+      update: () => ({
+        eq: () => ({
+          select: () => ({
+            single: () => Promise.resolve({
+              data: { ...sampleItems[0], is_completed: true },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    })
+
+    await act(async () => {
+      screen.getByTestId('toggle-s1').click()
+    })
+
+    await waitFor(() => {
+      const items = JSON.parse(screen.getByTestId('items').textContent!)
+      const s1 = items.find((i: any) => i.id === 's1')
+      expect(s1.done).toBe(true)
+    })
+  })
+
+  it('cleans up channel on unmount', async () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockCurrentTrip.tripCode = 'test-trip-Ab1234'
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            order: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }),
+      }),
+    })
+
+    const { unmount } = render(
+      <ShoppingProvider>
+        <TestConsumer />
+      </ShoppingProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    unmount()
+    expect(mockSupabase.removeChannel).toHaveBeenCalled()
+  })
+})

--- a/src/contexts/StayContext.test.tsx
+++ b/src/contexts/StayContext.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { StayProvider, useStayContext } from './StayContext'
+import type { Stay } from '@/types/stay'
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  auth: {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
+
+const mockCurrentTrip = vi.hoisted(() => ({
+  currentTrip: null as any,
+  tripCode: null as string | null,
+  loading: false,
+}))
+
+vi.mock('@/hooks/useCurrentTrip', () => ({
+  useCurrentTrip: () => mockCurrentTrip,
+}))
+
+vi.mock('@/contexts/TripContext', () => ({
+  useTripContext: () => ({ trips: [] }),
+}))
+
+const stay1: Stay = {
+  id: 'stay-1', trip_id: 'trip-1', name: 'Hotel Alpha',
+  check_in_date: '2025-07-01', check_out_date: '2025-07-05',
+  created_at: '2025-06-01', updated_at: '2025-06-01',
+}
+const stay2: Stay = {
+  id: 'stay-2', trip_id: 'trip-1', name: 'Hotel Beta',
+  check_in_date: '2025-07-05', check_out_date: '2025-07-10',
+  created_at: '2025-06-01', updated_at: '2025-06-01',
+}
+
+function TestConsumer() {
+  const { stays, loading, getStayForDate, getStaysForDate } = useStayContext()
+  const stayForJul3 = getStayForDate('2025-07-03')
+  const stayForJul5 = getStayForDate('2025-07-05')
+  const staysForJul5 = getStaysForDate('2025-07-05')
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="count">{stays.length}</span>
+      <span data-testid="stay-jul3">{stayForJul3?.name ?? 'null'}</span>
+      <span data-testid="stay-jul5">{stayForJul5?.name ?? 'null'}</span>
+      <span data-testid="stays-jul5-count">{staysForJul5.length}</span>
+    </div>
+  )
+}
+
+describe('StayContext', () => {
+  beforeEach(() => {
+    mockCurrentTrip.currentTrip = null
+    mockCurrentTrip.tripCode = null
+    mockSupabase.from.mockReset()
+  })
+
+  it('getStayForDate uses exclusive check-out (date < check_out)', async () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockCurrentTrip.tripCode = 'test-trip-Ab1234'
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => Promise.resolve({ data: [stay1, stay2], error: null }),
+        }),
+      }),
+    })
+
+    render(
+      <StayProvider>
+        <TestConsumer />
+      </StayProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('count').textContent).toBe('2')
+    expect(screen.getByTestId('stay-jul3').textContent).toBe('Hotel Alpha')
+    // Jul 5 is check-out of stay1 (exclusive), check-in of stay2
+    expect(screen.getByTestId('stay-jul5').textContent).toBe('Hotel Beta')
+  })
+
+  it('getStaysForDate uses inclusive check-out (date <= check_out)', async () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockCurrentTrip.tripCode = 'test-trip-Ab1234'
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => Promise.resolve({ data: [stay1, stay2], error: null }),
+        }),
+      }),
+    })
+
+    render(
+      <StayProvider>
+        <TestConsumer />
+      </StayProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    // Jul 5 is both check_out of stay1 (inclusive) and check_in of stay2
+    expect(screen.getByTestId('stays-jul5-count').textContent).toBe('2')
+  })
+})

--- a/src/contexts/TripContext.test.tsx
+++ b/src/contexts/TripContext.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { TripProvider, useTripContext } from './TripContext'
+import { buildTrip } from '@/test/factories'
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  auth: {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
+
+const mockAuth = vi.hoisted(() => ({
+  user: null as any,
+  userProfile: null,
+  session: null,
+  loading: false,
+  signInWithGoogle: vi.fn(),
+  signOut: vi.fn(),
+  updateBankDetails: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+vi.mock('@/lib/tripCodeGenerator', () => ({
+  generateTripCode: () => 'test-trip-Abc123',
+}))
+
+function TestConsumer() {
+  const { trips, loading, error, getTripById, getTripByCode } = useTripContext()
+  const trip1 = getTripById('trip-1')
+  const tripByCode = getTripByCode('summer-trip-Ab1234')
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ?? 'null'}</span>
+      <span data-testid="count">{trips.length}</span>
+      <span data-testid="trip1">{trip1?.name ?? 'null'}</span>
+      <span data-testid="tripByCode">{tripByCode?.name ?? 'null'}</span>
+    </div>
+  )
+}
+
+describe('TripContext', () => {
+  beforeEach(() => {
+    mockAuth.loading = false
+    mockSupabase.from.mockReset()
+  })
+
+  it('waits for authLoading=false before fetching', async () => {
+    mockAuth.loading = true
+    mockSupabase.from.mockReturnValue({
+      select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
+    })
+
+    render(
+      <TripProvider>
+        <TestConsumer />
+      </TripProvider>
+    )
+
+    expect(screen.getByTestId('loading').textContent).toBe('true')
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
+  it('sets trips from response', async () => {
+    const trips = [
+      buildTrip({ id: 'trip-1', name: 'Summer', trip_code: 'summer-trip-Ab1234' }),
+      buildTrip({ id: 'trip-2', name: 'Winter' }),
+    ]
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({ order: () => Promise.resolve({ data: trips, error: null }) }),
+    })
+
+    render(
+      <TripProvider>
+        <TestConsumer />
+      </TripProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('count').textContent).toBe('2')
+    expect(screen.getByTestId('trip1').textContent).toBe('Summer')
+    expect(screen.getByTestId('tripByCode').textContent).toBe('Summer')
+  })
+
+  it('getTripById returns undefined when not found', async () => {
+    mockSupabase.from.mockReturnValue({
+      select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
+    })
+
+    render(
+      <TripProvider>
+        <TestConsumer />
+      </TripProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('trip1').textContent).toBe('null')
+    expect(screen.getByTestId('tripByCode').textContent).toBe('null')
+  })
+})

--- a/src/contexts/UserPreferencesContext.test.tsx
+++ b/src/contexts/UserPreferencesContext.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { UserPreferencesProvider, useUserPreferences } from './UserPreferencesContext'
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  auth: {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
+
+const mockAuth = vi.hoisted(() => ({
+  user: null as any,
+  userProfile: null as any,
+  session: null,
+  loading: false,
+  signInWithGoogle: vi.fn(),
+  signOut: vi.fn(),
+  updateBankDetails: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+function TestConsumer() {
+  const { mode, loading, setMode } = useUserPreferences()
+  return (
+    <div>
+      <span data-testid="mode">{mode}</span>
+      <span data-testid="loading">{String(loading)}</span>
+      <button data-testid="set-full" onClick={() => setMode('full')}>Set Full</button>
+    </div>
+  )
+}
+
+describe('UserPreferencesContext', () => {
+  beforeEach(() => {
+    mockAuth.user = null
+    mockAuth.loading = false
+    mockSupabase.from.mockReset()
+  })
+
+  it('sets loading=false when no user (local prefs authoritative)', async () => {
+    render(
+      <UserPreferencesProvider>
+        <TestConsumer />
+      </UserPreferencesProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+  })
+
+  it('fetches from Supabase when user exists and server overrides local', async () => {
+    mockAuth.user = { id: 'user-1' }
+
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: { preferred_mode: 'full', default_trip_id: null },
+              error: null,
+            }),
+        }),
+      }),
+      upsert: () => Promise.resolve({ error: null }),
+    })
+
+    render(
+      <UserPreferencesProvider>
+        <TestConsumer />
+      </UserPreferencesProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+      expect(screen.getByTestId('mode').textContent).toBe('full')
+    })
+  })
+
+  it('does not double-fetch (hasInitialized ref)', async () => {
+    mockAuth.user = { id: 'user-1' }
+
+    let fetchCount = 0
+    mockSupabase.from.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => {
+            fetchCount++
+            return Promise.resolve({
+              data: { preferred_mode: 'quick', default_trip_id: null },
+              error: null,
+            })
+          },
+        }),
+      }),
+      upsert: () => Promise.resolve({ error: null }),
+    })
+
+    const { rerender } = render(
+      <UserPreferencesProvider>
+        <TestConsumer />
+      </UserPreferencesProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    rerender(
+      <UserPreferencesProvider>
+        <TestConsumer />
+      </UserPreferencesProvider>
+    )
+
+    expect(fetchCount).toBe(1)
+  })
+
+  it('setMode updates local state', async () => {
+    mockAuth.user = null
+
+    render(
+      <UserPreferencesProvider>
+        <TestConsumer />
+      </UserPreferencesProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    await act(async () => {
+      screen.getByTestId('set-full').click()
+    })
+
+    expect(screen.getByTestId('mode').textContent).toBe('full')
+  })
+})

--- a/src/hooks/useCurrentTrip.test.tsx
+++ b/src/hooks/useCurrentTrip.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { useCurrentTrip } from './useCurrentTrip'
+import { ReactNode } from 'react'
+import { buildTrip } from '@/test/factories'
+
+// Mock TripContext
+const trips = [
+  buildTrip({ id: 'trip-1', trip_code: 'summer-2025-Ab1234', name: 'Summer 2025' }),
+]
+vi.mock('@/contexts/TripContext', () => ({
+  useTripContext: () => ({
+    trips,
+    loading: false,
+    getTripByCode: (code: string) => trips.find(t => t.trip_code === code),
+  }),
+}))
+
+// Mock myTripsStorage
+const mockAddToMyTrips = vi.fn()
+vi.mock('@/lib/myTripsStorage', () => ({
+  addToMyTrips: (...args: any[]) => mockAddToMyTrips(...args),
+}))
+
+function createWrapper(route: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[route]}>
+        <Routes>
+          <Route path="/t/:tripCode/*" element={children} />
+          <Route path="/" element={children} />
+        </Routes>
+      </MemoryRouter>
+    )
+  }
+}
+
+describe('useCurrentTrip', () => {
+  beforeEach(() => {
+    mockAddToMyTrips.mockClear()
+  })
+
+  it('reads tripCode from params and looks up trip', () => {
+    const { result } = renderHook(() => useCurrentTrip(), {
+      wrapper: createWrapper('/t/summer-2025-Ab1234/expenses'),
+    })
+
+    expect(result.current.tripCode).toBe('summer-2025-Ab1234')
+    expect(result.current.currentTrip?.name).toBe('Summer 2025')
+  })
+
+  it('calls addToMyTrips when trip is found', () => {
+    renderHook(() => useCurrentTrip(), {
+      wrapper: createWrapper('/t/summer-2025-Ab1234/expenses'),
+    })
+
+    expect(mockAddToMyTrips).toHaveBeenCalledWith('summer-2025-Ab1234', 'Summer 2025')
+  })
+
+  it('returns null when no tripCode param', () => {
+    const { result } = renderHook(() => useCurrentTrip(), {
+      wrapper: createWrapper('/'),
+    })
+
+    expect(result.current.tripCode).toBeUndefined()
+    expect(result.current.currentTrip).toBeNull()
+  })
+})

--- a/src/hooks/useMyParticipant.test.tsx
+++ b/src/hooks/useMyParticipant.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useMyParticipant } from './useMyParticipant'
+import { buildParticipant } from '@/test/factories'
+
+// Mock AuthContext
+const mockAuth = {
+  user: null as any,
+  userProfile: null,
+  session: null,
+  loading: false,
+  signInWithGoogle: vi.fn(),
+  signOut: vi.fn(),
+  updateBankDetails: vi.fn(),
+}
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+// Mock ParticipantContext
+const mockParticipants = {
+  participants: [
+    buildParticipant({ id: 'p1', name: 'Alice', user_id: 'user-1' }),
+    buildParticipant({ id: 'p2', name: 'Bob', user_id: 'user-2' }),
+  ],
+  loading: false,
+}
+vi.mock('@/contexts/ParticipantContext', () => ({
+  useParticipantContext: () => mockParticipants,
+}))
+
+describe('useMyParticipant', () => {
+  it('returns null when unauthenticated', () => {
+    mockAuth.user = null
+    const { result } = renderHook(() => useMyParticipant())
+    expect(result.current.myParticipant).toBeNull()
+    expect(result.current.isLinked).toBe(false)
+  })
+
+  it('finds participant matching user.id', () => {
+    mockAuth.user = { id: 'user-1' }
+    const { result } = renderHook(() => useMyParticipant())
+    expect(result.current.myParticipant?.name).toBe('Alice')
+    expect(result.current.isLinked).toBe(true)
+  })
+
+  it('returns null when user has no matching participant', () => {
+    mockAuth.user = { id: 'user-99' }
+    const { result } = renderHook(() => useMyParticipant())
+    expect(result.current.myParticipant).toBeNull()
+    expect(result.current.isLinked).toBe(false)
+  })
+})

--- a/src/lib/activeTripDetection.test.ts
+++ b/src/lib/activeTripDetection.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getActiveTripId } from './activeTripDetection'
+import { buildTrip } from '@/test/factories'
+
+describe('getActiveTripId', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Set "today" to 2025-07-15
+    vi.setSystemTime(new Date('2025-07-15T12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns null for empty trip list', () => {
+    expect(getActiveTripId([])).toBeNull()
+  })
+
+  it('returns trip that is currently active', () => {
+    const trip = buildTrip({
+      id: 'active',
+      start_date: '2025-07-10',
+      end_date: '2025-07-20',
+    })
+    expect(getActiveTripId([trip])).toBe('active')
+  })
+
+  it('picks the soonest-ending trip when multiple are active', () => {
+    const trip1 = buildTrip({
+      id: 'ends-sooner',
+      start_date: '2025-07-10',
+      end_date: '2025-07-18',
+    })
+    const trip2 = buildTrip({
+      id: 'ends-later',
+      start_date: '2025-07-01',
+      end_date: '2025-07-25',
+    })
+    expect(getActiveTripId([trip1, trip2])).toBe('ends-sooner')
+  })
+
+  it('falls back to the nearest upcoming trip when no active trip', () => {
+    const trip = buildTrip({
+      id: 'upcoming',
+      start_date: '2025-07-20',
+      end_date: '2025-07-30',
+    })
+    expect(getActiveTripId([trip])).toBe('upcoming')
+  })
+
+  it('picks the nearest upcoming trip among multiple', () => {
+    const far = buildTrip({
+      id: 'far',
+      start_date: '2025-08-10',
+      end_date: '2025-08-20',
+    })
+    const near = buildTrip({
+      id: 'near',
+      start_date: '2025-07-20',
+      end_date: '2025-07-25',
+    })
+    expect(getActiveTripId([far, near])).toBe('near')
+  })
+
+  it('returns null when all trips are in the past', () => {
+    const pastTrip = buildTrip({
+      id: 'past',
+      start_date: '2025-06-01',
+      end_date: '2025-06-10',
+    })
+    expect(getActiveTripId([pastTrip])).toBeNull()
+  })
+
+  it('includes start date as active (inclusive start)', () => {
+    const trip = buildTrip({
+      id: 'starts-today',
+      start_date: '2025-07-15',
+      end_date: '2025-07-20',
+    })
+    expect(getActiveTripId([trip])).toBe('starts-today')
+  })
+
+  it('includes end date as active (inclusive end)', () => {
+    const trip = buildTrip({
+      id: 'ends-today',
+      start_date: '2025-07-10',
+      end_date: '2025-07-15',
+    })
+    expect(getActiveTripId([trip])).toBe('ends-today')
+  })
+})

--- a/src/lib/adminAuth.test.ts
+++ b/src/lib/adminAuth.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { authenticateAdmin, isAdminAuthenticated, logoutAdmin } from './adminAuth'
+
+describe('adminAuth', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('starts unauthenticated', () => {
+    expect(isAdminAuthenticated()).toBe(false)
+  })
+
+  it('authenticates with correct password', () => {
+    // VITE_ADMIN_PASSWORD is set to 'test-admin-pw' in setup.ts
+    expect(authenticateAdmin('test-admin-pw')).toBe(true)
+    expect(isAdminAuthenticated()).toBe(true)
+  })
+
+  it('rejects wrong password', () => {
+    expect(authenticateAdmin('wrong')).toBe(false)
+    expect(isAdminAuthenticated()).toBe(false)
+  })
+
+  it('logs out', () => {
+    authenticateAdmin('test-admin-pw')
+    logoutAdmin()
+    expect(isAdminAuthenticated()).toBe(false)
+  })
+})

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getDayContext, formatDayHeader, getDayNumber, generateDateRange } from './dateUtils'
+
+describe('getDayContext', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Set "today" to 2025-07-15
+    vi.setSystemTime(new Date('2025-07-15T12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns "today" for today\'s date', () => {
+    expect(getDayContext('2025-07-15')).toBe('today')
+  })
+
+  it('returns "tomorrow" for the next day', () => {
+    expect(getDayContext('2025-07-16')).toBe('tomorrow')
+  })
+
+  it('returns "past" for a past date', () => {
+    expect(getDayContext('2025-07-10')).toBe('past')
+  })
+
+  it('returns "future" for a date beyond tomorrow', () => {
+    expect(getDayContext('2025-07-20')).toBe('future')
+  })
+})
+
+describe('formatDayHeader', () => {
+  it('formats date as "Day, Mon DD"', () => {
+    const formatted = formatDayHeader('2025-11-23')
+    // Different environments may format slightly differently,
+    // but should contain the weekday abbreviation and the day
+    expect(formatted).toContain('23')
+  })
+})
+
+describe('getDayNumber', () => {
+  it('returns 1 for the start date', () => {
+    expect(getDayNumber('2025-07-01', '2025-07-01')).toBe(1)
+  })
+
+  it('returns correct day number for offset', () => {
+    expect(getDayNumber('2025-07-05', '2025-07-01')).toBe(5)
+  })
+
+  it('returns correct day number for last day of trip', () => {
+    expect(getDayNumber('2025-07-10', '2025-07-01')).toBe(10)
+  })
+})
+
+describe('generateDateRange', () => {
+  it('generates inclusive range', () => {
+    const range = generateDateRange('2025-07-01', '2025-07-03')
+    expect(range).toEqual(['2025-07-01', '2025-07-02', '2025-07-03'])
+  })
+
+  it('returns single date when start equals end', () => {
+    const range = generateDateRange('2025-07-01', '2025-07-01')
+    expect(range).toEqual(['2025-07-01'])
+  })
+
+  it('returns empty array when start > end', () => {
+    const range = generateDateRange('2025-07-10', '2025-07-01')
+    expect(range).toEqual([])
+  })
+
+  it('handles month boundaries', () => {
+    const range = generateDateRange('2025-07-30', '2025-08-02')
+    expect(range).toEqual(['2025-07-30', '2025-07-31', '2025-08-01', '2025-08-02'])
+  })
+})

--- a/src/lib/myTripsStorage.test.ts
+++ b/src/lib/myTripsStorage.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getMyTrips,
+  addToMyTrips,
+  removeFromMyTrips,
+  isInMyTrips,
+  clearMyTrips,
+  getMyTripsCount,
+} from './myTripsStorage'
+
+describe('myTripsStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns empty array when nothing stored', () => {
+    expect(getMyTrips()).toEqual([])
+  })
+
+  it('adds a trip', () => {
+    addToMyTrips('trip-code-Ab1234', 'My Trip')
+    const trips = getMyTrips()
+    expect(trips).toHaveLength(1)
+    expect(trips[0].tripCode).toBe('trip-code-Ab1234')
+    expect(trips[0].tripName).toBe('My Trip')
+  })
+
+  it('updates existing trip name and lastAccessed', () => {
+    addToMyTrips('trip-code-Ab1234', 'Old Name')
+
+    // Re-add with new name
+    addToMyTrips('trip-code-Ab1234', 'New Name')
+    const trips = getMyTrips()
+    expect(trips).toHaveLength(1)
+    expect(trips[0].tripName).toBe('New Name')
+  })
+
+  it('removes a trip', () => {
+    addToMyTrips('trip-1-Ab1234', 'Trip 1')
+    addToMyTrips('trip-2-Ab1234', 'Trip 2')
+    removeFromMyTrips('trip-1-Ab1234')
+    const trips = getMyTrips()
+    expect(trips).toHaveLength(1)
+    expect(trips[0].tripCode).toBe('trip-2-Ab1234')
+  })
+
+  it('sorts by lastAccessed descending', () => {
+    addToMyTrips('trip-old-Ab1234', 'Old')
+    addToMyTrips('trip-new-Ab1234', 'New')
+    // Re-access the old trip to make it most recent
+    addToMyTrips('trip-old-Ab1234', 'Old')
+    const trips = getMyTrips()
+    expect(trips[0].tripCode).toBe('trip-old-Ab1234')
+  })
+
+  it('checks if trip is in list', () => {
+    addToMyTrips('trip-code-Ab1234', 'Test')
+    expect(isInMyTrips('trip-code-Ab1234')).toBe(true)
+    expect(isInMyTrips('other-Ab1234')).toBe(false)
+  })
+
+  it('counts trips', () => {
+    expect(getMyTripsCount()).toBe(0)
+    addToMyTrips('t1-Ab1234', 'T1')
+    addToMyTrips('t2-Ab1234', 'T2')
+    expect(getMyTripsCount()).toBe(2)
+  })
+
+  it('clears all trips', () => {
+    addToMyTrips('t1-Ab1234', 'T1')
+    clearMyTrips()
+    expect(getMyTrips()).toEqual([])
+  })
+
+  it('handles corrupted JSON gracefully', () => {
+    localStorage.setItem('trip-splitter:my-trips', '{invalid json}')
+    expect(getMyTrips()).toEqual([])
+  })
+})

--- a/src/lib/tripCodeGenerator.test.ts
+++ b/src/lib/tripCodeGenerator.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createTripSlug,
+  generateTripCode,
+  isValidTripCode,
+  extractTripCodeFromUrl,
+  generateShareableUrl,
+} from './tripCodeGenerator'
+
+describe('createTripSlug', () => {
+  it('converts to lowercase', () => {
+    expect(createTripSlug('Summer 2025')).toBe('summer-2025')
+  })
+
+  it('replaces special characters with hyphens', () => {
+    expect(createTripSlug('Beach Trip!')).toBe('beach-trip')
+  })
+
+  it('strips leading and trailing hyphens', () => {
+    expect(createTripSlug('!!!hello!!!')).toBe('hello')
+  })
+
+  it('truncates to 30 characters', () => {
+    const long = 'a'.repeat(50)
+    expect(createTripSlug(long).length).toBeLessThanOrEqual(30)
+  })
+
+  it('handles empty string', () => {
+    expect(createTripSlug('')).toBe('')
+  })
+
+  it('collapses multiple special chars into single hyphen', () => {
+    expect(createTripSlug('hello   world')).toBe('hello-world')
+  })
+})
+
+describe('generateTripCode', () => {
+  it('produces format slug-XXXXXX', () => {
+    const code = generateTripCode('Summer 2025')
+    expect(code).toMatch(/^summer-2025-[a-zA-Z0-9]{6}$/)
+  })
+
+  it('generates unique codes across calls', () => {
+    const codes = new Set(Array.from({ length: 10 }, () => generateTripCode('Test')))
+    expect(codes.size).toBe(10)
+  })
+})
+
+describe('isValidTripCode', () => {
+  it('accepts valid trip codes', () => {
+    expect(isValidTripCode('summer-2025-a3x9k2')).toBe(true)
+    expect(isValidTripCode('my-trip-Abc123')).toBe(true)
+  })
+
+  it('rejects invalid formats', () => {
+    expect(isValidTripCode('invalid')).toBe(false)
+    expect(isValidTripCode('')).toBe(false)
+    expect(isValidTripCode('abc-12345')).toBe(false) // only 5 chars
+    expect(isValidTripCode('abc-1234567')).toBe(false) // 7 chars
+  })
+})
+
+describe('extractTripCodeFromUrl', () => {
+  it('extracts from full URL with /t/', () => {
+    const result = extractTripCodeFromUrl('https://split.xtian.me/t/summer-2025-a3x9k2')
+    expect(result).toBe('summer-2025-a3x9k2')
+  })
+
+  it('returns direct code if valid', () => {
+    expect(extractTripCodeFromUrl('summer-2025-a3x9k2')).toBe('summer-2025-a3x9k2')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(extractTripCodeFromUrl('not-valid')).toBeNull()
+    expect(extractTripCodeFromUrl('https://example.com/other')).toBeNull()
+  })
+})
+
+describe('generateShareableUrl', () => {
+  it('produces correct URL format', () => {
+    const url = generateShareableUrl('summer-2025-a3x9k2', 'https://split.xtian.me')
+    expect(url).toBe('https://split.xtian.me/t/summer-2025-a3x9k2')
+  })
+})

--- a/src/lib/userPreferencesStorage.test.ts
+++ b/src/lib/userPreferencesStorage.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getLocalPreferences, setLocalPreferences } from './userPreferencesStorage'
+
+describe('userPreferencesStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns default mode based on window width', () => {
+    // jsdom has a default window width that we can check against
+    const prefs = getLocalPreferences()
+    // Default mode depends on window.innerWidth < 1024
+    const expectedMode = window.innerWidth < 1024 ? 'quick' : 'full'
+    expect(prefs.preferredMode).toBe(expectedMode)
+    expect(prefs.defaultTripId).toBeNull()
+  })
+
+  it('merges stored preferences with defaults', () => {
+    localStorage.setItem(
+      'trip-splitter:user-preferences',
+      JSON.stringify({ preferredMode: 'full', defaultTripId: 'trip-123' })
+    )
+    const prefs = getLocalPreferences()
+    expect(prefs.preferredMode).toBe('full')
+    expect(prefs.defaultTripId).toBe('trip-123')
+  })
+
+  it('sets and persists preferences', () => {
+    setLocalPreferences({ preferredMode: 'quick' })
+    const prefs = getLocalPreferences()
+    expect(prefs.preferredMode).toBe('quick')
+  })
+
+  it('merges partial updates without losing other fields', () => {
+    setLocalPreferences({ preferredMode: 'full', defaultTripId: 'trip-1' })
+    setLocalPreferences({ preferredMode: 'quick' })
+    const prefs = getLocalPreferences()
+    expect(prefs.preferredMode).toBe('quick')
+    expect(prefs.defaultTripId).toBe('trip-1')
+  })
+
+  it('handles corrupted JSON gracefully', () => {
+    localStorage.setItem('trip-splitter:user-preferences', 'not-json')
+    const prefs = getLocalPreferences()
+    expect(prefs).toHaveProperty('preferredMode')
+    expect(prefs).toHaveProperty('defaultTripId')
+  })
+})

--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ConditionalHomePage } from './ConditionalHomePage'
+import { buildTrip } from '@/test/factories'
+
+// Track navigation
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+// Mock AuthContext
+const mockAuth = {
+  user: null as any,
+  userProfile: null,
+  session: null,
+  loading: false,
+  signInWithGoogle: vi.fn(),
+  signOut: vi.fn(),
+  updateBankDetails: vi.fn(),
+}
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+// Mock UserPreferencesContext
+const mockPrefs = {
+  mode: 'full' as 'full' | 'quick',
+  defaultTripId: null,
+  setMode: vi.fn(),
+  setDefaultTripId: vi.fn(),
+  loading: false,
+}
+vi.mock('@/contexts/UserPreferencesContext', () => ({
+  useUserPreferences: () => mockPrefs,
+}))
+
+// Mock TripContext
+const mockTrips = {
+  trips: [] as any[],
+  loading: false,
+  error: null,
+  getTripById: vi.fn(),
+  getTripByCode: vi.fn(),
+  createTrip: vi.fn(),
+  updateTrip: vi.fn(),
+  deleteTrip: vi.fn(),
+  refreshTrips: vi.fn(),
+}
+vi.mock('@/contexts/TripContext', () => ({
+  useTripContext: () => mockTrips,
+}))
+
+// Mock activeTripDetection
+vi.mock('@/lib/activeTripDetection', () => ({
+  getActiveTripId: vi.fn(() => null),
+}))
+
+// Mock myTripsStorage
+vi.mock('@/lib/myTripsStorage', () => ({
+  getMyTrips: () => [{ tripCode: 'summer-trip-Ab1234' }],
+}))
+
+// Mock HomePage
+vi.mock('./HomePage', () => ({
+  HomePage: () => <div data-testid="home-page">Full Mode Home</div>,
+}))
+
+import { getActiveTripId } from '@/lib/activeTripDetection'
+
+describe('ConditionalHomePage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    mockAuth.loading = false
+    mockPrefs.loading = false
+    mockPrefs.mode = 'full'
+    mockTrips.loading = false
+    mockTrips.trips = []
+    vi.mocked(getActiveTripId).mockReturnValue(null)
+  })
+
+  it('shows spinner while loading', () => {
+    mockAuth.loading = true
+
+    render(
+      <MemoryRouter>
+        <ConditionalHomePage />
+      </MemoryRouter>
+    )
+
+    // Should show loading spinner (svg element with animate-spin class)
+    const spinner = document.querySelector('.animate-spin')
+    expect(spinner).toBeTruthy()
+  })
+
+  it('renders HomePage in full mode', async () => {
+    mockPrefs.mode = 'full'
+
+    render(
+      <MemoryRouter>
+        <ConditionalHomePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    })
+  })
+
+  it('navigates to /t/{code}/quick in quick mode with active trip', async () => {
+    mockPrefs.mode = 'quick'
+    const trip = buildTrip({
+      id: 'trip-1',
+      trip_code: 'summer-trip-Ab1234',
+    })
+    mockTrips.trips = [trip]
+    vi.mocked(getActiveTripId).mockReturnValue('trip-1')
+
+    render(
+      <MemoryRouter>
+        <ConditionalHomePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/t/summer-trip-Ab1234/quick',
+        { replace: true }
+      )
+    })
+  })
+
+  it('navigates to /quick in quick mode with no active trip', async () => {
+    mockPrefs.mode = 'quick'
+    vi.mocked(getActiveTripId).mockReturnValue(null)
+
+    render(
+      <MemoryRouter>
+        <ConditionalHomePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/quick', { replace: true })
+    })
+  })
+})

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect } from 'vitest'
+import {
+  convertToBaseCurrency,
+  calculateExpenseShares,
+  calculateBalances,
+  getBalanceForEntity,
+  formatBalance,
+  getBalanceColorClass,
+} from './balanceCalculator'
+import { buildParticipant, buildFamily, buildExpense, buildSettlement } from '@/test/factories'
+import type { Participant, Family } from '@/types/participant'
+
+// ─── convertToBaseCurrency ────────────────────────────────────────
+describe('convertToBaseCurrency', () => {
+  it('returns the amount unchanged when currencies are the same', () => {
+    expect(convertToBaseCurrency(100, 'EUR', 'EUR', {})).toBe(100)
+  })
+
+  it('converts using the provided exchange rate', () => {
+    // 385 THB / 38.5 = 10 EUR
+    expect(convertToBaseCurrency(385, 'THB', 'EUR', { THB: 38.5 })).toBe(10)
+  })
+
+  it('falls back to original amount when rate is missing', () => {
+    expect(convertToBaseCurrency(100, 'USD', 'EUR', {})).toBe(100)
+  })
+
+  it('falls back to original amount when rate is zero', () => {
+    expect(convertToBaseCurrency(100, 'USD', 'EUR', { USD: 0 })).toBe(100)
+  })
+})
+
+// ─── calculateExpenseShares ───────────────────────────────────────
+describe('calculateExpenseShares', () => {
+  const p1 = buildParticipant({ id: 'p1', name: 'Alice' })
+  const p2 = buildParticipant({ id: 'p2', name: 'Bob' })
+  const p3 = buildParticipant({ id: 'p3', name: 'Carol', family_id: 'f1' })
+  const p4 = buildParticipant({ id: 'p4', name: 'Dave', family_id: 'f1' })
+  const p5 = buildParticipant({ id: 'p5', name: 'Eve', family_id: 'f2' })
+
+  const f1 = buildFamily({ id: 'f1', family_name: 'Smith', adults: 2, children: 1 })
+  const f2 = buildFamily({ id: 'f2', family_name: 'Jones', adults: 1, children: 0 })
+
+  const participants: Participant[] = [p1, p2, p3, p4, p5]
+  const families: Family[] = [f1, f2]
+
+  // --- individuals distribution ---
+  describe('individuals + equal', () => {
+    it('splits evenly among listed individuals', () => {
+      const expense = buildExpense({
+        amount: 90,
+        distribution: { type: 'individuals', participants: ['p1', 'p2', 'p3'] },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'individuals')
+      expect(shares.get('p1')).toBe(30)
+      expect(shares.get('p2')).toBe(30)
+      expect(shares.get('p3')).toBe(30)
+    })
+
+    it('aggregates to family in families tracking mode', () => {
+      const expense = buildExpense({
+        amount: 100,
+        distribution: { type: 'individuals', participants: ['p3', 'p4'] },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'families')
+      // Both p3 and p4 belong to f1, so family f1 gets the full 100
+      expect(shares.get('f1')).toBe(100)
+    })
+  })
+
+  describe('individuals + percentage', () => {
+    it('splits by percentage', () => {
+      const expense = buildExpense({
+        amount: 200,
+        distribution: {
+          type: 'individuals',
+          participants: ['p1', 'p2'],
+          splitMode: 'percentage',
+          participantSplits: [
+            { participantId: 'p1', value: 60 },
+            { participantId: 'p2', value: 40 },
+          ],
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'individuals')
+      expect(shares.get('p1')).toBe(120)
+      expect(shares.get('p2')).toBe(80)
+    })
+  })
+
+  describe('individuals + amount', () => {
+    it('splits by custom amounts', () => {
+      const expense = buildExpense({
+        amount: 150,
+        distribution: {
+          type: 'individuals',
+          participants: ['p1', 'p2'],
+          splitMode: 'amount',
+          participantSplits: [
+            { participantId: 'p1', value: 100 },
+            { participantId: 'p2', value: 50 },
+          ],
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'individuals')
+      expect(shares.get('p1')).toBe(100)
+      expect(shares.get('p2')).toBe(50)
+    })
+  })
+
+  // --- families distribution ---
+  describe('families + equal (as units)', () => {
+    it('splits evenly among families as units by default', () => {
+      const expense = buildExpense({
+        amount: 200,
+        distribution: { type: 'families', families: ['f1', 'f2'] },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'families')
+      expect(shares.get('f1')).toBe(100)
+      expect(shares.get('f2')).toBe(100)
+    })
+  })
+
+  describe('families + equal (accountForFamilySize)', () => {
+    it('splits proportionally by family size', () => {
+      const expense = buildExpense({
+        amount: 400,
+        distribution: {
+          type: 'families',
+          families: ['f1', 'f2'],
+          accountForFamilySize: true,
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'families')
+      // f1 = 3 people, f2 = 1 person => total 4
+      // f1 gets 400 * 3/4 = 300, f2 gets 400 * 1/4 = 100
+      expect(shares.get('f1')).toBe(300)
+      expect(shares.get('f2')).toBe(100)
+    })
+  })
+
+  describe('families + percentage', () => {
+    it('splits families by percentage', () => {
+      const expense = buildExpense({
+        amount: 500,
+        distribution: {
+          type: 'families',
+          families: ['f1', 'f2'],
+          splitMode: 'percentage',
+          familySplits: [
+            { familyId: 'f1', value: 70 },
+            { familyId: 'f2', value: 30 },
+          ],
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'families')
+      expect(shares.get('f1')).toBe(350)
+      expect(shares.get('f2')).toBe(150)
+    })
+  })
+
+  describe('families + amount', () => {
+    it('splits families by custom amount', () => {
+      const expense = buildExpense({
+        amount: 300,
+        distribution: {
+          type: 'families',
+          families: ['f1', 'f2'],
+          splitMode: 'amount',
+          familySplits: [
+            { familyId: 'f1', value: 200 },
+            { familyId: 'f2', value: 100 },
+          ],
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'families')
+      expect(shares.get('f1')).toBe(200)
+      expect(shares.get('f2')).toBe(100)
+    })
+  })
+
+  // --- mixed distribution ---
+  describe('mixed + equal', () => {
+    it('deduplicates family members from standalone participants', () => {
+      // p1 is standalone (no family), p3 belongs to f1
+      // We list both f1 AND p3 — p3 should be deduped
+      const expense = buildExpense({
+        amount: 400,
+        distribution: {
+          type: 'mixed',
+          families: ['f1'],
+          participants: ['p1', 'p3'], // p3 is in f1, should be deduped
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'individuals')
+      // f1 = 3 people + p1 = 1 standalone => total 4 people
+      // perPerson = 400 / 4 = 100
+      // f1 = 300, p1 = 100
+      expect(shares.get('f1')).toBe(300)
+      expect(shares.get('p1')).toBe(100)
+      expect(shares.has('p3')).toBe(false) // p3 is counted under f1
+    })
+  })
+
+  describe('mixed + percentage', () => {
+    it('splits by percentage for families and standalone participants', () => {
+      const expense = buildExpense({
+        amount: 1000,
+        distribution: {
+          type: 'mixed',
+          families: ['f1'],
+          participants: ['p1'],
+          splitMode: 'percentage',
+          familySplits: [{ familyId: 'f1', value: 80 }],
+          participantSplits: [{ participantId: 'p1', value: 20 }],
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'individuals')
+      expect(shares.get('f1')).toBe(800)
+      expect(shares.get('p1')).toBe(200)
+    })
+  })
+
+  describe('mixed + amount', () => {
+    it('splits by custom amount for families and standalone participants', () => {
+      const expense = buildExpense({
+        amount: 600,
+        distribution: {
+          type: 'mixed',
+          families: ['f1'],
+          participants: ['p1'],
+          splitMode: 'amount',
+          familySplits: [{ familyId: 'f1', value: 400 }],
+          participantSplits: [{ participantId: 'p1', value: 200 }],
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, families, 'individuals')
+      expect(shares.get('f1')).toBe(400)
+      expect(shares.get('p1')).toBe(200)
+    })
+  })
+})
+
+// ─── calculateBalances ────────────────────────────────────────────
+describe('calculateBalances', () => {
+  const alice = buildParticipant({ id: 'p1', name: 'Alice' })
+  const bob = buildParticipant({ id: 'p2', name: 'Bob' })
+  const participants = [alice, bob]
+  const families: Family[] = []
+
+  it('initializes all entities with zero balances when no expenses', () => {
+    const result = calculateBalances([], participants, families, 'individuals')
+    expect(result.balances).toHaveLength(2)
+    expect(result.totalExpenses).toBe(0)
+    result.balances.forEach(b => {
+      expect(b.totalPaid).toBe(0)
+      expect(b.totalShare).toBe(0)
+      expect(b.balance).toBe(0)
+    })
+  })
+
+  it('credits payer and debits shares correctly', () => {
+    const expense = buildExpense({
+      amount: 100,
+      paid_by: 'p1',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+    const result = calculateBalances([expense], participants, families, 'individuals')
+    const aliceBalance = result.balances.find(b => b.id === 'p1')!
+    const bobBalance = result.balances.find(b => b.id === 'p2')!
+
+    expect(aliceBalance.totalPaid).toBe(100)
+    expect(aliceBalance.totalShare).toBe(50)
+    expect(aliceBalance.balance).toBe(50)  // owed 50
+
+    expect(bobBalance.totalPaid).toBe(0)
+    expect(bobBalance.totalShare).toBe(50)
+    expect(bobBalance.balance).toBe(-50) // owes 50
+  })
+
+  it('applies currency conversion', () => {
+    const expense = buildExpense({
+      amount: 200,
+      currency: 'USD',
+      paid_by: 'p1',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+    const result = calculateBalances(
+      [expense], participants, families, 'individuals',
+      [], 'EUR', { USD: 1.1 }
+    )
+    const converted = 200 / 1.1
+    expect(result.totalExpenses).toBeCloseTo(converted, 2)
+  })
+
+  it('applies settlements to balances', () => {
+    const expense = buildExpense({
+      amount: 100,
+      paid_by: 'p1',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+    // Bob pays Alice 50 to settle up
+    const settlement = buildSettlement({
+      from_participant_id: 'p2',
+      to_participant_id: 'p1',
+      amount: 50,
+      currency: 'EUR',
+    })
+    const result = calculateBalances(
+      [expense], participants, families, 'individuals', [settlement]
+    )
+    const aliceBalance = result.balances.find(b => b.id === 'p1')!
+    const bobBalance = result.balances.find(b => b.id === 'p2')!
+
+    // Alice: paid 100, share 50, balance = 50, settlement -50 => 0
+    // But settlement changes: Alice receives 50 so balance decreases by 50
+    // Bob: paid 0, share 50, balance = -50, settlement +50 => 0
+    expect(aliceBalance.balance).toBeCloseTo(0, 2)
+    expect(bobBalance.balance).toBeCloseTo(0, 2)
+  })
+
+  it('sorts by balance descending', () => {
+    const expense = buildExpense({
+      amount: 100,
+      paid_by: 'p1',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+    const result = calculateBalances([expense], participants, families, 'individuals')
+    expect(result.balances[0].balance).toBeGreaterThanOrEqual(result.balances[1].balance)
+  })
+
+  it('calculates totalExpenses', () => {
+    const expenses = [
+      buildExpense({ amount: 100 }),
+      buildExpense({ amount: 200 }),
+    ]
+    const result = calculateBalances(expenses, participants, families, 'individuals')
+    expect(result.totalExpenses).toBe(300)
+  })
+
+  it('suggests the participant with the lowest balance as next payer', () => {
+    const expense = buildExpense({
+      amount: 100,
+      paid_by: 'p1',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+    const result = calculateBalances([expense], participants, families, 'individuals')
+    expect(result.suggestedNextPayer?.id).toBe('p2') // Bob owes the most
+  })
+
+  it('handles families tracking mode with standalone participants', () => {
+    const famP1 = buildParticipant({ id: 'fp1', name: 'FamAlice', family_id: 'f1' })
+    const standalone = buildParticipant({ id: 'sp1', name: 'Standalone', family_id: null })
+    const fam = buildFamily({ id: 'f1', family_name: 'Smith', adults: 2, children: 0 })
+
+    const expense = buildExpense({
+      amount: 90,
+      paid_by: 'fp1',
+      distribution: { type: 'families', families: ['f1'] },
+    })
+
+    const result = calculateBalances(
+      [expense], [famP1, standalone], [fam], 'families'
+    )
+    // Should have entries for family f1 and standalone sp1
+    expect(result.balances.some(b => b.id === 'f1')).toBe(true)
+    expect(result.balances.some(b => b.id === 'sp1')).toBe(true)
+  })
+})
+
+// ─── getBalanceForEntity ──────────────────────────────────────────
+describe('getBalanceForEntity', () => {
+  const balances = [
+    { id: 'p1', name: 'Alice', totalPaid: 100, totalShare: 50, balance: 50, isFamily: false },
+  ]
+
+  it('returns balance when entity is found', () => {
+    expect(getBalanceForEntity('p1', balances)).toEqual(balances[0])
+  })
+
+  it('returns null when entity is not found', () => {
+    expect(getBalanceForEntity('p99', balances)).toBeNull()
+  })
+})
+
+// ─── formatBalance ────────────────────────────────────────────────
+describe('formatBalance', () => {
+  it('formats positive balance with + prefix', () => {
+    const formatted = formatBalance(50, 'EUR')
+    expect(formatted).toMatch(/^\+/)
+    expect(formatted).toContain('50')
+  })
+
+  it('formats negative balance with - prefix', () => {
+    const formatted = formatBalance(-50, 'EUR')
+    expect(formatted).toMatch(/^-/)
+    expect(formatted).toContain('50')
+  })
+
+  it('formats zero balance without sign', () => {
+    const formatted = formatBalance(0, 'EUR')
+    expect(formatted).not.toMatch(/^[+-]/)
+  })
+})
+
+// ─── getBalanceColorClass ─────────────────────────────────────────
+describe('getBalanceColorClass', () => {
+  it('returns green for positive balance', () => {
+    expect(getBalanceColorClass(10)).toContain('green')
+  })
+
+  it('returns red for negative balance', () => {
+    expect(getBalanceColorClass(-10)).toContain('red')
+  })
+
+  it('returns gray for zero balance', () => {
+    expect(getBalanceColorClass(0)).toContain('gray')
+  })
+})

--- a/src/services/mealExpenseLinkService.test.ts
+++ b/src/services/mealExpenseLinkService.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { canLinkExpenseToMeal } from './mealExpenseLinkService'
+import { buildExpense } from '@/test/factories'
+
+// Only testing the pure function — async Supabase functions are integration tests
+describe('canLinkExpenseToMeal', () => {
+  it('returns true for Food category', () => {
+    const expense = buildExpense({ category: 'Food' })
+    expect(canLinkExpenseToMeal(expense)).toBe(true)
+  })
+
+  it('returns false for other categories', () => {
+    expect(canLinkExpenseToMeal(buildExpense({ category: 'Transport' }))).toBe(false)
+    expect(canLinkExpenseToMeal(buildExpense({ category: 'Accommodation' }))).toBe(false)
+    expect(canLinkExpenseToMeal(buildExpense({ category: 'Activities' }))).toBe(false)
+    expect(canLinkExpenseToMeal(buildExpense({ category: 'Other' }))).toBe(false)
+  })
+})

--- a/src/services/settlementOptimizer.test.ts
+++ b/src/services/settlementOptimizer.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateOptimalSettlement,
+  formatSettlementTransaction,
+  areBalancesSettled,
+  calculateTotalDebt,
+  calculateTotalCredit,
+  SettlementTransaction,
+} from './settlementOptimizer'
+import type { ParticipantBalance } from './balanceCalculator'
+
+function balance(id: string, name: string, bal: number): ParticipantBalance {
+  return { id, name, totalPaid: 0, totalShare: 0, balance: bal, isFamily: false }
+}
+
+// ─── calculateOptimalSettlement ───────────────────────────────────
+describe('calculateOptimalSettlement', () => {
+  it('produces no transactions when all balances are zero', () => {
+    const balances = [balance('a', 'A', 0), balance('b', 'B', 0)]
+    const result = calculateOptimalSettlement(balances)
+    expect(result.transactions).toHaveLength(0)
+    expect(result.totalTransactions).toBe(0)
+  })
+
+  it('handles 2-person settlement', () => {
+    const balances = [balance('a', 'A', 50), balance('b', 'B', -50)]
+    const result = calculateOptimalSettlement(balances)
+    expect(result.transactions).toHaveLength(1)
+    expect(result.transactions[0].fromId).toBe('b')
+    expect(result.transactions[0].toId).toBe('a')
+    expect(result.transactions[0].amount).toBe(50)
+  })
+
+  it('minimizes transactions with 3 people', () => {
+    // A = +60, B = -40, C = -20
+    const balances = [balance('a', 'A', 60), balance('b', 'B', -40), balance('c', 'C', -20)]
+    const result = calculateOptimalSettlement(balances)
+    // Optimal: B pays A 40, C pays A 20 => 2 transactions
+    expect(result.totalTransactions).toBe(2)
+    const totalPaid = result.transactions.reduce((sum, t) => sum + t.amount, 0)
+    expect(totalPaid).toBeCloseTo(60, 2)
+  })
+
+  it('handles partial match', () => {
+    // A = +30, B = +20, C = -50
+    const balances = [balance('a', 'A', 30), balance('b', 'B', 20), balance('c', 'C', -50)]
+    const result = calculateOptimalSettlement(balances)
+    const totalPaid = result.transactions.reduce((sum, t) => sum + t.amount, 0)
+    expect(totalPaid).toBeCloseTo(50, 2)
+  })
+
+  it('handles exact match between debtor and creditor', () => {
+    const balances = [balance('a', 'A', 100), balance('b', 'B', -100)]
+    const result = calculateOptimalSettlement(balances)
+    expect(result.transactions).toHaveLength(1)
+    expect(result.transactions[0].amount).toBe(100)
+  })
+
+  it('handles 4+ participants', () => {
+    const balances = [
+      balance('a', 'A', 100),
+      balance('b', 'B', 50),
+      balance('c', 'C', -80),
+      balance('d', 'D', -70),
+    ]
+    const result = calculateOptimalSettlement(balances)
+    // Total debt = 150, total credit = 150
+    const totalPaid = result.transactions.reduce((sum, t) => sum + t.amount, 0)
+    expect(totalPaid).toBeCloseTo(150, 2)
+  })
+
+  it('ignores balances within 0.01 tolerance', () => {
+    const balances = [balance('a', 'A', 0.005), balance('b', 'B', -0.005)]
+    const result = calculateOptimalSettlement(balances)
+    expect(result.transactions).toHaveLength(0)
+  })
+
+  it('rounds amounts to 2 decimal places', () => {
+    // Create a scenario that might produce floating point issues
+    const balances = [balance('a', 'A', 33.33), balance('b', 'B', -33.33)]
+    const result = calculateOptimalSettlement(balances)
+    result.transactions.forEach(t => {
+      const decimals = t.amount.toString().split('.')[1]?.length ?? 0
+      expect(decimals).toBeLessThanOrEqual(2)
+    })
+  })
+
+  it('uses provided currency', () => {
+    const result = calculateOptimalSettlement([], 'USD')
+    expect(result.currency).toBe('USD')
+  })
+})
+
+// ─── formatSettlementTransaction ──────────────────────────────────
+describe('formatSettlementTransaction', () => {
+  it('formats transaction as readable string', () => {
+    const tx: SettlementTransaction = {
+      fromId: 'b',
+      fromName: 'Bob',
+      toId: 'a',
+      toName: 'Alice',
+      amount: 50,
+      isFromFamily: false,
+      isToFamily: false,
+    }
+    const formatted = formatSettlementTransaction(tx, 'EUR')
+    expect(formatted).toContain('Bob')
+    expect(formatted).toContain('Alice')
+    expect(formatted).toContain('pays')
+  })
+})
+
+// ─── areBalancesSettled ───────────────────────────────────────────
+describe('areBalancesSettled', () => {
+  it('returns true when all balances are within tolerance', () => {
+    const balances = [balance('a', 'A', 0.005), balance('b', 'B', -0.005)]
+    expect(areBalancesSettled(balances)).toBe(true)
+  })
+
+  it('returns false when a balance exceeds tolerance', () => {
+    const balances = [balance('a', 'A', 10), balance('b', 'B', -10)]
+    expect(areBalancesSettled(balances)).toBe(false)
+  })
+
+  it('returns true for empty array', () => {
+    expect(areBalancesSettled([])).toBe(true)
+  })
+})
+
+// ─── calculateTotalDebt / calculateTotalCredit ────────────────────
+describe('calculateTotalDebt', () => {
+  it('sums absolute values of negative balances', () => {
+    const balances = [
+      balance('a', 'A', 30),
+      balance('b', 'B', -20),
+      balance('c', 'C', -10),
+    ]
+    expect(calculateTotalDebt(balances)).toBe(30)
+  })
+})
+
+describe('calculateTotalCredit', () => {
+  it('sums positive balances', () => {
+    const balances = [
+      balance('a', 'A', 30),
+      balance('b', 'B', -20),
+      balance('c', 'C', 10),
+    ]
+    expect(calculateTotalCredit(balances)).toBe(40)
+  })
+})

--- a/src/services/transactionHistoryBuilder.test.ts
+++ b/src/services/transactionHistoryBuilder.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildTransactionHistory } from './transactionHistoryBuilder'
+import { buildParticipant, buildFamily, buildExpense, buildSettlement } from '@/test/factories'
+
+// Mock the balanceCalculator dependency
+vi.mock('@/services/balanceCalculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/balanceCalculator')>()
+  return { ...actual }
+})
+
+describe('buildTransactionHistory', () => {
+  const alice = buildParticipant({ id: 'p1', name: 'Alice' })
+  const bob = buildParticipant({ id: 'p2', name: 'Bob' })
+  const participants = [alice, bob]
+
+  it('returns empty array with no expenses or settlements', () => {
+    const result = buildTransactionHistory([], [], participants, [], alice, 'individuals')
+    expect(result).toHaveLength(0)
+  })
+
+  it('marks expense as you_paid when user is the payer', () => {
+    const expense = buildExpense({
+      paid_by: 'p1',
+      amount: 100,
+      description: 'Dinner',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+
+    const result = buildTransactionHistory(
+      [expense], [], participants, [], alice, 'individuals'
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe('you_paid')
+    expect(result[0].roleAmount).toBe(100)
+    expect(result[0].myShare).toBe(50) // split between 2
+  })
+
+  it('marks expense as your_share when user has a share but did not pay', () => {
+    const expense = buildExpense({
+      paid_by: 'p2',
+      amount: 100,
+      description: 'Lunch',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+
+    const result = buildTransactionHistory(
+      [expense], [], participants, [], alice, 'individuals'
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe('your_share')
+    expect(result[0].roleAmount).toBe(50) // Alice's share
+    expect(result[0].payerName).toBe('Bob')
+  })
+
+  it('excludes expense when user is irrelevant (not payer, no share)', () => {
+    const carol = buildParticipant({ id: 'p3', name: 'Carol' })
+    const expense = buildExpense({
+      paid_by: 'p2',
+      distribution: { type: 'individuals', participants: ['p2', 'p3'] },
+    })
+
+    const result = buildTransactionHistory(
+      [expense], [], [alice, bob, carol], [], alice, 'individuals'
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('marks settlement as you_settled when user is the sender', () => {
+    const settlement = buildSettlement({
+      from_participant_id: 'p1',
+      to_participant_id: 'p2',
+      amount: 50,
+      note: 'Settling up',
+    })
+
+    const result = buildTransactionHistory(
+      [], [settlement], participants, [], alice, 'individuals'
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe('you_settled')
+    expect(result[0].roleAmount).toBe(50)
+    expect(result[0].recipientName).toBe('Bob')
+  })
+
+  it('marks settlement as you_received when user is the recipient', () => {
+    const settlement = buildSettlement({
+      from_participant_id: 'p2',
+      to_participant_id: 'p1',
+      amount: 30,
+    })
+
+    const result = buildTransactionHistory(
+      [], [settlement], participants, [], alice, 'individuals'
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe('you_received')
+    expect(result[0].roleAmount).toBe(30)
+    expect(result[0].payerName).toBe('Bob')
+  })
+
+  it('sorts by date descending', () => {
+    const expense1 = buildExpense({
+      id: 'e1',
+      paid_by: 'p1',
+      expense_date: '2025-07-10',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+    const expense2 = buildExpense({
+      id: 'e2',
+      paid_by: 'p1',
+      expense_date: '2025-07-15',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+
+    const result = buildTransactionHistory(
+      [expense1, expense2], [], participants, [], alice, 'individuals'
+    )
+
+    expect(result[0].date).toBe('2025-07-15')
+    expect(result[1].date).toBe('2025-07-10')
+  })
+
+  it('resolves entity to family in families tracking mode', () => {
+    const famAlice = buildParticipant({ id: 'fp1', name: 'Alice', family_id: 'f1' })
+    const famBob = buildParticipant({ id: 'fp2', name: 'Bob', family_id: 'f2' })
+    const fam1 = buildFamily({ id: 'f1', family_name: 'AliceFamily', adults: 1, children: 0 })
+    const fam2 = buildFamily({ id: 'f2', family_name: 'BobFamily', adults: 1, children: 0 })
+
+    const expense = buildExpense({
+      paid_by: 'fp2',
+      amount: 200,
+      distribution: { type: 'families', families: ['f1', 'f2'] },
+    })
+
+    const result = buildTransactionHistory(
+      [expense], [], [famAlice, famBob], [fam1, fam2], famAlice, 'families'
+    )
+
+    // Alice's family has a share, Bob paid
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe('your_share')
+  })
+})

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,0 +1,92 @@
+import type { Participant, Family } from '@/types/participant'
+import type { Expense, ExpenseDistribution } from '@/types/expense'
+import type { Settlement } from '@/types/settlement'
+import type { Trip } from '@/types/trip'
+
+let _id = 0
+function nextId(): string {
+  return `test-${++_id}`
+}
+
+export function resetFactoryIds() {
+  _id = 0
+}
+
+export function buildParticipant(overrides: Partial<Participant> = {}): Participant {
+  const id = overrides.id ?? nextId()
+  return {
+    id,
+    trip_id: 'trip-1',
+    family_id: null,
+    name: `Participant ${id}`,
+    is_adult: true,
+    ...overrides,
+  }
+}
+
+export function buildFamily(overrides: Partial<Family> = {}): Family {
+  const id = overrides.id ?? nextId()
+  return {
+    id,
+    trip_id: 'trip-1',
+    family_name: `Family ${id}`,
+    adults: 2,
+    children: 1,
+    ...overrides,
+  }
+}
+
+export function buildExpense(
+  overrides: Partial<Expense> & { distribution?: ExpenseDistribution } = {}
+): Expense {
+  const id = overrides.id ?? nextId()
+  return {
+    id,
+    trip_id: 'trip-1',
+    description: `Expense ${id}`,
+    amount: 100,
+    currency: 'EUR',
+    paid_by: 'p1',
+    distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    category: 'Food',
+    expense_date: '2025-07-15',
+    created_at: '2025-07-15T10:00:00Z',
+    updated_at: '2025-07-15T10:00:00Z',
+    ...overrides,
+  }
+}
+
+export function buildSettlement(overrides: Partial<Settlement> = {}): Settlement {
+  const id = overrides.id ?? nextId()
+  return {
+    id,
+    trip_id: 'trip-1',
+    from_participant_id: 'p2',
+    to_participant_id: 'p1',
+    amount: 50,
+    currency: 'EUR',
+    settlement_date: '2025-07-20',
+    created_at: '2025-07-20T10:00:00Z',
+    updated_at: '2025-07-20T10:00:00Z',
+    ...overrides,
+  }
+}
+
+export function buildTrip(overrides: Partial<Trip> = {}): Trip {
+  const id = overrides.id ?? nextId()
+  return {
+    id,
+    trip_code: `test-trip-${id}-Ab1234`,
+    name: `Trip ${id}`,
+    start_date: '2025-07-01',
+    end_date: '2025-07-10',
+    tracking_mode: 'individuals',
+    default_currency: 'EUR',
+    exchange_rates: {},
+    enable_meals: true,
+    enable_shopping: true,
+    default_split_all: true,
+    created_at: '2025-06-01T00:00:00Z',
+    ...overrides,
+  }
+}

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -1,0 +1,61 @@
+import { vi } from 'vitest'
+
+interface MockResponse {
+  data?: unknown
+  error?: { message: string; code?: string } | null
+}
+
+/**
+ * Creates a Proxy-based chainable mock for Supabase client.
+ * Supports any chain depth (.from().select().eq().single() etc.)
+ * and resolves with configurable { data, error }.
+ */
+export function createMockSupabase() {
+  let _response: MockResponse = { data: null, error: null }
+
+  function createChain(): any {
+    const chain: any = new Proxy(() => {}, {
+      get(_target, prop) {
+        if (prop === 'then') {
+          // Make the chain thenable (await support)
+          return (resolve: (v: MockResponse) => void) => resolve(_response)
+        }
+        // Return chain for any property access
+        return (..._args: unknown[]) => createChain()
+      },
+      apply() {
+        return createChain()
+      },
+    })
+    return chain
+  }
+
+  const mockAuth = {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    }),
+    signInWithIdToken: vi.fn().mockResolvedValue({ error: null }),
+    signOut: vi.fn().mockResolvedValue({ error: null }),
+  }
+
+  const mockChannel: { on: ReturnType<typeof vi.fn>; subscribe: ReturnType<typeof vi.fn> } = {
+    on: vi.fn().mockReturnThis(),
+    subscribe: vi.fn(),
+  }
+  mockChannel.subscribe.mockReturnValue(mockChannel)
+
+  const supabase = {
+    from: vi.fn(() => createChain()),
+    auth: mockAuth,
+    channel: vi.fn(() => mockChannel),
+    removeChannel: vi.fn(),
+    mockResponse(response: MockResponse) {
+      _response = response
+    },
+    mockChannel,
+  }
+
+  return supabase
+}

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -1,0 +1,19 @@
+import { render, RenderOptions } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ReactElement } from 'react'
+
+interface RenderWithRouterOptions extends Omit<RenderOptions, 'wrapper'> {
+  route?: string
+}
+
+export function renderWithRouter(
+  ui: ReactElement,
+  { route = '/', ...options }: RenderWithRouterOptions = {}
+) {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+    ),
+    ...options,
+  })
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom'
+import { cleanup } from '@testing-library/react'
+import { afterEach, vi } from 'vitest'
+
+// Stub Supabase env vars so the real module doesn't throw on import
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co')
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key')
+vi.stubEnv('VITE_ADMIN_PASSWORD', 'test-admin-pw')
+
+// Provide a proper Storage mock (Node 22+ has a built-in localStorage
+// that can conflict with jsdom's implementation)
+function createStorage(): Storage {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = String(value) },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    get length() { return Object.keys(store).length },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  }
+}
+
+const localStorageMock = createStorage()
+const sessionStorageMock = createStorage()
+
+vi.stubGlobal('localStorage', localStorageMock)
+vi.stubGlobal('sessionStorage', sessionStorageMock)
+
+// Cleanup after each test
+afterEach(() => {
+  cleanup()
+  localStorageMock.clear()
+  sessionStorageMock.clear()
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+})


### PR DESCRIPTION
## Summary
- Set up Vitest + Testing Library infrastructure from scratch (vitest.config.ts, test setup, mock factories, render helpers)
- Added 20 test files with 139 tests covering business logic, utilities, localStorage, contexts, hooks, and a page component
- All tests passing, build and type-check clean

## Test plan
- [x] `npm run test:run` — all 139 tests pass
- [x] `npm run build` — builds successfully
- [x] `npm run type-check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)