### PR TITLE
Fix Day Planner nav hidden on mobile when only activities enabled

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -86,7 +86,7 @@ export function Layout() {
       { path: `/t/${tripCode}/dashboard`, label: 'Overview', requiresTrip: true },
       { path: `/t/${tripCode}/expenses`, label: 'Expenses', requiresTrip: true },
     ]
-    if (currentTrip?.enable_meals) {
+    if (currentTrip?.enable_meals || currentTrip?.enable_activities) {
       items.push({ path: `/t/${tripCode}/planner`, label: 'Day Planner', requiresTrip: true })
     }
     if (currentTrip?.enable_shopping) {


### PR DESCRIPTION
## Summary
- Mobile nav only checked `enable_meals` to show the Day Planner item, while desktop nav correctly checked `enable_meals || enable_activities`
- This made the Day Planner inaccessible on mobile when only activities were enabled
- Aligned mobile logic with desktop by adding `|| currentTrip?.enable_activities` to the condition

## Test plan
- [ ] Disable meals, enable activities on a trip
- [ ] Verify Day Planner appears in mobile bottom nav
- [ ] Verify Day Planner still appears when meals enabled but activities disabled
- [ ] Verify Day Planner hidden when both meals and activities disabled

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)