### PR TITLE
Fix loading hangs and silent submission failures on quick page

### DIFF
--- a/src/lib/fetchWithTimeout.ts
+++ b/src/lib/fetchWithTimeout.ts
@@ -1,0 +1,26 @@
+/**
+ * Wraps a promise with a timeout. If the promise doesn't resolve within
+ * the specified milliseconds, the returned promise rejects with a timeout error.
+ */
+export function withTimeout<T>(
+  promise: PromiseLike<T>,
+  ms: number,
+  message = 'Request timed out'
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(message))
+    }, ms)
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- Add 15-second timeouts to all Supabase fetch and mutation calls in ParticipantContext, ExpenseContext, and SettlementContext to prevent infinite loading on slow mobile connections (iPhone Safari)
- Remove `trips.length` from context effect dependencies to eliminate unnecessary refetch cascades
- Add error display with retry button and "Taking longer than expected..." slow-loading indicator to QuickGroupDetailPage

## Test plan
- [ ] Open quick page — should load normally
- [ ] Simulate slow network (Chrome DevTools throttling) — should show "Taking longer than expected" after 8s, then error + retry after 15s timeout
- [ ] Add expense on quick page — should work normally
- [ ] Simulate offline during submission — should show error after 15s timeout
- [ ] Click Retry when error is shown — data should reload
- [ ] Switch between trips — verify fresh data still loads (currentTrip?.id dependency handles this)

Fixes #114, #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)