### PR TITLE
Fix keyboard covering expense wizard sheet on iOS

### DIFF
--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -473,6 +473,9 @@ function MobileWizard({
           height: keyboard.isVisible
             ? `${keyboard.availableHeight}px`
             : '90vh',
+          bottom: keyboard.isVisible
+            ? `${keyboard.keyboardHeight}px`
+            : undefined,
         }}
         onInteractOutside={(e) => {
           // Prevent closing when clicking outside during submission


### PR DESCRIPTION
## Root cause

On iOS Safari the layout viewport does **not** shrink when the soft keyboard opens. A `position: fixed; bottom: 0` element stays anchored at the physical bottom of the screen — directly behind the keyboard.

PR #129 added `height: visualViewport.height` when the keyboard is visible, which correctly sized the sheet. But the sheet was still anchored at `bottom: 0` of the layout viewport (= behind the keyboard), so the entire card was hidden.

## Fix

Add `bottom: keyboardHeight` to the `SheetContent` inline style when the keyboard is visible. This lifts the sheet's bottom edge to sit just above the keyboard. Combined with the existing `height: availableHeight`, the sheet fills exactly the visible space above the keyboard.

```
Before keyboard open:  bottom: 0        height: 90vh
After keyboard open:   bottom: 335px    height: 509px   (example: iPhone 12, 335px keyboard)
```

Android is unaffected — its layout viewport shrinks with the keyboard, so `keyboard.isVisible` stays false and `bottom: undefined` leaves the default Tailwind `bottom-0` in place.

## Test plan

- [ ] Open the expense wizard on iPhone Safari → tap the Description or Amount field → keyboard appears → sheet stays visible above the keyboard
- [ ] Same test on Android Chrome → sheet behaves correctly
- [ ] Submit an expense through the full wizard → works normally
- [ ] `npm run type-check` passes

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)