### PR TITLE
Fix iOS decimal input, root URL redirect, and quick page loading (#93, #96, #97)

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -445,6 +445,7 @@ export function ExpenseForm({
         <div className="flex gap-2">
           <Input
             type="number"
+            inputMode="decimal"
             id="amount"
             value={amount}
             onChange={e => setAmount(e.target.value)}
@@ -643,6 +644,7 @@ export function ExpenseForm({
                 {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
                   <Input
                     type="number"
+                    inputMode="decimal"
                     value={participantSplitValues[participant.id] || ''}
                     onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value)}
                     placeholder={splitMode === 'percentage' ? '%' : currency}
@@ -680,6 +682,7 @@ export function ExpenseForm({
                       {splitMode !== 'equal' && selectedFamilies.includes(family.id) && (
                         <Input
                           type="number"
+                          inputMode="decimal"
                           value={familySplitValues[family.id] || ''}
                           onChange={(e) => handleFamilySplitChange(family.id, e.target.value)}
                           placeholder={splitMode === 'percentage' ? '%' : currency}
@@ -718,6 +721,7 @@ export function ExpenseForm({
                         {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
                           <Input
                             type="number"
+                            inputMode="decimal"
                             value={participantSplitValues[participant.id] || ''}
                             onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value)}
                             placeholder={splitMode === 'percentage' ? '%' : currency}
@@ -758,6 +762,7 @@ export function ExpenseForm({
                     {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
                       <Input
                         type="number"
+                        inputMode="decimal"
                         value={participantSplitValues[participant.id] || ''}
                         onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value)}
                         placeholder={splitMode === 'percentage' ? '%' : currency}

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -23,7 +23,13 @@ export function UserPreferencesProvider({ children }: { children: ReactNode }) {
   const [defaultTripId, setDefaultTripIdState] = useState<string | null>(
     () => getLocalPreferences().defaultTripId
   )
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(() => {
+    try {
+      return !localStorage.getItem('trip-splitter:user-preferences')
+    } catch {
+      return true
+    }
+  })
   const hasInitialized = useRef(false)
 
   // Sync from Supabase when user signs in

--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -85,7 +85,7 @@ describe('ConditionalHomePage', () => {
   })
 
   it('shows spinner while loading', () => {
-    mockAuth.loading = true
+    mockPrefs.loading = true
 
     render(
       <MemoryRouter>

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -17,11 +17,11 @@ import { Loader2 } from 'lucide-react'
  */
 export function ConditionalHomePage() {
   const navigate = useNavigate()
-  const { user, loading: authLoading } = useAuth()
+  const { user } = useAuth()
   const { mode, loading: prefsLoading } = useUserPreferences()
   const { trips, loading: tripsLoading } = useTripContext()
 
-  const isLoading = authLoading || prefsLoading || tripsLoading
+  const isLoading = prefsLoading || (mode === 'quick' && tripsLoading)
 
   useEffect(() => {
     if (isLoading) return

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -20,7 +20,7 @@ import {
 
 export function QuickGroupDetailPage() {
   const navigate = useNavigate()
-  const { currentTrip } = useCurrentTrip()
+  const { currentTrip, loading: tripLoading } = useCurrentTrip()
   const { myParticipant, isLinked } = useMyParticipant()
   const { participants, families, loading: participantsLoading } = useParticipantContext()
   const { expenses, loading: expensesLoading } = useExpenseContext()
@@ -31,7 +31,30 @@ export function QuickGroupDetailPage() {
 
   const loading = participantsLoading || expensesLoading || settlementsLoading
 
-  if (!currentTrip) return null
+  if (tripLoading) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-6">
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!currentTrip) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-6">
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-muted-foreground mb-4">Trip not found</p>
+            <Button onClick={() => navigate('/quick')} variant="outline" size="sm">
+              Go to My Trips
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
 
   // Calculate balance (with currency conversion)
   const balanceCalc = calculateBalances(


### PR DESCRIPTION
## Summary
- **#93**: Add `inputMode="decimal"` to all 5 number inputs in `ExpenseForm` so iOS Safari shows a decimal key on the numeric keypad
- **#96**: Initialize `UserPreferencesContext` loading state from localStorage so returning users skip the auth/Supabase round-trip; update `ConditionalHomePage` to render full mode immediately without blocking on auth or trips loading
- **#97**: Show a spinner while trip data loads and a "Trip not found" card with navigation when the trip doesn't exist, instead of a blank white screen

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] All 139 tests pass (`npm run test:run`)
- [ ] Manual: on iOS Safari, verify decimal key appears on expense amount inputs
- [ ] Manual: visit `/` with quick mode in localStorage — should redirect immediately
- [ ] Manual: visit `/t/<code>/quick` directly — should show spinner then content

Closes #93, closes #96, closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)