### PR TITLE
Fix decimal input on iOS with European locale (comma separator)

### DIFF
--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -270,14 +270,14 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
         <Label htmlFor="amount">Amount</Label>
         <div className="flex gap-2">
           <Input
-            type="number"
+            type="text"
+            inputMode="decimal"
             id="amount"
             value={amount}
-            onChange={e => setAmount(e.target.value)}
+            onChange={e => setAmount(e.target.value.replace(',', '.'))}
             className="flex-1 text-2xl h-14 tabular-nums"
             placeholder="0.00"
-            step="0.01"
-            min="0.01"
+            pattern="[0-9]*[.,]?[0-9]*"
             required
             disabled={loading}
           />

--- a/src/components/StayForm.tsx
+++ b/src/components/StayForm.tsx
@@ -163,21 +163,23 @@ export function StayForm({ stay, onSuccess, onCancel }: StayFormProps) {
         <Label>Coordinates (Optional)</Label>
         <div className="grid grid-cols-2 gap-4">
           <Input
-            type="number"
+            type="text"
+            inputMode="decimal"
             id="stay-latitude"
             value={formData.latitude}
-            onChange={(e) => setFormData({ ...formData, latitude: e.target.value })}
+            onChange={(e) => setFormData({ ...formData, latitude: e.target.value.replace(',', '.') })}
             placeholder="Latitude"
-            step="any"
+            pattern="-?[0-9]*[.,]?[0-9]*"
             disabled={submitting}
           />
           <Input
-            type="number"
+            type="text"
+            inputMode="decimal"
             id="stay-longitude"
             value={formData.longitude}
-            onChange={(e) => setFormData({ ...formData, longitude: e.target.value })}
+            onChange={(e) => setFormData({ ...formData, longitude: e.target.value.replace(',', '.') })}
             placeholder="Longitude"
-            step="any"
+            pattern="-?[0-9]*[.,]?[0-9]*"
             disabled={submitting}
           />
         </div>

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -444,15 +444,14 @@ export function ExpenseForm({
         <Label htmlFor="amount">Amount</Label>
         <div className="flex gap-2">
           <Input
-            type="number"
+            type="text"
             inputMode="decimal"
             id="amount"
             value={amount}
-            onChange={e => setAmount(e.target.value)}
+            onChange={e => setAmount(e.target.value.replace(',', '.'))}
             className="flex-1 text-2xl h-14 tabular-nums"
             placeholder="0.00"
-            step="0.01"
-            min="0.01"
+            pattern="[0-9]*[.,]?[0-9]*"
             required
             disabled={loading}
           />
@@ -643,13 +642,12 @@ export function ExpenseForm({
                 </label>
                 {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
                   <Input
-                    type="number"
+                    type="text"
                     inputMode="decimal"
                     value={participantSplitValues[participant.id] || ''}
-                    onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value)}
+                    onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value.replace(',', '.'))}
                     placeholder={splitMode === 'percentage' ? '%' : currency}
-                    step={splitMode === 'percentage' ? '0.1' : '0.01'}
-                    min="0"
+                    pattern="[0-9]*[.,]?[0-9]*"
                     disabled={loading}
                     className="w-24 h-9"
                   />
@@ -681,13 +679,12 @@ export function ExpenseForm({
                       </label>
                       {splitMode !== 'equal' && selectedFamilies.includes(family.id) && (
                         <Input
-                          type="number"
+                          type="text"
                           inputMode="decimal"
                           value={familySplitValues[family.id] || ''}
-                          onChange={(e) => handleFamilySplitChange(family.id, e.target.value)}
+                          onChange={(e) => handleFamilySplitChange(family.id, e.target.value.replace(',', '.'))}
                           placeholder={splitMode === 'percentage' ? '%' : currency}
-                          step={splitMode === 'percentage' ? '0.1' : '0.01'}
-                          min="0"
+                          pattern="[0-9]*[.,]?[0-9]*"
                           disabled={loading}
                           className="w-24 h-9"
                         />

--- a/src/components/expenses/wizard/WizardStep1.tsx
+++ b/src/components/expenses/wizard/WizardStep1.tsx
@@ -78,15 +78,14 @@ export function WizardStep1({
         </Label>
         <div className="flex gap-3">
           <Input
-            type="number"
+            type="text"
             id="amount"
             value={amount}
-            onChange={(e) => onAmountChange(e.target.value)}
+            onChange={(e) => onAmountChange(e.target.value.replace(',', '.'))}
             className="flex-1 text-2xl h-14 tabular-nums"
             placeholder="0.00"
             inputMode="decimal"
-            step="0.01"
-            min="0.01"
+            pattern="[0-9]*[.,]?[0-9]*"
             required
             disabled={disabled}
           />

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -356,16 +356,16 @@ export function ManageTripPage() {
                   1 {currencyDefault || '...'} =
                 </Label>
                 <Input
-                  type="number"
+                  type="text"
+                  inputMode="decimal"
                   value={row.rate}
                   onChange={(e) => {
                     const updated = [...currencyRows]
-                    updated[index] = { ...updated[index], rate: e.target.value }
+                    updated[index] = { ...updated[index], rate: e.target.value.replace(',', '.') }
                     setCurrencyRows(updated)
                   }}
                   placeholder="0.00"
-                  step="0.01"
-                  min="0"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   className="w-28"
                 />
                 <Input


### PR DESCRIPTION
## Summary
- On iOS with European locale, the decimal keyboard shows a comma `,` instead of a dot
- With `type="number"`, typing `5,5` causes `e.target.value` to become `""`, making `parseFloat("")` return `NaN` and preventing form submission
- Changed all monetary/decimal inputs from `type="number"` to `type="text"` with `inputMode="decimal"` and `pattern` attributes
- Added comma-to-dot normalization in all onChange handlers

### Files changed (5):
- **WizardStep1.tsx** — expense amount input
- **ExpenseForm.tsx** — main amount + 4 split value inputs (participant & family)
- **SettlementForm.tsx** — settlement amount (also added missing `inputMode="decimal"`)
- **StayForm.tsx** — latitude/longitude coordinate inputs
- **ManageTripPage.tsx** — exchange rate input

## Test plan
- [ ] On iOS with European locale, enter decimal amounts using comma (e.g., `5,5`)
- [ ] Verify the value is accepted and form submits correctly
- [ ] On desktop, verify decimal amounts with dot still work normally
- [ ] Test expense creation with custom split percentages and amounts
- [ ] Test settlement form amount entry
- [ ] Test coordinate entry in stay form
- [ ] Test exchange rate entry in manage trip page

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)