### PR TITLE
Fix mobile home redirect, keyboard auto-focus, and expenses header overflow

### DIFF
--- a/src/components/expenses/wizard/WizardStep1.tsx
+++ b/src/components/expenses/wizard/WizardStep1.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -35,15 +34,6 @@ export function WizardStep1({
   const currencies = availableCurrencies && availableCurrencies.length > 0
     ? availableCurrencies
     : ['EUR', 'USD', 'GBP', 'THB']
-  const descriptionRef = useRef<HTMLInputElement>(null)
-
-  // Auto-focus description on mount
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      descriptionRef.current?.focus()
-    }, 100)
-    return () => clearTimeout(timer)
-  }, [])
 
   return (
     <motion.div
@@ -58,7 +48,6 @@ export function WizardStep1({
           Description
         </Label>
         <Input
-          ref={descriptionRef}
           type="text"
           id="description"
           value={description}

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -21,11 +21,14 @@ export function ConditionalHomePage() {
   const { mode, loading: prefsLoading } = useUserPreferences()
   const { trips, loading: tripsLoading } = useTripContext()
 
-  const isLoading = prefsLoading || (mode === 'quick' && tripsLoading)
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
+  const shouldGoQuick = mode === 'quick' || isMobile
+
+  const isLoading = prefsLoading || (shouldGoQuick && tripsLoading)
 
   useEffect(() => {
     if (isLoading) return
-    if (mode !== 'quick') return
+    if (!shouldGoQuick) return
 
     // For quick mode, auto-detect active trip from user's linked trips
     const myTripCodes = new Set(getMyTrips().map(t => t.tripCode))
@@ -42,7 +45,7 @@ export function ConditionalHomePage() {
 
     // No active trip found, show the quick home screen
     navigate('/quick', { replace: true })
-  }, [isLoading, user, mode, trips, navigate])
+  }, [isLoading, user, mode, shouldGoQuick, trips, navigate])
 
   // Show spinner while any context is still loading
   if (isLoading) {
@@ -54,7 +57,7 @@ export function ConditionalHomePage() {
   }
 
   // Don't render HomePage when we're about to redirect to quick mode
-  if (mode === 'quick') return null
+  if (shouldGoQuick) return null
 
   // Show Full Mode home page by default
   return <HomePage />

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -120,8 +120,8 @@ export function ExpensesPage() {
     <>
       <div className="space-y-4">
         {/* Header */}
-        <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-bold text-foreground">Expenses</h2>
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
+          <h2 className="text-xl font-bold text-foreground">Expenses</h2>
           <div className="flex items-center gap-2">
             {expenses.length > 0 && (
               <Button onClick={handleExportExcel} variant="outline" size="sm" className="gap-2">
@@ -129,7 +129,7 @@ export function ExpensesPage() {
                 Export Excel
               </Button>
             )}
-            <Button onClick={() => setShowForm(!showForm)}>
+            <Button onClick={() => setShowForm(!showForm)} size="sm">
               <Plus size={16} className="mr-2" />
               {showForm ? 'Cancel' : 'Add Expense'}
             </Button>


### PR DESCRIPTION
## Summary

- **#119** `ConditionalHomePage`: on viewports < 768 px, always redirects to the active trip's quick page regardless of the stored `full` mode preference set from desktop
- **#122** `WizardStep1`: removed auto-focus `useEffect` so the mobile soft keyboard no longer pops up when the expense wizard opens
- **#123** `ExpensesPage`: header uses `flex-wrap` + `gap-y-2`, heading shrunk to `text-xl`, Add Expense button given `size="sm"` — prevents horizontal overflow on narrow Android portrait screens (~360 px)

No migrations. No new files.

## Test plan

- [ ] Load `/` on a mobile viewport (Chrome DevTools < 768 px) → redirects to `/t/:tripCode/quick`
- [ ] Open add-expense sheet → keyboard does **not** open automatically; only fires on tap
- [ ] Expenses page at ~360 px wide → heading and buttons fit without horizontal scroll
- [ ] `npm run type-check` passes

Closes #119, #122, #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)