### PR TITLE
Add Grafana Cloud observability (Loki + OTLP metrics)

### DIFF
--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -1,0 +1,129 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "Grafana Cloud Loki datasource",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    },
+    {
+      "name": "DS_MIMIR",
+      "label": "Prometheus (Mimir)",
+      "description": "Grafana Cloud Prometheus / Mimir datasource",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "loki", "name": "Loki", "version": "1.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "logs", "name": "Logs", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "sum by (service) (rate({env=\"production\"} |= `\"level\":\"error\"` [1m]))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_MIMIR}" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2 }, "unit": "ms" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_MIMIR}" },
+          "expr": "avg by (service_name, status) (function_latency_ms)",
+          "legendFormat": "{{service_name}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Edge Function Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "{env=\"production\", level=\"error\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Live Error Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_MIMIR}" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "id": 4,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_MIMIR}" },
+          "expr": "sum by (status, service_name) (rate(function_requests_total[5m]))",
+          "legendFormat": "{{service_name}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Status",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["trip-splitter", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Trip Splitter Pro — Observability",
+  "uid": "trip-splitter-observability",
+  "version": 1
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -24,6 +24,13 @@ export class ErrorBoundary extends Component<Props, State> {
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo)
+    import('@/lib/logger').then(({ logger }) => {
+      logger.error('React ErrorBoundary caught error', {
+        errorMessage: error.message,
+        errorName: error.name,
+        componentStack: errorInfo.componentStack?.slice(0, 1000) ?? '',
+      })
+    }).catch(() => {})
   }
 
   private handleReset = () => {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,45 @@
+import { supabase } from '@/lib/supabase'
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+let persistentContext: Record<string, unknown> = {}
+
+function log(level: LogLevel, message: string, context?: Record<string, unknown>): void {
+  console[level](message, context)
+
+  supabase.functions
+    .invoke('log-proxy', {
+      body: {
+        level,
+        message,
+        service: 'browser',
+        context: {
+          url: window.location.pathname,
+          ...persistentContext,
+          ...context,
+        },
+      },
+    })
+    .catch(() => {})
+}
+
+export const logger = {
+  debug(message: string, context?: Record<string, unknown>): void {
+    log('debug', message, context)
+  },
+  info(message: string, context?: Record<string, unknown>): void {
+    log('info', message, context)
+  },
+  warn(message: string, context?: Record<string, unknown>): void {
+    log('warn', message, context)
+  },
+  error(message: string, context?: Record<string, unknown>): void {
+    log('error', message, context)
+  },
+  setContext(ctx: Record<string, unknown>): void {
+    persistentContext = { ...persistentContext, ...ctx }
+  },
+  clearContext(): void {
+    persistentContext = {}
+  },
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,27 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
+window.addEventListener('error', (event) => {
+  import('@/lib/logger').then(({ logger }) => {
+    logger.error('Unhandled window error', {
+      errorMessage: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      errorName: event.error?.name,
+    })
+  }).catch(() => {})
+})
+
+window.addEventListener('unhandledrejection', (event) => {
+  import('@/lib/logger').then(({ logger }) => {
+    const reason = event.reason
+    logger.error('Unhandled promise rejection', {
+      reason: reason instanceof Error ? reason.message : String(reason),
+      reasonName: reason instanceof Error ? reason.name : undefined,
+    })
+  }).catch(() => {})
+})
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/supabase/functions/_shared/logger.ts
+++ b/supabase/functions/_shared/logger.ts
@@ -1,0 +1,78 @@
+/**
+ * Server-side Loki logger for Supabase edge functions.
+ * Credentials are read from Supabase secrets (never exposed to the browser).
+ */
+
+declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+function pushToLoki(
+  service: string,
+  level: LogLevel,
+  message: string,
+  context?: Record<string, unknown>,
+): Promise<void> {
+  const lokiUrl = Deno.env.get('LOKI_PUSH_URL')
+  const lokiUsername = Deno.env.get('LOKI_USERNAME')
+  const grafanaToken = Deno.env.get('GRAFANA_API_TOKEN')
+
+  if (!lokiUrl || !lokiUsername || !grafanaToken) {
+    return Promise.resolve()
+  }
+
+  const timestampNs = String(Date.now() * 1_000_000)
+  const line = JSON.stringify({ level, message, service, env: 'production', ...context })
+
+  const body = JSON.stringify({
+    streams: [
+      {
+        stream: { service, level, env: 'production' },
+        values: [[timestampNs, line]],
+      },
+    ],
+  })
+
+  const credentials = btoa(`${lokiUsername}:${grafanaToken}`)
+
+  return fetch(lokiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${credentials}`,
+    },
+    body,
+  }).then(() => undefined)
+}
+
+function fireAndForget(service: string, level: LogLevel, message: string, context?: Record<string, unknown>): void {
+  const promise = pushToLoki(service, level, message, context).catch(() => {})
+  try {
+    if (typeof EdgeRuntime !== 'undefined') {
+      EdgeRuntime.waitUntil(promise)
+    }
+  } catch {
+    // EdgeRuntime unavailable in local dev — fire-and-forget is fine
+  }
+}
+
+export interface Logger {
+  debug(message: string, context?: Record<string, unknown>): void
+  info(message: string, context?: Record<string, unknown>): void
+  warn(message: string, context?: Record<string, unknown>): void
+  error(message: string, context?: Record<string, unknown>): void
+}
+
+export function createLogger(service: string): Logger {
+  const log = (level: LogLevel, message: string, context?: Record<string, unknown>) => {
+    console.log(JSON.stringify({ level, service, message, ...context }))
+    fireAndForget(service, level, message, context)
+  }
+
+  return {
+    debug: (message, context) => log('debug', message, context),
+    info: (message, context) => log('info', message, context),
+    warn: (message, context) => log('warn', message, context),
+    error: (message, context) => log('error', message, context),
+  }
+}

--- a/supabase/functions/_shared/metrics.ts
+++ b/supabase/functions/_shared/metrics.ts
@@ -1,0 +1,107 @@
+/**
+ * OTLP HTTP JSON metrics pusher for Supabase edge functions.
+ * Uses /otlp/v1/metrics (no Snappy compression required, pure fetch).
+ */
+
+declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
+
+export interface MetricPoint {
+  name: string
+  value: number
+  labels?: Record<string, string>
+  type?: 'counter' | 'gauge'
+}
+
+function buildOtlpBody(service: string, points: MetricPoint[]): string {
+  const nowNs = String(BigInt(Date.now()) * 1_000_000n)
+
+  const metrics = points.map((p) => {
+    const attributes = Object.entries(p.labels ?? {}).map(([key, value]) => ({
+      key,
+      value: { stringValue: value },
+    }))
+
+    const dataPoint = {
+      attributes,
+      startTimeUnixNano: nowNs,
+      timeUnixNano: nowNs,
+      asDouble: p.value,
+    }
+
+    // Default to gauge; use sum (monotonic) for counters
+    if (p.type === 'counter') {
+      return {
+        name: p.name,
+        sum: {
+          dataPoints: [dataPoint],
+          aggregationTemporality: 2, // AGGREGATION_TEMPORALITY_CUMULATIVE
+          isMonotonic: true,
+        },
+      }
+    }
+
+    return {
+      name: p.name,
+      gauge: { dataPoints: [dataPoint] },
+    }
+  })
+
+  return JSON.stringify({
+    resourceMetrics: [
+      {
+        resource: {
+          attributes: [
+            { key: 'service.name', value: { stringValue: service } },
+            { key: 'deployment.environment', value: { stringValue: 'production' } },
+          ],
+        },
+        scopeMetrics: [
+          {
+            scope: { name: 'trip-splitter-pro' },
+            metrics,
+          },
+        ],
+      },
+    ],
+  })
+}
+
+function pushToOtlp(service: string, points: MetricPoint[]): Promise<void> {
+  const endpoint = Deno.env.get('OTLP_METRICS_ENDPOINT')
+  const mimirUsername = Deno.env.get('MIMIR_USERNAME')
+  const grafanaToken = Deno.env.get('GRAFANA_API_TOKEN')
+
+  if (!endpoint || !mimirUsername || !grafanaToken) {
+    return Promise.resolve()
+  }
+
+  const credentials = btoa(`${mimirUsername}:${grafanaToken}`)
+
+  return fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${credentials}`,
+    },
+    body: buildOtlpBody(service, points),
+  }).then(() => undefined)
+}
+
+export interface Metrics {
+  push(points: MetricPoint[]): void
+}
+
+export function createMetrics(service: string): Metrics {
+  return {
+    push(points: MetricPoint[]) {
+      const promise = pushToOtlp(service, points).catch(() => {})
+      try {
+        if (typeof EdgeRuntime !== 'undefined') {
+          EdgeRuntime.waitUntil(promise)
+        }
+      } catch {
+        // EdgeRuntime unavailable in local dev — fire-and-forget is fine
+      }
+    },
+  }
+}

--- a/supabase/functions/create-github-issue/index.ts
+++ b/supabase/functions/create-github-issue/index.ts
@@ -1,4 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts"
+import { createLogger } from '../_shared/logger.ts'
+import { createMetrics } from '../_shared/metrics.ts'
 
 const GITHUB_REPO = "kristjanelias-xtian/trip-splitter-pro"
 
@@ -7,15 +9,24 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 }
 
+const logger = createLogger('create-github-issue')
+const metrics = createMetrics('create-github-issue')
+
 Deno.serve(async (req) => {
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders })
   }
 
+  const requestStart = performance.now()
+
   try {
+    logger.info('Request received', { method: req.method })
+
     const githubToken = Deno.env.get("GITHUB_TOKEN")
     if (!githubToken) {
+      logger.error('GitHub token not configured')
+      metrics.push([{ name: 'function_requests_total', value: 1, labels: { status: 'error', reason: 'missing_token' }, type: 'counter' }])
       return new Response(
         JSON.stringify({ error: "GitHub token not configured" }),
         { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
@@ -25,11 +36,16 @@ Deno.serve(async (req) => {
     const { title, body } = await req.json()
 
     if (!title || typeof title !== "string") {
+      logger.warn('Invalid input: title missing or not a string')
+      metrics.push([{ name: 'function_requests_total', value: 1, labels: { status: 'error', reason: 'invalid_input' }, type: 'counter' }])
       return new Response(
         JSON.stringify({ error: "Title is required" }),
         { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
       )
     }
+
+    const githubStart = performance.now()
+    logger.info('Calling GitHub API')
 
     const response = await fetch(
       `https://api.github.com/repos/${GITHUB_REPO}/issues`,
@@ -49,9 +65,15 @@ Deno.serve(async (req) => {
       }
     )
 
+    const githubLatencyMs = performance.now() - githubStart
+    logger.info('GitHub API responded', { status: response.status, latencyMs: Math.round(githubLatencyMs) })
+    metrics.push([{ name: 'github_api_latency_ms', value: Math.round(githubLatencyMs), labels: { service_name: 'create-github-issue' }, type: 'gauge' }])
+
     if (!response.ok) {
       const errorText = await response.text()
       console.error("GitHub API error:", response.status, errorText)
+      logger.error('GitHub API returned error', { status: response.status })
+      metrics.push([{ name: 'function_requests_total', value: 1, labels: { status: 'error', reason: 'github_api_error' }, type: 'counter' }])
       return new Response(
         JSON.stringify({ error: "Failed to create GitHub issue" }),
         { status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" } }
@@ -59,13 +81,25 @@ Deno.serve(async (req) => {
     }
 
     const issue = await response.json()
+    const totalMs = Math.round(performance.now() - requestStart)
+    logger.info('Issue created', { issueNumber: issue.number, totalMs })
+    metrics.push([
+      { name: 'function_requests_total', value: 1, labels: { status: 'success' }, type: 'counter' },
+      { name: 'function_latency_ms', value: totalMs, labels: { service_name: 'create-github-issue', status: 'success' }, type: 'gauge' },
+    ])
 
     return new Response(
       JSON.stringify({ url: issue.html_url, number: issue.number }),
       { status: 201, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     )
   } catch (err) {
+    const totalMs = Math.round(performance.now() - requestStart)
     console.error("Edge function error:", err)
+    logger.error('Unhandled exception', { error: String(err) })
+    metrics.push([
+      { name: 'function_requests_total', value: 1, labels: { status: 'error', reason: 'unhandled_exception' }, type: 'counter' },
+      { name: 'function_latency_ms', value: totalMs, labels: { service_name: 'create-github-issue', status: 'error' }, type: 'gauge' },
+    ])
     return new Response(
       JSON.stringify({ error: "Internal server error" }),
       { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }

--- a/supabase/functions/log-proxy/index.ts
+++ b/supabase/functions/log-proxy/index.ts
@@ -1,0 +1,65 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts"
+import { createLogger } from '../_shared/logger.ts'
+
+const VALID_LEVELS = new Set(['debug', 'info', 'warn', 'error'])
+const MAX_MESSAGE_LEN = 2000
+const MAX_SERVICE_LEN = 64
+const MAX_CONTEXT_KEYS = 20
+const MAX_CONTEXT_VALUE_LEN = 500
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders })
+  }
+
+  try {
+    const body = await req.json()
+    const { level, message, service: rawService, context: rawContext } = body
+
+    if (!VALID_LEVELS.has(level)) {
+      return new Response(
+        JSON.stringify({ ok: false }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    if (typeof message !== 'string') {
+      return new Response(
+        JSON.stringify({ ok: false }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const safeMessage = message.slice(0, MAX_MESSAGE_LEN)
+    const safeService = typeof rawService === 'string'
+      ? rawService.slice(0, MAX_SERVICE_LEN)
+      : 'browser'
+
+    let safeContext: Record<string, unknown> | undefined
+    if (rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)) {
+      safeContext = {}
+      const entries = Object.entries(rawContext).slice(0, MAX_CONTEXT_KEYS)
+      for (const [k, v] of entries) {
+        safeContext[k] = typeof v === 'string' ? v.slice(0, MAX_CONTEXT_VALUE_LEN) : v
+      }
+    }
+
+    const logger = createLogger(safeService)
+    logger[level as 'debug' | 'info' | 'warn' | 'error'](safeMessage, safeContext)
+
+    return new Response(
+      JSON.stringify({ ok: true }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    )
+  } catch {
+    return new Response(
+      JSON.stringify({ ok: false }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    )
+  }
+})


### PR DESCRIPTION
## Summary

- Browser logs proxied through new `log-proxy` Supabase edge function — Grafana credentials never reach the client bundle
- Shared `_shared/logger.ts` pushes structured logs to Loki; `_shared/metrics.ts` pushes OTLP HTTP JSON metrics to Grafana Cloud Mimir
- `create-github-issue` edge function fully instrumented with per-path logging and latency/request-count metrics
- Global `error` and `unhandledrejection` handlers added to `main.tsx`
- `ErrorBoundary.tsx` reports caught React errors to Loki
- `grafana-dashboard.json` importable dashboard (error rate, latency, live error logs, request rate by status)

## Test plan

- [ ] Deploy to Cloudflare Pages via this PR merge
- [ ] In browser console on deployed app, verify log appears in Grafana Explore → Loki → `{service="browser"}` within 30s
- [ ] Submit a bug report via ReportIssueDialog, verify logs under `{service="create-github-issue"}`
- [ ] Check `function_requests_total` metric in Grafana Explore → Prometheus after any edge function call
- [ ] Import `grafana-dashboard.json` into Grafana, confirm all 4 panels load

🤖 Generated with [Claude Code](https://claude.com/claude-code)