### PR TITLE
Rebrand to Spl1t

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Split</title>
+    <title>Spl1t</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -165,9 +165,9 @@ export function Layout() {
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.3 }}
               >
-                <img src="/logo.png" alt="Split" className="h-9 w-9 rounded-full" />
+                <img src="/logo.png" alt="Spl1t" className="h-9 w-9 rounded-full" />
                 <h1 className="text-2xl font-bold text-foreground">
-                  Split
+                  Spl1t
                 </h1>
               </motion.div>
             )}

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -70,9 +70,9 @@ export function QuickLayout() {
                 </>
               ) : (
                 <div className="flex items-center gap-2">
-                  <img src="/logo.png" alt="Split" className="h-8 w-8 rounded-full" />
+                  <img src="/logo.png" alt="Spl1t" className="h-8 w-8 rounded-full" />
                   <h1 className="text-lg font-semibold text-foreground">
-                    Split
+                    Spl1t
                   </h1>
                 </div>
               )}

--- a/src/lib/adminAuth.ts
+++ b/src/lib/adminAuth.ts
@@ -5,7 +5,7 @@
  * Uses sessionStorage to persist authentication state during browser session.
  */
 
-const ADMIN_SESSION_KEY = 'trip-splitter:admin-auth'
+const ADMIN_SESSION_KEY = 'spl1t:admin-auth'
 const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD || 'admin123'
 
 /**

--- a/src/lib/userPreferencesStorage.ts
+++ b/src/lib/userPreferencesStorage.ts
@@ -3,7 +3,18 @@
  * Used for instant reads and as fallback when user is not authenticated
  */
 
-const PREFERENCES_KEY = 'trip-splitter:user-preferences'
+const PREFERENCES_KEY = 'spl1t:user-preferences'
+const OLD_PREFERENCES_KEY = 'trip-splitter:user-preferences'
+
+function migratePreferencesKey(): void {
+  try {
+    const old = localStorage.getItem(OLD_PREFERENCES_KEY)
+    if (old) {
+      localStorage.setItem(PREFERENCES_KEY, old)
+      localStorage.removeItem(OLD_PREFERENCES_KEY)
+    }
+  } catch {}
+}
 
 export type AppMode = 'quick' | 'full'
 
@@ -17,6 +28,7 @@ function getDefaultMode(): AppMode {
 }
 
 export function getLocalPreferences(): UserPreferencesLocal {
+  migratePreferencesKey()
   const defaults: UserPreferencesLocal = {
     preferredMode: getDefaultMode(),
     defaultTripId: null,


### PR DESCRIPTION
## Summary
- Updates all user-facing brand wordmarks from "Split" to "Spl1t" (page title, full-mode header, quick-mode header, logo alt text)
- Renames localStorage/sessionStorage keys from `trip-splitter:*` to `spl1t:*` with backwards-compatible one-time migration so existing users don't lose their saved preferences or buffered logs
- Adds `PLAN.md` — living planning document for upcoming features (Events, Email, AI Receipt Reader)

## What was NOT changed
Functional UI labels ("Split a bill with the group", "Split between everyone", "Split With" Excel column) are left as-is per agreed scope.

## Migration behaviour
- `userPreferencesStorage`: on first `getLocalPreferences()` call, copies old key → new key → removes old. Safe for new users (old key absent → no-op).
- `logger`: same pattern, guarded by a module-level boolean so the migration runs once per page load at most.
- `adminAuth`: sessionStorage only — sessions don't survive page reloads so no migration needed; just a key rename.

## Test plan
- [x] `npm run type-check` passes clean
- [x] 138/139 tests pass (1 pre-existing failure in ShoppingContext unrelated to this change)
- [ ] Open the app — header should show "Spl1t" in both full and quick modes
- [ ] Browser tab title should read "Spl1t"
- [ ] Open DevTools → Application → Local Storage — confirm `spl1t:user-preferences` key exists after navigating

🤖 Generated with [Claude Code](https://claude.com/claude-code)