### PR TITLE
Fix feature toggles, expense auto-fill, and wizard custom splits

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -71,6 +71,29 @@ export function ExpenseForm({
   const [participantSplitValues, setParticipantSplitValues] = useState<Record<string, string>>({})
   const [familySplitValues, setFamilySplitValues] = useState<Record<string, string>>({})
 
+  // Auto-fill split value when exactly one party is selected in "By Amount" mode
+  useEffect(() => {
+    if (splitMode !== 'amount') return
+    const amountNum = parseFloat(amount)
+    if (isNaN(amountNum) || amountNum <= 0) return
+    const totalSelected = selectedParticipants.length + selectedFamilies.length
+    if (totalSelected !== 1) return
+
+    if (selectedFamilies.length === 1) {
+      const id = selectedFamilies[0]
+      const current = familySplitValues[id]
+      if (!current || current === '' || current === '0') {
+        setFamilySplitValues(prev => ({ ...prev, [id]: amount }))
+      }
+    } else if (selectedParticipants.length === 1) {
+      const id = selectedParticipants[0]
+      const current = participantSplitValues[id]
+      if (!current || current === '' || current === '0') {
+        setParticipantSplitValues(prev => ({ ...prev, [id]: amount }))
+      }
+    }
+  }, [splitMode, selectedFamilies, selectedParticipants, amount])
+
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const isMounted = useRef(true)

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -56,8 +56,8 @@ export function ManageTripPage() {
   )
   const [isSavingCurrency, setIsSavingCurrency] = useState(false)
 
-  // Feature toggle state
-  const [isTogglingFeature, setIsTogglingFeature] = useState(false)
+  // Feature toggle state - track which features are currently being toggled
+  const [togglingFeatures, setTogglingFeatures] = useState<Set<string>>(new Set())
 
   if (!currentTrip) {
     return (
@@ -117,7 +117,7 @@ export function ManageTripPage() {
   }
 
   const handleToggleFeature = async (feature: 'enable_meals' | 'enable_activities' | 'enable_shopping' | 'default_split_all', value: boolean) => {
-    setIsTogglingFeature(true)
+    setTogglingFeatures(prev => new Set(prev).add(feature))
     try {
       const success = await updateTrip(currentTrip.id, { [feature]: value })
       if (success) {
@@ -139,7 +139,7 @@ export function ManageTripPage() {
         description: 'An error occurred while updating the feature.',
       })
     } finally {
-      setIsTogglingFeature(false)
+      setTogglingFeatures(prev => { const next = new Set(prev); next.delete(feature); return next })
     }
   }
 
@@ -284,7 +284,7 @@ export function ManageTripPage() {
             <Switch
               checked={currentTrip.enable_meals}
               onCheckedChange={(checked) => handleToggleFeature('enable_meals', checked)}
-              disabled={isTogglingFeature}
+              disabled={togglingFeatures.has('enable_meals')}
             />
           </div>
           <div className="flex items-center justify-between">
@@ -295,7 +295,7 @@ export function ManageTripPage() {
             <Switch
               checked={currentTrip.enable_activities}
               onCheckedChange={(checked) => handleToggleFeature('enable_activities', checked)}
-              disabled={isTogglingFeature}
+              disabled={togglingFeatures.has('enable_activities')}
             />
           </div>
           <div className="flex items-center justify-between">
@@ -306,7 +306,7 @@ export function ManageTripPage() {
             <Switch
               checked={currentTrip.enable_shopping}
               onCheckedChange={(checked) => handleToggleFeature('enable_shopping', checked)}
-              disabled={isTogglingFeature}
+              disabled={togglingFeatures.has('enable_shopping')}
             />
           </div>
           <div className="flex items-center justify-between">
@@ -317,7 +317,7 @@ export function ManageTripPage() {
             <Switch
               checked={currentTrip.default_split_all ?? true}
               onCheckedChange={(checked) => handleToggleFeature('default_split_all', checked)}
-              disabled={isTogglingFeature}
+              disabled={togglingFeatures.has('default_split_all')}
             />
           </div>
         </CardContent>


### PR DESCRIPTION
## Summary

- **Issues 111/112:** Feature toggle switches on the Manage Trip page no longer gray out all at once — each switch only disables while its own async update is in-flight
- **Issue 108:** Full expense form auto-fills the split value when exactly one party is selected in "By Amount" mode (only when the field is empty/zero)
- **Issue 109/110:** Mobile expense wizard Step 4 now shows per-participant/family input fields for "By Percentage" and "By Amount" split modes, with validation and a running total indicator

## Test plan

- [ ] Go to Manage Trip → toggle Meal Planning off → confirm Shopping List switch remains interactive
- [ ] In full expense form, select "By Amount" with one family → amount auto-fills; select two → no auto-fill
- [ ] In mobile wizard, click Advanced Options → select "By Percentage" → verify per-party inputs appear in Step 4
- [ ] Fill percentages summing to 100% → submit → verify expense saved correctly
- [ ] Fill amounts summing to total → submit → verify expense saved correctly
- [ ] Verify `npm run type-check` and `npm run build` pass

Closes #108, closes #109, closes #110, closes #111, closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)