### PR TITLE
Fix ModeToggle showing Full when mobile is on a quick route

### DIFF
--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { Zap, Settings2 } from 'lucide-react'
 
@@ -8,11 +8,17 @@ interface ModeToggleProps {
 
 export function ModeToggle({ onGradient = false }: ModeToggleProps) {
   const navigate = useNavigate()
+  const location = useLocation()
   const { tripCode } = useParams<{ tripCode: string }>()
   const { mode, setMode } = useUserPreferences()
 
+  // If the user is on a quick route (e.g. mobile redirect overrode a stored
+  // 'full' preference), the toggle should reflect where they actually are.
+  const isOnQuickRoute = location.pathname === '/quick' || location.pathname.includes('/quick')
+  const effectiveMode = isOnQuickRoute ? 'quick' : mode
+
   const handleModeChange = async (newMode: 'quick' | 'full') => {
-    if (newMode === mode) return
+    if (newMode === effectiveMode) return
     await setMode(newMode)
 
     // Navigate to the appropriate view
@@ -49,7 +55,7 @@ export function ModeToggle({ onGradient = false }: ModeToggleProps) {
       <button
         onClick={() => handleModeChange('quick')}
         className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-          mode === 'quick' ? activeClass : inactiveClass
+          effectiveMode === 'quick' ? activeClass : inactiveClass
         }`}
       >
         <Zap size={14} />
@@ -58,7 +64,7 @@ export function ModeToggle({ onGradient = false }: ModeToggleProps) {
       <button
         onClick={() => handleModeChange('full')}
         className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-          mode === 'full' ? activeClass : inactiveClass
+          effectiveMode === 'full' ? activeClass : inactiveClass
         }`}
       >
         <Settings2 size={14} />


### PR DESCRIPTION
## Summary

- **#133** `ModeToggle`: the mobile redirect (PR #131) correctly sends iPhones to the `/quick` route even when the stored preference is `full`, but the toggle still highlighted **Full** because it read only the stored preference.

## Root cause

`ModeToggle` used `mode` from `UserPreferencesContext` for both the no-op guard (`if (newMode === mode) return`) and the button highlight classes. When a mobile user's stored preference is `'full'` but they were routed to a quick page, `mode === 'full'` made Full appear active.

## Fix

Derive `effectiveMode` from the current pathname:
```ts
const isOnQuickRoute = location.pathname === '/quick' || location.pathname.includes('/quick')
const effectiveMode = isOnQuickRoute ? 'quick' : mode
```
Use `effectiveMode` for highlighting and the no-op guard. The stored preference (`mode`) is intentionally left unchanged — desktop sessions keep their full-mode preference.

## Test plan

- [ ] On iPhone (or narrow viewport), load the app → redirected to quick page → toggle shows **Quick** as active
- [ ] Explicitly tap **Full** in the toggle → navigates to full mode, toggle shows **Full**
- [ ] On desktop with stored `full` preference → toggle shows **Full** (unaffected)
- [ ] `npm run type-check` passes

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)