### PR TITLE
Fix loading flows, form submission reliability, and settlements re-fetch loop

### DIFF
--- a/src/components/quick/QuickExpenseSheet.tsx
+++ b/src/components/quick/QuickExpenseSheet.tsx
@@ -28,12 +28,13 @@ export function QuickExpenseSheet({ open, onOpenChange }: QuickExpenseSheetProps
 
   const handleSubmit = async (input: CreateExpenseInput) => {
     const result = await createExpense(input)
-    if (result) {
-      toast({
-        title: 'Expense added',
-        description: `${input.description} - ${input.currency} ${input.amount.toFixed(2)}`,
-      })
+    if (!result) {
+      throw new Error('Failed to create expense')
     }
+    toast({
+      title: 'Expense added',
+      description: `${input.description} - ${input.currency} ${input.amount.toFixed(2)}`,
+    })
   }
 
   return (

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -100,16 +100,16 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
 
   const handleSubmit = async (input: CreateSettlementInput) => {
     const result = await createSettlement(input)
-    if (result) {
-      toast({
-        title: 'Payment recorded',
-        description: `${input.currency} ${input.amount.toFixed(2)} payment logged`,
-      })
-      // Reset to suggestions view for next time
-      setView('suggestions')
-      setPrefill(null)
-      onOpenChange(false)
+    if (!result) {
+      throw new Error('Failed to record settlement')
     }
+    toast({
+      title: 'Payment recorded',
+      description: `${input.currency} ${input.amount.toFixed(2)} payment logged`,
+    })
+    setView('suggestions')
+    setPrefill(null)
+    onOpenChange(false)
   }
 
   const handleOpenChange = (isOpen: boolean) => {

--- a/src/contexts/ActivityContext.tsx
+++ b/src/contexts/ActivityContext.tsx
@@ -28,13 +28,14 @@ function sortActivities(a: Activity, b: Activity): number {
 export function ActivityProvider({ children }: { children: ReactNode }) {
   const [activities, setActivities] = useState<Activity[]>([])
   const [loading, setLoading] = useState(true)
+  const [initialLoadDone, setInitialLoadDone] = useState(false)
   const { currentTrip, tripCode } = useCurrentTrip()
   const { trips } = useTripContext()
 
   const fetchActivities = async () => {
     if (!currentTrip) {
       setActivities([])
-      setLoading(false)
+      setInitialLoadDone(true)
       return
     }
 
@@ -57,6 +58,7 @@ export function ActivityProvider({ children }: { children: ReactNode }) {
       setActivities([])
     } finally {
       setLoading(false)
+      setInitialLoadDone(true)
     }
   }
 
@@ -66,10 +68,8 @@ export function ActivityProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (tripCode && currentTrip) {
+      setInitialLoadDone(false)
       fetchActivities()
-    } else {
-      setActivities([])
-      setLoading(false)
     }
   }, [tripCode, currentTrip?.id, trips.length])
 
@@ -151,7 +151,7 @@ export function ActivityProvider({ children }: { children: ReactNode }) {
 
   const value: ActivityContextValue = {
     activities,
-    loading,
+    loading: loading || (!!currentTrip && !initialLoadDone),
     createActivity,
     updateActivity,
     deleteActivity,

--- a/src/contexts/MealContext.tsx
+++ b/src/contexts/MealContext.tsx
@@ -22,13 +22,14 @@ const MealContext = createContext<MealContextValue | undefined>(undefined)
 export function MealProvider({ children }: { children: ReactNode }) {
   const [meals, setMeals] = useState<Meal[]>([])
   const [loading, setLoading] = useState(true)
+  const [initialLoadDone, setInitialLoadDone] = useState(false)
   const { currentTrip, tripCode } = useCurrentTrip()
   const { trips } = useTripContext()
 
   const fetchMeals = async () => {
     if (!currentTrip) {
       setMeals([])
-      setLoading(false)
+      setInitialLoadDone(true)
       return
     }
 
@@ -52,6 +53,7 @@ export function MealProvider({ children }: { children: ReactNode }) {
       setMeals([])
     } finally {
       setLoading(false)
+      setInitialLoadDone(true)
     }
   }
 
@@ -61,10 +63,8 @@ export function MealProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (tripCode && currentTrip) {
+      setInitialLoadDone(false)
       fetchMeals()
-    } else {
-      setMeals([])
-      setLoading(false)
     }
   }, [tripCode, currentTrip?.id, trips.length])
 
@@ -269,7 +269,7 @@ export function MealProvider({ children }: { children: ReactNode }) {
 
   const value: MealContextValue = {
     meals,
-    loading,
+    loading: loading || (!!currentTrip && !initialLoadDone),
     createMeal,
     updateMeal,
     deleteMeal,

--- a/src/contexts/StayContext.tsx
+++ b/src/contexts/StayContext.tsx
@@ -21,13 +21,14 @@ const StayContext = createContext<StayContextValue | undefined>(undefined)
 export function StayProvider({ children }: { children: ReactNode }) {
   const [stays, setStays] = useState<Stay[]>([])
   const [loading, setLoading] = useState(true)
+  const [initialLoadDone, setInitialLoadDone] = useState(false)
   const { currentTrip, tripCode } = useCurrentTrip()
   const { trips } = useTripContext()
 
   const fetchStays = async () => {
     if (!currentTrip) {
       setStays([])
-      setLoading(false)
+      setInitialLoadDone(true)
       return
     }
 
@@ -50,6 +51,7 @@ export function StayProvider({ children }: { children: ReactNode }) {
       setStays([])
     } finally {
       setLoading(false)
+      setInitialLoadDone(true)
     }
   }
 
@@ -59,10 +61,8 @@ export function StayProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (tripCode && currentTrip) {
+      setInitialLoadDone(false)
       fetchStays()
-    } else {
-      setStays([])
-      setLoading(false)
     }
   }, [tripCode, currentTrip?.id, trips.length])
 
@@ -159,7 +159,7 @@ export function StayProvider({ children }: { children: ReactNode }) {
 
   const value: StayContextValue = {
     stays,
-    loading,
+    loading: loading || (!!currentTrip && !initialLoadDone),
     createStay,
     updateStay,
     deleteStay,

--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -19,7 +19,7 @@ interface TripContextType {
 const TripContext = createContext<TripContextType | undefined>(undefined)
 
 export function TripProvider({ children }: { children: ReactNode }) {
-  const { loading: authLoading } = useAuth()
+  const { loading: authLoading, user } = useAuth()
   const [trips, setTrips] = useState<Trip[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -143,11 +143,11 @@ export function TripProvider({ children }: { children: ReactNode }) {
     await fetchTrips()
   }
 
-  // Fetch trips after auth has resolved
+  // Fetch trips after auth has resolved or user changes
   useEffect(() => {
     if (authLoading) return
     fetchTrips()
-  }, [authLoading])
+  }, [authLoading, user?.id])
 
   const value: TripContextType = {
     trips,

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -43,17 +43,19 @@ export function ExpensesPage() {
 
   const handleCreateExpense = async (input: CreateExpenseInput) => {
     const result = await createExpense(input)
-    if (result) {
-      setShowForm(false)
+    if (!result) {
+      throw new Error('Failed to create expense')
     }
+    setShowForm(false)
   }
 
   const handleUpdateExpense = async (input: CreateExpenseInput) => {
     if (!editingExpense) return
     const result = await updateExpense(editingExpense.id, input)
-    if (result) {
-      setEditingExpense(null)
+    if (!result) {
+      throw new Error('Failed to update expense')
     }
+    setEditingExpense(null)
   }
 
   const handleDeleteExpense = async () => {

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -14,10 +14,10 @@ export function TripsPage() {
 
   const handleCreateTrip = async (input: CreateTripInput) => {
     const newTrip = await createTrip(input)
-    if (newTrip) {
-      // Navigate to manage page for new trip using trip code
-      navigate(`/t/${newTrip.trip_code}/manage`)
+    if (!newTrip) {
+      throw new Error('Failed to create trip')
     }
+    navigate(`/t/${newTrip.trip_code}/manage`)
   }
 
   const handleCancel = () => {


### PR DESCRIPTION
## Summary
- **Standardize context loading**: Add `initialLoadDone` pattern to MealContext, ShoppingContext, ActivityContext, StayContext — prevents premature "empty" flash when `currentTrip` is null during initial load
- **Fix TripContext user change**: Add `user?.id` to fetch dependency so trips refresh when a different user signs in
- **Fix form error propagation**: Page-level handlers now throw on failure so form-level `catch` blocks fire and display error messages instead of silently doing nothing
- **Fix SettlementsPage infinite loop**: Memoize `calculateBalances`/`calculateOptimalSettlement` and use a stable string key for the `useEffect` dependency — stops continuous `user_profiles` queries
- **Fix ShoppingContext delete rollback**: Save items before optimistic delete, restore on DB failure
- **Add ShoppingContext update optimistic**: `updateShoppingItem` now updates local state immediately instead of waiting for real-time subscription

## Test plan
- [ ] Navigate to a trip — all tabs (Expenses, Meals, Shopping) show loading skeletons until data arrives, no premature empty flash
- [ ] Submit an expense with network throttling — on failure, form shows error message instead of silently resetting
- [ ] Sign out and sign in as different user — trips list refreshes
- [ ] Open SettlementsPage and check network tab — no continuous `user_profiles` queries
- [ ] Toggle airplane mode, delete a shopping item — item reappears after failure
- [ ] `npm run type-check && npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)