### PR TITLE
Fix Leaflet map rendering on top of Report Issue dialog

### DIFF
--- a/src/components/StayMap.tsx
+++ b/src/components/StayMap.tsx
@@ -63,7 +63,7 @@ function StayMap({ stays }: StayMapProps) {
   const center: L.LatLngTuple = [staysWithCoords[0].latitude, staysWithCoords[0].longitude]
 
   return (
-    <Card className="overflow-hidden">
+    <Card className="overflow-hidden isolate">
       <MapContainer
         center={center}
         zoom={10}


### PR DESCRIPTION
## Summary
- Leaflet's internal CSS uses z-indexes up to 1000, which leaked into the page-level stacking context
- The Report Issue dialog uses `z-50` (= 50), so the map painted over it
- Added `isolation: isolate` to the Card wrapper to create a new stacking context, confining Leaflet's z-indexes within the card

## Test plan
- [ ] Open a trip with stays that have coordinates (so the map renders)
- [ ] Click the Report Issue button in the header
- [ ] Verify the dialog appears fully on top of the map
- [ ] Verify map controls still work when dialog is closed

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)