### PR TITLE
Default payer to authenticated user and buffer failed logs

### DIFF
--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -9,6 +9,7 @@ import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
+import { useAuth } from '@/contexts/AuthContext'
 import { calculateBalances } from '@/services/balanceCalculator'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
@@ -77,6 +78,7 @@ function MobileWizard({
   const { participants, families, getAdultParticipants } = useParticipantContext()
   const { expenses } = useExpenseContext()
   const { settlements } = useSettlementContext()
+  const { user } = useAuth()
 
   // Keyboard detection for mobile
   const contentRef = useRef<HTMLDivElement>(null)
@@ -146,6 +148,15 @@ function MobileWizard({
       }
     }
   }, [open, participants, families])
+
+  // Pre-fill paidBy with the authenticated user's linked adult participant
+  useEffect(() => {
+    if (!open) return
+    if (paidBy !== '') return // already set (editing, or user already chose someone)
+    if (!user || participants.length === 0) return
+    const myParticipant = participants.find(p => p.user_id === user.id && p.is_adult)
+    if (myParticipant) setPaidBy(myParticipant.id)
+  }, [open, participants, user])
 
   // Reset form when closed
   useEffect(() => {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -4,23 +4,64 @@ type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
 let persistentContext: Record<string, unknown> = {}
 
+// ── Failed-log queue ────────────────────────────────────────────────────────
+// When the Supabase edge function is unreachable (e.g. the same connectivity
+// issue that caused the error we're trying to log), we buffer the entry in
+// localStorage and retry it the next time a log send succeeds.
+
+const QUEUE_KEY = 'trip-splitter:failed-logs'
+const MAX_QUEUED = 50
+
+interface QueuedEntry {
+  level: LogLevel
+  message: string
+  body: Record<string, unknown>
+  ts: number
+}
+
+function enqueue(entry: QueuedEntry): void {
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY)
+    const q: QueuedEntry[] = raw ? JSON.parse(raw) : []
+    q.push(entry)
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(q.slice(-MAX_QUEUED)))
+  } catch {}
+}
+
+function flushQueue(): void {
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY)
+    if (!raw) return
+    const q: QueuedEntry[] = JSON.parse(raw)
+    if (q.length === 0) return
+    localStorage.removeItem(QUEUE_KEY) // optimistic clear
+    for (const entry of q) {
+      supabase.functions
+        .invoke('log-proxy', { body: { ...entry.body, message: `[queued] ${entry.body.message}`, context: { ...(entry.body.context as object), queued_at: new Date(entry.ts).toISOString() } } })
+        .catch(() => enqueue(entry)) // re-queue if still failing
+    }
+  } catch {}
+}
+// ────────────────────────────────────────────────────────────────────────────
+
 function log(level: LogLevel, message: string, context?: Record<string, unknown>): void {
   console[level](message, context)
 
+  const body = {
+    level,
+    message,
+    service: 'browser',
+    context: {
+      url: window.location.pathname,
+      ...persistentContext,
+      ...context,
+    },
+  }
+
   supabase.functions
-    .invoke('log-proxy', {
-      body: {
-        level,
-        message,
-        service: 'browser',
-        context: {
-          url: window.location.pathname,
-          ...persistentContext,
-          ...context,
-        },
-      },
-    })
-    .catch(() => {})
+    .invoke('log-proxy', { body })
+    .then(() => flushQueue()) // on success, replay any buffered entries
+    .catch(() => enqueue({ level, message, body, ts: Date.now() }))
 }
 
 export const logger = {


### PR DESCRIPTION
## Summary

- **#135** — Pre-fill the "Who paid?" field with the signed-in user's linked participant when opening the expense wizard for a new expense
- **#136** — Buffer log entries that fail to reach Grafana (because the Supabase Edge Function is down) and replay them automatically on the next successful send

---

## #135 — Default payer

**Root cause:** `paidBy` initialised as `''`; the user always had to manually tap the suggestion banner or pick from the dropdown.

**Fix:** Added a `useEffect` in `MobileWizard` that finds the participant whose `user_id` matches the signed-in auth user (must be `is_adult`) and sets it as `paidBy` when:
- The form opens (`open === true`)
- `paidBy` is still empty (doesn't override edits or existing values)
- Participants have loaded (`participants.length > 0`)

Falls back gracefully to empty if the user has no linked participant.

## #136 — Buffered log queue

**Root cause:** `logger.ts` sends logs via `supabase.functions.invoke('log-proxy')`. When Supabase itself is the source of the connectivity failure (timeout on expense create), the log-proxy call also fails and the error is **silently discarded** by `.catch(() => {})`. This is why the timeout never appeared in Grafana.

**Fix:** Instead of silently swallowing failures, failed log entries are serialised to `localStorage` (capped at 50 entries). The next time any log send **succeeds**, the queue is flushed and replayed to Grafana — tagged with a `[queued]` prefix and the original `queued_at` timestamp so they're identifiable.

## Test plan

- [ ] Sign in, open Add Expense — "Who paid?" pre-selects your linked participant
- [ ] If no participant is linked, field is empty (no regression)
- [ ] Simulate offline → trigger an error → come back online → next logger call replays the queued entry to Grafana
- [ ] `npm run type-check` passes

Closes #135, #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)