### PR TITLE
Fix standalone participant share skipped in individuals distribution (families mode)

### DIFF
--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -226,6 +226,9 @@ export function calculateExpenseShares(
           if (familyId) {
             const currentShare = shares.get(familyId) || 0
             shares.set(familyId, currentShare + shareAmount)
+          } else {
+            // Standalone participant in families mode — assign directly by participant ID
+            shares.set(participantId, shareAmount)
           }
         } else {
           shares.set(participantId, shareAmount)
@@ -241,6 +244,8 @@ export function calculateExpenseShares(
           if (familyId) {
             const currentShare = shares.get(familyId) || 0
             shares.set(familyId, currentShare + shareAmount)
+          } else {
+            shares.set(split.participantId, shareAmount)
           }
         } else {
           shares.set(split.participantId, shareAmount)
@@ -255,6 +260,8 @@ export function calculateExpenseShares(
           if (familyId) {
             const currentShare = shares.get(familyId) || 0
             shares.set(familyId, currentShare + split.value)
+          } else {
+            shares.set(split.participantId, split.value)
           }
         } else {
           shares.set(split.participantId, split.value)


### PR DESCRIPTION
## Summary

- In `calculateExpenseShares()`, standalone participants (`family_id === null`) inside `individuals` distribution were silently skipped when `trackingMode === 'families'`
- Their `totalShare` was never incremented while `totalPaid` was, causing balance to appear incorrectly positive/less negative
- Added `else` clauses in all three split modes (`equal`, `percentage`, `amount`) to assign shares directly by participant ID for standalone participants — matching the existing pattern in `mixed` distribution

Fixes #120

## Test plan

- [ ] Open Thai trip with a standalone participant alongside family groups
- [ ] Add an expense paid by the standalone participant, distributed only to themselves
- [ ] Verify their balance does not change (paid = share, net = 0)
- [ ] Verify existing mixed-distribution expenses still display correctly
- [ ] `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)