### PR TITLE
Add Events model — Phase 2

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,115 @@
+import { motion } from 'framer-motion'
+import { Calendar, Edit, Trash2, Users, User, Zap } from 'lucide-react'
+import { Event } from '@/types/trip'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+
+interface EventCardProps {
+  event: Event
+  isSelected: boolean
+  onSelect: () => void
+  onEdit: () => void
+  onDelete: () => void
+}
+
+export function EventCard({ event, isSelected, onSelect, onEdit, onDelete }: EventCardProps) {
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    })
+  }
+
+  const formatDateDisplay = () => {
+    if (event.event_type === 'event' || event.start_date === event.end_date) {
+      return formatDate(event.start_date)
+    }
+    return `${formatDate(event.start_date)} - ${formatDate(event.end_date)}`
+  }
+
+  return (
+    <motion.div
+      whileHover={{ y: -2 }}
+      whileTap={{ scale: 0.98 }}
+      transition={{ duration: 0.2 }}
+    >
+      <Card
+        className={`p-4 cursor-pointer transition-all ${
+          isSelected
+            ? 'border-2 border-primary bg-primary/5 shadow-md'
+            : 'border hover:border-primary/50 hover:shadow-sm'
+        }`}
+        onClick={onSelect}
+      >
+        <div className="flex items-start justify-between">
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-2">
+              <h3 className="text-lg font-semibold text-foreground">
+                {event.name}
+              </h3>
+              {event.event_type === 'event' ? (
+                <Badge variant="soft" className="bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-400">
+                  <Zap size={10} className="mr-1" />
+                  Event
+                </Badge>
+              ) : (
+                <Badge variant="outline" className="text-blue-600 border-blue-200 dark:text-blue-400">
+                  <Calendar size={10} className="mr-1" />
+                  Trip
+                </Badge>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Calendar size={14} />
+              <span>{formatDateDisplay()}</span>
+            </div>
+
+            <Badge variant={event.tracking_mode === 'individuals' ? 'outline' : 'soft'}>
+              {event.tracking_mode === 'individuals' ? (
+                <>
+                  <User size={12} className="mr-1" />
+                  Individuals only
+                </>
+              ) : (
+                <>
+                  <Users size={12} className="mr-1" />
+                  Individuals + Families
+                </>
+              )}
+            </Badge>
+          </div>
+
+          <div className="flex gap-1 ml-4">
+            <Button
+              onClick={(e) => {
+                e.stopPropagation()
+                onEdit()
+              }}
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              title="Edit"
+            >
+              <Edit size={16} />
+            </Button>
+            <Button
+              onClick={(e) => {
+                e.stopPropagation()
+                onDelete()
+              }}
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+              title="Delete"
+            >
+              <Trash2 size={16} />
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,0 +1,320 @@
+import { useState, FormEvent } from 'react'
+import { motion } from 'framer-motion'
+import { Calendar, Zap } from 'lucide-react'
+import { CreateEventInput, TrackingMode } from '@/types/trip'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { fadeInUp } from '@/lib/animations'
+
+interface EventFormProps {
+  onSubmit: (input: CreateEventInput) => Promise<void>
+  onCancel?: () => void
+  initialValues?: Partial<CreateEventInput>
+  submitLabel?: string
+  isLoading?: boolean
+  disableTrackingMode?: boolean
+  isEditMode?: boolean
+}
+
+export function EventForm({
+  onSubmit,
+  onCancel,
+  initialValues,
+  submitLabel = 'Create',
+  isLoading: externalLoading,
+  disableTrackingMode = false,
+  isEditMode = false,
+}: EventFormProps) {
+  const today = new Date().toISOString().split('T')[0]
+  const [eventType, setEventType] = useState<'trip' | 'event'>(initialValues?.event_type || 'trip')
+  const [name, setName] = useState(initialValues?.name || '')
+  const [startDate, setStartDate] = useState(initialValues?.start_date || today)
+  const [endDate, setEndDate] = useState(initialValues?.end_date || today)
+  const [trackingMode, setTrackingMode] = useState<TrackingMode>(initialValues?.tracking_mode || 'individuals')
+  const [defaultCurrency, setDefaultCurrency] = useState(initialValues?.default_currency || 'EUR')
+  const [enableMeals, setEnableMeals] = useState(initialValues?.enable_meals ?? false)
+  const [enableActivities, setEnableActivities] = useState(initialValues?.enable_activities ?? false)
+  const [enableShopping, setEnableShopping] = useState(initialValues?.enable_shopping ?? false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isSubmitting = externalLoading || loading
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!name.trim()) {
+      setError(`Please enter a ${eventType === 'event' ? 'event' : 'trip'} name`)
+      return
+    }
+
+    // For events, end_date = start_date. For trips, validate range.
+    const resolvedEndDate = eventType === 'event' ? startDate : endDate
+    if (eventType === 'trip' && new Date(endDate) < new Date(startDate)) {
+      setError('End date must be on or after start date')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await onSubmit({
+        name: name.trim(),
+        start_date: startDate,
+        end_date: resolvedEndDate,
+        event_type: eventType,
+        tracking_mode: trackingMode,
+        default_currency: defaultCurrency.trim().toUpperCase() || 'EUR',
+        enable_meals: enableMeals,
+        enable_activities: enableActivities,
+        enable_shopping: enableShopping,
+      })
+    } catch (err) {
+      setError(`Failed to save. Please try again.`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <motion.form
+      onSubmit={handleSubmit}
+      className="space-y-6 bg-card p-6 rounded-lg soft-shadow"
+      variants={fadeInUp}
+      initial="initial"
+      animate="animate"
+    >
+      {error && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="p-4 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm"
+        >
+          {error}
+        </motion.div>
+      )}
+
+      {/* Type selector — only shown when creating (not editing) */}
+      {!isEditMode && (
+        <div className="space-y-2">
+          <Label>Type</Label>
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={() => setEventType('trip')}
+              disabled={isSubmitting}
+              className={`flex items-center gap-3 p-4 rounded-lg border-2 text-left transition-all ${
+                eventType === 'trip'
+                  ? 'border-primary bg-primary/10'
+                  : 'border-border hover:border-primary/40 hover:bg-primary/5'
+              }`}
+            >
+              <Calendar size={20} className={eventType === 'trip' ? 'text-primary' : 'text-muted-foreground'} />
+              <div>
+                <div className="font-medium text-foreground text-sm">Trip</div>
+                <div className="text-xs text-muted-foreground">Multi-day</div>
+              </div>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setEventType('event')}
+              disabled={isSubmitting}
+              className={`flex items-center gap-3 p-4 rounded-lg border-2 text-left transition-all ${
+                eventType === 'event'
+                  ? 'border-primary bg-primary/10'
+                  : 'border-border hover:border-primary/40 hover:bg-primary/5'
+              }`}
+            >
+              <Zap size={20} className={eventType === 'event' ? 'text-primary' : 'text-muted-foreground'} />
+              <div>
+                <div className="font-medium text-foreground text-sm">Event</div>
+                <div className="text-xs text-muted-foreground">One occasion</div>
+              </div>
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="name">{eventType === 'event' ? 'Event' : 'Trip'} Name</Label>
+        <Input
+          type="text"
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={eventType === 'event' ? 'e.g., Team Dinner, Wedding Party' : 'e.g., Summer Vacation 2025'}
+          required
+          disabled={isSubmitting}
+        />
+      </div>
+
+      {eventType === 'trip' ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="start_date">Start Date</Label>
+            <Input
+              type="date"
+              id="start_date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="end_date">End Date</Label>
+            <Input
+              type="date"
+              id="end_date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              min={startDate}
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Label htmlFor="event_date">Date</Label>
+          <Input
+            type="date"
+            id="event_date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            required
+            disabled={isSubmitting}
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="defaultCurrency">Default Currency</Label>
+        <Input
+          id="defaultCurrency"
+          value={defaultCurrency}
+          onChange={(e) => setDefaultCurrency(e.target.value.toUpperCase().slice(0, 3))}
+          placeholder="EUR"
+          maxLength={3}
+          className="w-32 uppercase"
+          disabled={isSubmitting}
+        />
+        <p className="text-xs text-muted-foreground">
+          All balances and settlements will be shown in this currency
+        </p>
+      </div>
+
+      {/* Feature toggles — shown for trips only when creating; hidden for events by default */}
+      {!isEditMode && eventType === 'trip' && (
+        <div className="space-y-4">
+          <Label>Features</Label>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">Meal Planning</span>
+              <p className="text-xs text-muted-foreground">Plan meals and assign cooking responsibilities</p>
+            </div>
+            <Switch
+              checked={enableMeals}
+              onCheckedChange={setEnableMeals}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">Activity Planning</span>
+              <p className="text-xs text-muted-foreground">Plan activities for each day of your trip</p>
+            </div>
+            <Switch
+              checked={enableActivities}
+              onCheckedChange={setEnableActivities}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">Shopping List</span>
+              <p className="text-xs text-muted-foreground">Collaborative shopping list with real-time updates</p>
+            </div>
+            <Switch
+              checked={enableShopping}
+              onCheckedChange={setEnableShopping}
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <Label>Tracking Mode</Label>
+        {disableTrackingMode && (
+          <p className="text-sm text-muted-foreground">
+            Cannot change tracking mode after adding participants
+          </p>
+        )}
+        <div className="space-y-3">
+          <label className="flex items-start p-4 rounded-lg border-2 border-border cursor-pointer transition-all hover:border-primary hover:bg-primary/5 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
+            <input
+              type="radio"
+              name="trackingMode"
+              value="individuals"
+              checked={trackingMode === 'individuals'}
+              onChange={(e) => setTrackingMode(e.target.value as TrackingMode)}
+              className="mt-0.5 mr-3 text-primary focus:ring-primary"
+              disabled={isSubmitting || disableTrackingMode}
+            />
+            <div>
+              <div className="font-medium text-foreground">Individuals only</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Track expenses per person
+              </div>
+            </div>
+          </label>
+
+          <label className="flex items-start p-4 rounded-lg border-2 border-border cursor-pointer transition-all hover:border-primary hover:bg-primary/5 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
+            <input
+              type="radio"
+              name="trackingMode"
+              value="families"
+              checked={trackingMode === 'families'}
+              onChange={(e) => setTrackingMode(e.target.value as TrackingMode)}
+              className="mt-0.5 mr-3 text-primary focus:ring-primary"
+              disabled={isSubmitting || disableTrackingMode}
+            />
+            <div>
+              <div className="font-medium text-foreground">Individuals + Families</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Track at family level with individual breakdowns
+              </div>
+            </div>
+          </label>
+        </div>
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="flex-1"
+          size="lg"
+        >
+          {isSubmitting ? 'Saving...' : submitLabel}
+        </Button>
+        {onCancel && (
+          <Button
+            type="button"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            variant="outline"
+            size="lg"
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+    </motion.form>
+  )
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import { Outlet, Link, useLocation } from 'react-router-dom'
+import React from 'react'
 import { useState } from 'react'
 import {
   Home, DollarSign, CreditCard, CalendarDays,
@@ -30,10 +31,12 @@ import {
 } from "@/components/ui/sheet"
 
 // Icon mapping
-const iconMap = {
+const iconMap: Record<string, React.ElementType> = {
   'Overview': Home,
   'Trips': Home,
+  'Events & Trips': Home,
   'Manage Trip': Settings2,
+  'Manage Event': Settings2,
   'Expenses': DollarSign,
   'Settlements': CreditCard,
   'Day Planner': CalendarDays,
@@ -48,15 +51,17 @@ export function Layout() {
   const { user } = useAuth()
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
 
+  const manageLabel = currentTrip?.event_type === 'event' ? 'Manage Event' : 'Manage Trip'
+
   // Desktop navigation - all items visible
   const getDesktopNavItems = () => {
     const items = [
-      { path: '/', label: 'Trips', requiresTrip: false },
+      { path: '/', label: 'Events & Trips', requiresTrip: false },
     ]
 
     if (tripCode) {
       items.push(
-        { path: `/t/${tripCode}/manage`, label: 'Manage Trip', requiresTrip: true },
+        { path: `/t/${tripCode}/manage`, label: manageLabel, requiresTrip: true },
         { path: `/t/${tripCode}/expenses`, label: 'Expenses', requiresTrip: true },
         { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
       )
@@ -102,8 +107,8 @@ export function Layout() {
     }
 
     return [
-      { path: '/', label: 'Trips', requiresTrip: false },
-      { path: `/t/${tripCode}/manage`, label: 'Manage Trip', requiresTrip: true },
+      { path: '/', label: 'Events & Trips', requiresTrip: false },
+      { path: `/t/${tripCode}/manage`, label: manageLabel, requiresTrip: true },
       { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
     ]
   }

--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -1,18 +1,18 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
-import { Trip, CreateTripInput, UpdateTripInput } from '@/types/trip'
+import { Event, CreateEventInput, UpdateEventInput } from '@/types/trip'
 import { generateTripCode } from '@/lib/tripCodeGenerator'
 import { logger } from '@/lib/logger'
 
 interface TripContextType {
-  trips: Trip[]
+  trips: Event[]
   loading: boolean
   error: string | null
-  getTripById: (id: string) => Trip | undefined
-  getTripByCode: (tripCode: string) => Trip | undefined
-  createTrip: (input: CreateTripInput) => Promise<Trip | null>
-  updateTrip: (id: string, input: UpdateTripInput) => Promise<boolean>
+  getTripById: (id: string) => Event | undefined
+  getTripByCode: (tripCode: string) => Event | undefined
+  createTrip: (input: CreateEventInput) => Promise<Event | null>
+  updateTrip: (id: string, input: UpdateEventInput) => Promise<boolean>
   deleteTrip: (id: string) => Promise<boolean>
   refreshTrips: () => Promise<void>
 }
@@ -21,7 +21,7 @@ const TripContext = createContext<TripContextType | undefined>(undefined)
 
 export function TripProvider({ children }: { children: ReactNode }) {
   const { loading: authLoading, user } = useAuth()
-  const [trips, setTrips] = useState<Trip[]>([])
+  const [trips, setTrips] = useState<Event[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -37,7 +37,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
 
       if (fetchError) throw fetchError
 
-      setTrips((data as unknown as Trip[]) || [])
+      setTrips((data as unknown as Event[]) || [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch trips')
       logger.error('Failed to fetch trips', { error: err instanceof Error ? err.message : String(err) })
@@ -57,7 +57,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
   }
 
   // Create new trip
-  const createTrip = async (input: CreateTripInput): Promise<Trip | null> => {
+  const createTrip = async (input: CreateEventInput): Promise<Event | null> => {
     try {
       setError(null)
 
@@ -80,7 +80,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
 
       if (createError) throw createError
 
-      const newTrip = data as Trip
+      const newTrip = data as Event
       setTrips(prev => [newTrip, ...prev])
       logger.info('Trip created', { trip_id: newTrip.id, name: newTrip.name })
 
@@ -93,7 +93,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
   }
 
   // Update trip
-  const updateTrip = async (id: string, input: UpdateTripInput): Promise<boolean> => {
+  const updateTrip = async (id: string, input: UpdateEventInput): Promise<boolean> => {
     try {
       setError(null)
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -60,13 +60,13 @@ export function HomePage() {
         <div className="flex gap-3 mb-8">
           <Button onClick={handleCreateTrip} className="gap-2">
             <Plus size={18} />
-            Create New Trip
+            Create New
           </Button>
         </div>
 
         {/* My Trips List */}
         <div>
-          <h2 className="text-xl font-semibold text-foreground mb-4">My Trips</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-4">My Events & Trips</h2>
 
           {myTrips.length === 0 ? (
             <Card>
@@ -74,14 +74,14 @@ export function HomePage() {
                 <div className="text-center py-12">
                   <Calendar size={48} className="mx-auto text-muted-foreground/50 mb-4" />
                   <h3 className="text-lg font-semibold text-foreground mb-2">
-                    No trips yet
+                    Nothing yet
                   </h3>
                   <p className="text-muted-foreground mb-6">
-                    Create a new trip or access one via a shared link
+                    Create a new trip or event, or access one via a shared link
                   </p>
                   <Button onClick={handleCreateTrip} variant="outline" className="gap-2">
                     <Plus size={18} />
-                    Create Your First Trip
+                    Create Your First
                   </Button>
                 </div>
               </CardContent>

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -8,7 +8,7 @@ import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useMealContext } from '@/contexts/MealContext'
 import { IndividualsSetup } from '@/components/setup/IndividualsSetup'
 import { FamiliesSetup } from '@/components/setup/FamiliesSetup'
-import { TripForm } from '@/components/TripForm'
+import { EventForm } from '@/components/EventForm'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
@@ -34,7 +34,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { useToast } from '@/hooks/use-toast'
-import { CreateTripInput } from '@/types/trip'
+import { CreateEventInput } from '@/types/trip'
 import { StaySection } from '@/components/StaySection'
 
 export function ManageTripPage() {
@@ -62,11 +62,11 @@ export function ManageTripPage() {
   if (!currentTrip) {
     return (
       <div className="space-y-4">
-        <h2 className="text-2xl font-bold text-foreground">Manage Trip</h2>
+        <h2 className="text-2xl font-bold text-foreground">Manage</h2>
         <Card>
           <CardContent className="pt-6">
             <p className="text-muted-foreground">
-              No trip selected. Please select a trip to view settings.
+              No trip or event selected.
             </p>
           </CardContent>
         </Card>
@@ -74,13 +74,17 @@ export function ManageTripPage() {
     )
   }
 
-  const handleEditTrip = async (values: CreateTripInput) => {
+  const entityLabel = currentTrip.event_type === 'event' ? 'Event' : 'Trip'
+  const isEvent = currentTrip.event_type === 'event'
+
+  const handleEditTrip = async (values: CreateEventInput) => {
     setIsUpdating(true)
     try {
       const success = await updateTrip(currentTrip.id, {
         name: values.name,
         start_date: values.start_date,
         end_date: values.end_date,
+        event_type: values.event_type,
         tracking_mode: values.tracking_mode,
         default_currency: values.default_currency,
       })
@@ -88,21 +92,21 @@ export function ManageTripPage() {
       if (success) {
         setShowEditDialog(false)
         toast({
-          title: 'Trip updated',
-          description: 'Your trip details have been saved.',
+          title: `${entityLabel} updated`,
+          description: 'Your details have been saved.',
         })
       } else {
         toast({
           variant: 'destructive',
           title: 'Update failed',
-          description: 'Failed to update trip. Please try again.',
+          description: `Failed to update ${entityLabel.toLowerCase()}. Please try again.`,
         })
       }
     } catch (err) {
       toast({
         variant: 'destructive',
         title: 'Error',
-        description: 'An error occurred while updating the trip.',
+        description: `An error occurred while updating the ${entityLabel.toLowerCase()}.`,
       })
     } finally {
       setIsUpdating(false)
@@ -197,8 +201,8 @@ export function ManageTripPage() {
         localStorage.setItem('myTrips', JSON.stringify(filtered))
 
         toast({
-          title: 'Trip deleted',
-          description: 'The trip has been permanently deleted.',
+          title: `${entityLabel} deleted`,
+          description: `The ${entityLabel.toLowerCase()} has been permanently deleted.`,
         })
 
         // Navigate to home page
@@ -207,14 +211,14 @@ export function ManageTripPage() {
         toast({
           variant: 'destructive',
           title: 'Delete failed',
-          description: 'Failed to delete trip. Please try again.',
+          description: `Failed to delete ${entityLabel.toLowerCase()}. Please try again.`,
         })
       }
     } catch (err) {
       toast({
         variant: 'destructive',
         title: 'Error',
-        description: 'An error occurred while deleting the trip.',
+        description: `An error occurred while deleting the ${entityLabel.toLowerCase()}.`,
       })
     } finally {
       setIsDeleting(false)
@@ -225,38 +229,49 @@ export function ManageTripPage() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h2 className="text-2xl font-bold text-foreground">Manage Trip</h2>
+        <h2 className="text-2xl font-bold text-foreground">Manage {entityLabel}</h2>
         <p className="text-sm text-muted-foreground mt-1">{currentTrip.name}</p>
       </div>
 
-      {/* Trip Details Card */}
+      {/* Details Card */}
       <Card>
         <CardHeader>
-          <CardTitle>Trip Details</CardTitle>
-          <CardDescription>View and edit your trip information</CardDescription>
+          <CardTitle>{entityLabel} Details</CardTitle>
+          <CardDescription>View and edit your {entityLabel.toLowerCase()} information</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <Label className="text-muted-foreground">Trip Name</Label>
+              <Label className="text-muted-foreground">Name</Label>
               <p className="text-sm font-medium">{currentTrip.name}</p>
             </div>
             <div>
-              <Label className="text-muted-foreground">Trip Code</Label>
+              <Label className="text-muted-foreground">Code</Label>
               <p className="text-sm font-mono font-medium">{tripCode}</p>
             </div>
-            <div>
-              <Label className="text-muted-foreground">Start Date</Label>
-              <p className="text-sm font-medium">
-                {format(new Date(currentTrip.start_date), 'PPP')}
-              </p>
-            </div>
-            <div>
-              <Label className="text-muted-foreground">End Date</Label>
-              <p className="text-sm font-medium">
-                {format(new Date(currentTrip.end_date), 'PPP')}
-              </p>
-            </div>
+            {isEvent ? (
+              <div>
+                <Label className="text-muted-foreground">Date</Label>
+                <p className="text-sm font-medium">
+                  {format(new Date(currentTrip.start_date), 'PPP')}
+                </p>
+              </div>
+            ) : (
+              <>
+                <div>
+                  <Label className="text-muted-foreground">Start Date</Label>
+                  <p className="text-sm font-medium">
+                    {format(new Date(currentTrip.start_date), 'PPP')}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-muted-foreground">End Date</Label>
+                  <p className="text-sm font-medium">
+                    {format(new Date(currentTrip.end_date), 'PPP')}
+                  </p>
+                </div>
+              </>
+            )}
             <div>
               <Label className="text-muted-foreground">Tracking Mode</Label>
               <p className="text-sm font-medium capitalize">{currentTrip.tracking_mode}</p>
@@ -264,7 +279,7 @@ export function ManageTripPage() {
           </div>
           <Button onClick={() => setShowEditDialog(true)} className="mt-4">
             <Edit size={16} className="mr-2" />
-            Edit Trip Details
+            Edit Details
           </Button>
         </CardContent>
       </Card>
@@ -273,13 +288,13 @@ export function ManageTripPage() {
       <Card>
         <CardHeader>
           <CardTitle>Features</CardTitle>
-          <CardDescription>Enable or disable optional features for this trip</CardDescription>
+          <CardDescription>Enable or disable optional features for this {entityLabel.toLowerCase()}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="space-y-0.5">
               <Label>Meal Planning</Label>
-              <p className="text-xs text-muted-foreground">Plan meals for each day of your trip</p>
+              <p className="text-xs text-muted-foreground">Plan meals for each day</p>
             </div>
             <Switch
               checked={currentTrip.enable_meals}
@@ -290,7 +305,7 @@ export function ManageTripPage() {
           <div className="flex items-center justify-between">
             <div className="space-y-0.5">
               <Label>Activity Planning</Label>
-              <p className="text-xs text-muted-foreground">Plan activities for each day of your trip</p>
+              <p className="text-xs text-muted-foreground">Plan activities for each day</p>
             </div>
             <Switch
               checked={currentTrip.enable_activities}
@@ -327,7 +342,7 @@ export function ManageTripPage() {
       <Card>
         <CardHeader>
           <CardTitle>Currency Settings</CardTitle>
-          <CardDescription>Set your trip's default currency and exchange rates</CardDescription>
+          <CardDescription>Set the default currency and exchange rates</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
@@ -434,7 +449,7 @@ export function ManageTripPage() {
             <AlertDialogTrigger asChild>
               <Button variant="destructive">
                 <Trash2 size={16} className="mr-2" />
-                Delete Trip
+                Delete {entityLabel}
               </Button>
             </AlertDialogTrigger>
             <AlertDialogContent>
@@ -442,7 +457,7 @@ export function ManageTripPage() {
                 <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
                 <AlertDialogDescription>
                   This will permanently delete <strong>"{currentTrip.name}"</strong> and all
-                  associated data including expenses, settlements, meals, and shopping items.
+                  associated data including expenses, settlements, and shopping items.
                   <br />
                   <br />
                   <strong>This action cannot be undone.</strong>
@@ -455,7 +470,7 @@ export function ManageTripPage() {
                   disabled={isDeleting}
                   className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 >
-                  {isDeleting ? 'Deleting...' : 'Delete Trip'}
+                  {isDeleting ? 'Deleting...' : `Delete ${entityLabel}`}
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
@@ -467,9 +482,9 @@ export function ManageTripPage() {
       <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Edit Trip Details</DialogTitle>
+            <DialogTitle>Edit {entityLabel} Details</DialogTitle>
             <DialogDescription>
-              Update your trip name, dates, or tracking mode
+              Update the name, dates, or tracking mode
             </DialogDescription>
           </DialogHeader>
 
@@ -478,17 +493,18 @@ export function ManageTripPage() {
             <Alert>
               <Info size={16} className="mt-0.5" />
               <AlertDescription>
-                <strong>Note:</strong> Changing trip dates may hide meals that fall outside the
+                <strong>Note:</strong> Changing dates may hide meals that fall outside the
                 new date range. Those meals will remain in the database.
               </AlertDescription>
             </Alert>
           )}
 
-          <TripForm
+          <EventForm
             initialValues={{
               name: currentTrip.name,
               start_date: currentTrip.start_date,
               end_date: currentTrip.end_date,
+              event_type: currentTrip.event_type,
               tracking_mode: currentTrip.tracking_mode,
               default_currency: currentTrip.default_currency,
             }}

--- a/src/pages/QuickHomeScreen.tsx
+++ b/src/pages/QuickHomeScreen.tsx
@@ -80,11 +80,11 @@ export function QuickHomeScreen() {
             <CardContent className="pt-6">
               <div className="text-center py-8">
                 <p className="text-muted-foreground mb-4">
-                  No groups yet. Create a trip or join one via a shared link.
+                  No groups yet. Create a trip or event, or join one via a shared link.
                 </p>
                 <Button onClick={() => navigate('/create-trip')} className="gap-2">
                   <Plus size={18} />
-                  Create Trip
+                  Create New
                 </Button>
               </div>
             </CardContent>
@@ -154,7 +154,7 @@ export function QuickHomeScreen() {
           <div className="mt-6 text-center">
             <Button variant="outline" onClick={() => navigate('/create-trip')} className="gap-2">
               <Plus size={16} />
-              Create New Trip
+              Create New
             </Button>
           </div>
         )}
@@ -183,7 +183,7 @@ export function QuickHomeScreen() {
                 size={16}
                 className={`transition-transform ${showHidden ? 'rotate-180' : ''}`}
               />
-              {hiddenTrips.length} hidden {hiddenTrips.length === 1 ? 'trip' : 'trips'}
+              {hiddenTrips.length} hidden {hiddenTrips.length === 1 ? 'group' : 'groups'}
             </button>
 
             {showHidden && (

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
-import { TripForm } from '@/components/TripForm'
+import { EventForm } from '@/components/EventForm'
 import { SignInButton } from '@/components/auth/SignInButton'
-import { CreateTripInput } from '@/types/trip'
+import { CreateEventInput } from '@/types/trip'
 import { Card, CardContent } from '@/components/ui/card'
 import { LogIn } from 'lucide-react'
 
@@ -12,27 +12,27 @@ export function TripsPage() {
   const { user } = useAuth()
   const { createTrip, error } = useTripContext()
 
-  const handleCreateTrip = async (input: CreateTripInput) => {
-    const newTrip = await createTrip(input)
-    if (!newTrip) {
-      throw new Error('Failed to create trip')
+  const handleCreate = async (input: CreateEventInput) => {
+    const newEvent = await createTrip(input)
+    if (!newEvent) {
+      throw new Error('Failed to create')
     }
-    navigate(`/t/${newTrip.trip_code}/manage`)
+    navigate(`/t/${newEvent.trip_code}/manage`)
   }
 
   const handleCancel = () => {
-    // Go back to home page
     navigate('/')
   }
 
-  // Require authentication to create trips
+  const label = 'Create New'
+
   if (!user) {
     return (
       <div className="max-w-2xl mx-auto space-y-6">
         <div>
-          <h2 className="text-2xl font-bold text-foreground">Create New Trip</h2>
+          <h2 className="text-2xl font-bold text-foreground">{label}</h2>
           <p className="text-sm text-muted-foreground mt-1">
-            Set up a new trip and get a shareable link
+            Set up a new trip or event and get a shareable link
           </p>
         </div>
 
@@ -41,10 +41,10 @@ export function TripsPage() {
             <div className="text-center py-8">
               <LogIn size={48} className="mx-auto text-muted-foreground/50 mb-4" />
               <h3 className="text-lg font-semibold text-foreground mb-2">
-                Sign in to create a trip
+                Sign in to create
               </h3>
               <p className="text-sm text-muted-foreground mb-6">
-                You need to be signed in to create and manage trips.
+                You need to be signed in to create and manage trips and events.
               </p>
               <div className="flex justify-center">
                 <SignInButton />
@@ -60,9 +60,9 @@ export function TripsPage() {
     <div className="max-w-2xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-foreground">Create New Trip</h2>
+          <h2 className="text-2xl font-bold text-foreground">{label}</h2>
           <p className="text-sm text-muted-foreground mt-1">
-            Set up a new trip and get a shareable link
+            Set up a new trip or event and get a shareable link
           </p>
         </div>
       </div>
@@ -75,8 +75,8 @@ export function TripsPage() {
 
       <Card>
         <CardContent className="pt-6">
-          <TripForm
-            onSubmit={handleCreateTrip}
+          <EventForm
+            onSubmit={handleCreate}
             onCancel={handleCancel}
           />
         </CardContent>
@@ -87,9 +87,9 @@ export function TripsPage() {
           <strong>What happens next:</strong>
         </p>
         <ul className="text-sm text-muted-foreground space-y-1 mt-2">
-          <li>• A unique trip code will be generated (e.g., summer-2025-a3x9k2)</li>
-          <li>• You'll be able to add participants to your trip</li>
-          <li>• Share the trip link with your group via QR code or direct link</li>
+          <li>• A unique code will be generated (e.g., summer-2025-a3x9k2)</li>
+          <li>• You'll be able to add participants</li>
+          <li>• Share the link with your group via QR code or direct link</li>
           <li>• Everyone can view and add expenses in real-time</li>
         </ul>
       </div>

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,7 +1,7 @@
 import type { Participant, Family } from '@/types/participant'
 import type { Expense, ExpenseDistribution } from '@/types/expense'
 import type { Settlement } from '@/types/settlement'
-import type { Trip } from '@/types/trip'
+import type { Event } from '@/types/trip'
 
 let _id = 0
 function nextId(): string {
@@ -72,7 +72,7 @@ export function buildSettlement(overrides: Partial<Settlement> = {}): Settlement
   }
 }
 
-export function buildTrip(overrides: Partial<Trip> = {}): Trip {
+export function buildEvent(overrides: Partial<Event> = {}): Event {
   const id = overrides.id ?? nextId()
   return {
     id,
@@ -80,6 +80,7 @@ export function buildTrip(overrides: Partial<Trip> = {}): Trip {
     name: `Trip ${id}`,
     start_date: '2025-07-01',
     end_date: '2025-07-10',
+    event_type: 'trip',
     tracking_mode: 'individuals',
     default_currency: 'EUR',
     exchange_rates: {},
@@ -91,3 +92,6 @@ export function buildTrip(overrides: Partial<Trip> = {}): Trip {
     ...overrides,
   }
 }
+
+// Backward-compatible alias
+export const buildTrip = buildEvent

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -1,11 +1,12 @@
 export type TrackingMode = 'individuals' | 'families'
 
-export interface Trip {
+export interface Event {
   id: string
   trip_code: string // URL-friendly code for sharing (e.g., "summer-2025-a3x9k2")
   name: string
   start_date: string // ISO date string (YYYY-MM-DD)
   end_date: string // ISO date string (YYYY-MM-DD)
+  event_type: 'trip' | 'event'
   tracking_mode: TrackingMode
   default_currency: string
   exchange_rates: Record<string, number>
@@ -17,10 +18,11 @@ export interface Trip {
   created_at: string
 }
 
-export interface CreateTripInput {
+export interface CreateEventInput {
   name: string
   start_date: string
   end_date: string
+  event_type?: 'trip' | 'event'
   tracking_mode: TrackingMode
   trip_code?: string // Optional: will be auto-generated if not provided
   default_currency?: string
@@ -29,10 +31,11 @@ export interface CreateTripInput {
   enable_shopping?: boolean
 }
 
-export interface UpdateTripInput {
+export interface UpdateEventInput {
   name?: string
   start_date?: string
   end_date?: string
+  event_type?: 'trip' | 'event'
   tracking_mode?: TrackingMode
   default_currency?: string
   exchange_rates?: Record<string, number>
@@ -41,3 +44,8 @@ export interface UpdateTripInput {
   enable_shopping?: boolean
   default_split_all?: boolean
 }
+
+// Backward-compatible aliases — use Event, CreateEventInput, UpdateEventInput in new code
+export type Trip = Event
+export type CreateTripInput = CreateEventInput
+export type UpdateTripInput = UpdateEventInput

--- a/supabase/migrations/019_event_type.sql
+++ b/supabase/migrations/019_event_type.sql
@@ -1,0 +1,5 @@
+-- Add event_type column to trips table
+-- Existing rows default to 'trip' (backward compatible)
+ALTER TABLE trips
+  ADD COLUMN event_type TEXT NOT NULL DEFAULT 'trip'
+    CHECK (event_type IN ('trip', 'event'));


### PR DESCRIPTION
## Summary

- **DB migration** (`019_event_type.sql`): adds `event_type TEXT NOT NULL DEFAULT 'trip' CHECK (IN ('trip','event'))` to `trips` table
- **TypeScript rename**: `Trip` → `Event`, `CreateTripInput` → `CreateEventInput`, `UpdateTripInput` → `UpdateEventInput`; backward-compat type aliases keep all existing code compiling without mass changes
- **`EventForm`** (new): type selector (Trip / Event) at the top, single date input for events (auto-sets `end_date = start_date`), feature toggles (meals/activities/shopping) shown only for trips
- **`EventCard`** (new): shows type badge — Trip (blue outline) or Event (amber) — and shows a single date for events
- **`ManageTripPage`**: dynamic "Manage Trip / Manage Event" heading, single-date display in details card for events, uses `EventForm` in edit dialog, all "Trip" strings made dynamic via `entityLabel`
- **`TripsPage`**: uses `EventForm`, updated to "Create New" heading
- **`Layout`**: dynamic nav label ("Manage Trip" vs "Manage Event"), home link shows "Events & Trips"
- **`QuickHomeScreen`**, **`HomePage`**: "Create New Trip" → "Create New", "My Trips" → "My Events & Trips"
- **`factories.ts`**: new `buildEvent` factory with `event_type: 'trip'` default; `buildTrip` kept as alias so all existing tests pass unchanged

## Test plan

- [ ] Run migration on Supabase: `ALTER TABLE trips ADD COLUMN event_type TEXT NOT NULL DEFAULT 'trip' CHECK (event_type IN ('trip', 'event'))`
- [ ] Create a new Trip — type selector shows "Trip" selected, date range visible, feature toggles visible
- [ ] Create a new Event — type selector shows "Event" selected, single date only, no feature toggles shown
- [ ] Verify event is saved with `event_type = 'event'` in DB
- [ ] Open a trip's Manage page — heading shows "Manage Trip"
- [ ] Open an event's Manage page — heading shows "Manage Event", single date shown in details
- [ ] `npm run type-check` passes clean ✅
- [ ] `npm test` — 138 passed, 1 pre-existing failure (AuthContext) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)