### PR TITLE
Add AI Receipt Reader — Phase 3

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -15,6 +15,7 @@ import { MealProvider } from '@/contexts/MealContext'
 import { ActivityProvider } from '@/contexts/ActivityContext'
 import { StayProvider } from '@/contexts/StayContext'
 import { ShoppingProvider } from '@/contexts/ShoppingContext'
+import { ReceiptProvider } from '@/contexts/ReceiptContext'
 import { Toaster } from '@/components/ui/toaster'
 import { getTripGradientPattern } from '@/services/tripGradientService'
 import { SignInButton } from '@/components/auth/SignInButton'
@@ -194,7 +195,9 @@ export function Layout() {
                 <ActivityProvider>
                   <StayProvider>
                     <ShoppingProvider>
-                      <Outlet />
+                      <ReceiptProvider>
+                        <Outlet />
+                      </ReceiptProvider>
                     </ShoppingProvider>
                   </StayProvider>
                 </ActivityProvider>

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -7,6 +7,7 @@ import { ExpenseProvider } from '@/contexts/ExpenseContext'
 import { SettlementProvider } from '@/contexts/SettlementContext'
 import { MealProvider } from '@/contexts/MealContext'
 import { ShoppingProvider } from '@/contexts/ShoppingContext'
+import { ReceiptProvider } from '@/contexts/ReceiptContext'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { SignInButton } from '@/components/auth/SignInButton'
 import { ModeToggle } from '@/components/quick/ModeToggle'
@@ -93,7 +94,9 @@ export function QuickLayout() {
             <SettlementProvider>
               <MealProvider>
                 <ShoppingProvider>
-                  <Outlet />
+                  <ReceiptProvider>
+                    <Outlet />
+                  </ReceiptProvider>
                 </ShoppingProvider>
               </MealProvider>
             </SettlementProvider>

--- a/src/components/receipts/ReceiptCaptureSheet.tsx
+++ b/src/components/receipts/ReceiptCaptureSheet.tsx
@@ -1,0 +1,287 @@
+import { useState, useRef } from 'react'
+import { Camera, Upload, Loader2, X, ScanLine } from 'lucide-react'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { supabase } from '@/lib/supabase'
+import { useReceiptContext } from '@/contexts/ReceiptContext'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { logger } from '@/lib/logger'
+import { ExtractedItem } from '@/types/receipt'
+
+interface ReceiptCaptureSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  tripId?: string
+  onProcessed: (taskId: string, data: {
+    merchant: string | null
+    items: ExtractedItem[]
+    total: number | null
+    currency: string
+  }) => void
+}
+
+function compressImage(file: File): Promise<Blob> {
+  return Promise.race([
+    new Promise<Blob>((resolve, reject) => {
+      const img = new Image()
+      const url = URL.createObjectURL(file)
+      img.onload = () => {
+        URL.revokeObjectURL(url)
+        const maxWidth = 1200
+        let { width, height } = img
+        if (width > maxWidth) {
+          height = Math.round((height * maxWidth) / width)
+          width = maxWidth
+        }
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext('2d')!
+        ctx.drawImage(img, 0, 0, width, height)
+        canvas.toBlob(
+          (blob) => (blob ? resolve(blob) : reject(new Error('Compression failed'))),
+          'image/jpeg',
+          0.8
+        )
+      }
+      img.onerror = () => {
+        URL.revokeObjectURL(url)
+        reject(new Error('Failed to load image'))
+      }
+      img.src = url
+    }),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Image compression timed out')), 10000)
+    ),
+  ])
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      // Strip the data URL prefix (e.g. "data:image/jpeg;base64,")
+      const base64 = result.split(',')[1]
+      resolve(base64)
+    }
+    reader.onerror = () => reject(new Error('Failed to convert image to base64'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+export function ReceiptCaptureSheet({ open, onOpenChange, onProcessed }: ReceiptCaptureSheetProps) {
+  const { currentTrip } = useCurrentTrip()
+  const { createReceiptTask } = useReceiptContext()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const cameraInputRef = useRef<HTMLInputElement>(null)
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [scanning, setScanning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleFileSelected = (file: File) => {
+    setError(null)
+    setSelectedFile(file)
+    const url = URL.createObjectURL(file)
+    setPreviewUrl(url)
+  }
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) handleFileSelected(file)
+  }
+
+  const handleReset = () => {
+    setSelectedFile(null)
+    if (previewUrl) URL.revokeObjectURL(previewUrl)
+    setPreviewUrl(null)
+    setError(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    if (cameraInputRef.current) cameraInputRef.current.value = ''
+  }
+
+  const handleScan = async () => {
+    if (!selectedFile || !currentTrip) return
+    setScanning(true)
+    setError(null)
+
+    try {
+      // 1. Compress image
+      const compressed = await compressImage(selectedFile)
+      const base64 = await blobToBase64(compressed)
+
+      // 2. Create receipt_tasks row (pending)
+      const task = await createReceiptTask(currentTrip.id)
+      if (!task) {
+        setError('Failed to create receipt task. Please try again.')
+        setScanning(false)
+        return
+      }
+
+      // 3. Invoke edge function synchronously
+      logger.info('Invoking process-receipt', { task_id: task.id })
+      const { data, error: fnError } = await supabase.functions.invoke('process-receipt', {
+        body: {
+          receipt_task_id: task.id,
+          image_base64: base64,
+          mime_type: 'image/jpeg',
+        },
+      })
+
+      if (fnError || !data?.ok) {
+        const message = data?.error ?? fnError?.message ?? 'Failed to process receipt'
+        logger.error('process-receipt failed', { error: message, task_id: task.id })
+        setError(message)
+        setScanning(false)
+        return
+      }
+
+      // 4. Success — pass data to parent
+      onProcessed(task.id, {
+        merchant: data.merchant ?? null,
+        items: data.items ?? [],
+        total: data.total ?? null,
+        currency: data.currency ?? currentTrip.default_currency,
+      })
+
+      // Reset for next use
+      handleReset()
+      onOpenChange(false)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'An error occurred'
+      logger.error('Receipt capture failed', { error: message })
+      setError(message)
+    } finally {
+      setScanning(false)
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && !scanning) {
+      handleReset()
+    }
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent side="bottom" className="h-[85vh] flex flex-col">
+        <SheetHeader className="pb-2">
+          <SheetTitle className="flex items-center gap-2">
+            <ScanLine size={20} />
+            Scan Receipt
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="flex-1 flex flex-col gap-4 overflow-y-auto">
+          {!previewUrl ? (
+            /* File selection state */
+            <div className="flex-1 flex flex-col items-center justify-center gap-4 py-8">
+              <div className="w-24 h-24 rounded-full bg-muted flex items-center justify-center">
+                <Camera size={40} className="text-muted-foreground" />
+              </div>
+              <div className="text-center">
+                <p className="font-medium text-foreground">Add a receipt photo</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Take a photo or upload from your library
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-2 w-full max-w-xs">
+                {/* Camera capture (mobile) */}
+                <Button
+                  variant="default"
+                  className="gap-2"
+                  onClick={() => cameraInputRef.current?.click()}
+                >
+                  <Camera size={16} />
+                  Take Photo
+                </Button>
+
+                {/* File picker */}
+                <Button
+                  variant="outline"
+                  className="gap-2"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Upload size={16} />
+                  Choose from Library
+                </Button>
+              </div>
+
+              {/* Hidden file inputs */}
+              <input
+                ref={cameraInputRef}
+                type="file"
+                accept="image/*"
+                capture="environment"
+                className="hidden"
+                onChange={handleFileInputChange}
+              />
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleFileInputChange}
+              />
+            </div>
+          ) : (
+            /* Preview state */
+            <div className="flex-1 flex flex-col gap-4">
+              <div className="relative rounded-lg overflow-hidden border border-border">
+                <img
+                  src={previewUrl}
+                  alt="Receipt preview"
+                  className="w-full max-h-64 object-contain bg-muted"
+                />
+                {!scanning && (
+                  <button
+                    onClick={handleReset}
+                    className="absolute top-2 right-2 rounded-full bg-background/80 p-1 border border-border"
+                    aria-label="Remove image"
+                  >
+                    <X size={16} />
+                  </button>
+                )}
+              </div>
+
+              {error && (
+                <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-3 py-2">
+                  {error}
+                </div>
+              )}
+
+              <Button
+                onClick={handleScan}
+                disabled={scanning}
+                size="lg"
+                className="gap-2"
+              >
+                {scanning ? (
+                  <>
+                    <Loader2 size={16} className="animate-spin" />
+                    Analyzing receipt...
+                  </>
+                ) : (
+                  <>
+                    <ScanLine size={16} />
+                    Scan Receipt
+                  </>
+                )}
+              </Button>
+
+              {scanning && (
+                <p className="text-xs text-muted-foreground text-center">
+                  This usually takes 5–10 seconds
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -1,0 +1,522 @@
+import { useState, useEffect, useMemo } from 'react'
+import { Loader2, Users, ChevronDown, ChevronUp, AlertCircle } from 'lucide-react'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useExpenseContext } from '@/contexts/ExpenseContext'
+import { useReceiptContext } from '@/contexts/ReceiptContext'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useAuth } from '@/contexts/AuthContext'
+import { useToast } from '@/hooks/use-toast'
+import { ExtractedItem } from '@/types/receipt'
+import { IndividualsDistribution, ExpenseCategory } from '@/types/expense'
+import { Participant } from '@/types/participant'
+
+interface ReceiptReviewSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  taskId: string
+  merchant: string | null
+  items: ExtractedItem[]
+  extractedTotal: number | null
+  currency: string
+  onDone: () => void
+}
+
+// Participant chip color palette (consistent across rerenders)
+const CHIP_COLORS = [
+  'bg-blue-500',
+  'bg-emerald-500',
+  'bg-violet-500',
+  'bg-amber-500',
+  'bg-rose-500',
+  'bg-cyan-500',
+  'bg-fuchsia-500',
+  'bg-teal-500',
+]
+
+function getChipColor(index: number) {
+  return CHIP_COLORS[index % CHIP_COLORS.length]
+}
+
+function participantInitial(name: string) {
+  return name.charAt(0).toUpperCase()
+}
+
+interface EditableItem {
+  name: string
+  price: string // string for controlled input
+  qty: number
+  assignedIds: Set<string>
+}
+
+function buildDistribution(
+  editableItems: EditableItem[],
+  confirmedTotal: number,
+  tipAmount: number
+): { distribution: IndividualsDistribution; totalAmount: number } {
+  const rawShares: Record<string, number> = {}
+
+  for (const item of editableItems) {
+    const price = parseFloat(item.price) || 0
+    const assignedArr = Array.from(item.assignedIds)
+    if (assignedArr.length === 0 || price === 0) continue
+    const sharePerPerson = price / assignedArr.length
+    for (const pid of assignedArr) {
+      rawShares[pid] = (rawShares[pid] ?? 0) + sharePerPerson
+    }
+  }
+
+  const includedIds = Object.keys(rawShares)
+  if (includedIds.length === 0) {
+    return {
+      distribution: { type: 'individuals', participants: [], splitMode: 'amount', participantSplits: [] },
+      totalAmount: confirmedTotal + tipAmount,
+    }
+  }
+
+  const rawTotal = Object.values(rawShares).reduce((a, b) => a + b, 0)
+  const scaleFactor = rawTotal > 0 ? confirmedTotal / rawTotal : 1
+
+  // Scale shares to match confirmed_total
+  const participantSplits = includedIds.map(pid => ({
+    participantId: pid,
+    value: Math.round(rawShares[pid] * scaleFactor * 100) / 100,
+  }))
+
+  // Fix rounding on last participant
+  const sumScaled = participantSplits.reduce((a, b) => a + b.value, 0)
+  const roundingAdj = Math.round((confirmedTotal - sumScaled) * 100) / 100
+  participantSplits[participantSplits.length - 1].value += roundingAdj
+
+  // Add tip equally
+  const totalAmount = confirmedTotal + tipAmount
+  if (tipAmount > 0) {
+    const tipPerPerson = Math.round((tipAmount / includedIds.length) * 100) / 100
+    for (const split of participantSplits) {
+      split.value = Math.round((split.value + tipPerPerson) * 100) / 100
+    }
+    // Fix tip rounding
+    const sumWithTip = participantSplits.reduce((a, b) => a + b.value, 0)
+    const tipAdj = Math.round((totalAmount - sumWithTip) * 100) / 100
+    participantSplits[participantSplits.length - 1].value += tipAdj
+  }
+
+  return {
+    distribution: {
+      type: 'individuals',
+      participants: includedIds,
+      splitMode: 'amount',
+      participantSplits,
+    },
+    totalAmount,
+  }
+}
+
+export function ReceiptReviewSheet({
+  open,
+  onOpenChange,
+  taskId,
+  merchant,
+  items: initialItems,
+  extractedTotal,
+  currency,
+  onDone,
+}: ReceiptReviewSheetProps) {
+  const { currentTrip } = useCurrentTrip()
+  const { participants, getAdultParticipants } = useParticipantContext()
+  const { createExpense } = useExpenseContext()
+  const { completeReceiptTask } = useReceiptContext()
+  const { user } = useAuth()
+  const { toast } = useToast()
+
+  const adultParticipants = getAdultParticipants()
+
+  // Editable items state
+  const [editableItems, setEditableItems] = useState<EditableItem[]>([])
+  const [confirmedTotal, setConfirmedTotal] = useState('')
+  const [tipAmount, setTipAmount] = useState('0')
+  const [paidBy, setPaidBy] = useState('')
+  const [category, setCategory] = useState<ExpenseCategory>('Food')
+  const [merchantName, setMerchantName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [showAllItems, setShowAllItems] = useState(true)
+
+  // Reset state when sheet opens with new data
+  useEffect(() => {
+    if (!open) return
+
+    const defaultPayerId = adultParticipants.find(p => p.user_id === user?.id)?.id ?? adultParticipants[0]?.id ?? ''
+
+    setEditableItems(
+      initialItems.map(item => ({
+        name: item.name,
+        price: item.price.toFixed(2),
+        qty: item.qty,
+        assignedIds: new Set<string>(),
+      }))
+    )
+    setConfirmedTotal(extractedTotal != null ? extractedTotal.toFixed(2) : '')
+    setTipAmount('0')
+    setPaidBy(defaultPayerId)
+    setMerchantName(merchant ?? '')
+    setCategory('Food')
+    setShowAllItems(true)
+  }, [open, taskId])
+
+  // Toggle a participant for an item
+  const toggleParticipant = (itemIndex: number, participantId: string) => {
+    setEditableItems(prev =>
+      prev.map((item, i) => {
+        if (i !== itemIndex) return item
+        const next = new Set(item.assignedIds)
+        if (next.has(participantId)) {
+          next.delete(participantId)
+        } else {
+          next.add(participantId)
+        }
+        return { ...item, assignedIds: next }
+      })
+    )
+  }
+
+  // Toggle all participants for an item
+  const toggleAll = (itemIndex: number) => {
+    setEditableItems(prev =>
+      prev.map((item, i) => {
+        if (i !== itemIndex) return item
+        const allIds = participants.map(p => p.id)
+        const allAssigned = allIds.every(id => item.assignedIds.has(id))
+        return {
+          ...item,
+          assignedIds: allAssigned ? new Set() : new Set(allIds),
+        }
+      })
+    )
+  }
+
+  const updateItemName = (index: number, name: string) => {
+    setEditableItems(prev => prev.map((item, i) => (i === index ? { ...item, name } : item)))
+  }
+
+  const updateItemPrice = (index: number, price: string) => {
+    setEditableItems(prev =>
+      prev.map((item, i) =>
+        i === index ? { ...item, price: price.replace(',', '.') } : item
+      )
+    )
+  }
+
+  const itemsTotal = useMemo(
+    () => editableItems.reduce((sum, item) => sum + (parseFloat(item.price) || 0), 0),
+    [editableItems]
+  )
+
+  const totalFloat = parseFloat(confirmedTotal) || 0
+  const tipFloat = parseFloat(tipAmount) || 0
+  const totalExpense = totalFloat + tipFloat
+
+  const unassignedItems = editableItems.filter(item => item.assignedIds.size === 0 && parseFloat(item.price) > 0)
+  const canSubmit =
+    paidBy &&
+    totalFloat > 0 &&
+    unassignedItems.length === 0 &&
+    editableItems.some(item => item.assignedIds.size > 0)
+
+  const handleSubmit = async () => {
+    if (!currentTrip || !canSubmit) return
+    setSubmitting(true)
+
+    try {
+      const { distribution, totalAmount } = buildDistribution(editableItems, totalFloat, tipFloat)
+
+      const description = merchantName.trim()
+        ? `Receipt: ${merchantName.trim()}`
+        : 'Receipt'
+
+      const expense = await createExpense({
+        trip_id: currentTrip.id,
+        description,
+        amount: totalAmount,
+        currency,
+        paid_by: paidBy,
+        distribution,
+        category,
+        expense_date: new Date().toISOString().split('T')[0],
+      })
+
+      if (!expense) {
+        toast({ title: 'Failed to create expense', variant: 'destructive' })
+        setSubmitting(false)
+        return
+      }
+
+      await completeReceiptTask(taskId, expense.id)
+
+      toast({
+        title: 'Receipt added',
+        description: `${description} — ${currency} ${totalAmount.toFixed(2)}`,
+      })
+
+      onOpenChange(false)
+      onDone()
+    } catch (err) {
+      toast({ title: 'Error', description: String(err), variant: 'destructive' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[92vh] flex flex-col p-0">
+        <div className="px-4 pt-4 pb-2 border-b border-border">
+          <SheetHeader>
+            <SheetTitle>Review Receipt</SheetTitle>
+          </SheetHeader>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+          {/* Merchant + Category */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="merchant" className="text-xs">Merchant</Label>
+              <Input
+                id="merchant"
+                value={merchantName}
+                onChange={e => setMerchantName(e.target.value)}
+                placeholder="Restaurant, store..."
+                className="h-9 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="category" className="text-xs">Category</Label>
+              <Select value={category} onValueChange={val => setCategory(val as ExpenseCategory)}>
+                <SelectTrigger id="category" className="h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Food">Food</SelectItem>
+                  <SelectItem value="Accommodation">Accommodation</SelectItem>
+                  <SelectItem value="Transport">Transport</SelectItem>
+                  <SelectItem value="Activities">Activities</SelectItem>
+                  <SelectItem value="Training">Training</SelectItem>
+                  <SelectItem value="Other">Other</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Paid by */}
+          <div className="space-y-1">
+            <Label htmlFor="paidby" className="text-xs">Paid by</Label>
+            <Select value={paidBy} onValueChange={setPaidBy}>
+              <SelectTrigger id="paidby" className="h-9 text-sm">
+                <SelectValue placeholder="Who paid?" />
+              </SelectTrigger>
+              <SelectContent>
+                {adultParticipants.map(p => (
+                  <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Items */}
+          <div className="space-y-2">
+            <button
+              className="flex items-center justify-between w-full text-sm font-medium text-foreground"
+              onClick={() => setShowAllItems(v => !v)}
+            >
+              <span>Items ({editableItems.length})</span>
+              {showAllItems ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+            </button>
+
+            {showAllItems && (
+              <div className="space-y-3">
+                {editableItems.map((item, i) => (
+                  <ItemRow
+                    key={i}
+                    index={i}
+                    item={item}
+                    participants={participants}
+                    onNameChange={name => updateItemName(i, name)}
+                    onPriceChange={price => updateItemPrice(i, price)}
+                    onToggleParticipant={pid => toggleParticipant(i, pid)}
+                    onToggleAll={() => toggleAll(i)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Unassigned warning */}
+          {unassignedItems.length > 0 && (
+            <div className="flex items-start gap-2 text-sm text-amber-600 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-3 py-2">
+              <AlertCircle size={16} className="mt-0.5 shrink-0" />
+              <span>
+                {unassignedItems.length} item{unassignedItems.length > 1 ? 's' : ''} not assigned to anyone
+              </span>
+            </div>
+          )}
+
+          {/* Totals */}
+          <div className="border border-border rounded-lg p-3 space-y-3">
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>Items total</span>
+              <span>{currency} {itemsTotal.toFixed(2)}</span>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="confirmed-total" className="text-xs">Total charged ({currency})</Label>
+                <Input
+                  id="confirmed-total"
+                  inputMode="decimal"
+                  value={confirmedTotal}
+                  onChange={e => setConfirmedTotal(e.target.value.replace(',', '.'))}
+                  placeholder="0.00"
+                  className="h-9 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="tip" className="text-xs">Tip ({currency})</Label>
+                <Input
+                  id="tip"
+                  inputMode="decimal"
+                  value={tipAmount}
+                  onChange={e => setTipAmount(e.target.value.replace(',', '.'))}
+                  placeholder="0.00"
+                  className="h-9 text-sm"
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between font-semibold text-sm border-t border-border pt-2">
+              <span>Total expense</span>
+              <span>{currency} {totalExpense.toFixed(2)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Submit */}
+        <div className="px-4 py-3 border-t border-border">
+          <Button
+            onClick={handleSubmit}
+            disabled={!canSubmit || submitting}
+            className="w-full gap-2"
+            size="lg"
+          >
+            {submitting ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                Adding expense...
+              </>
+            ) : (
+              `Add Expense — ${currency} ${totalExpense.toFixed(2)}`
+            )}
+          </Button>
+          {!canSubmit && totalFloat > 0 && unassignedItems.length > 0 && (
+            <p className="text-xs text-muted-foreground text-center mt-2">
+              Assign all items to submit
+            </p>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+interface ItemRowProps {
+  index: number
+  item: EditableItem
+  participants: Participant[]
+  onNameChange: (name: string) => void
+  onPriceChange: (price: string) => void
+  onToggleParticipant: (pid: string) => void
+  onToggleAll: () => void
+}
+
+function ItemRow({
+  index: _index,
+  item,
+  participants,
+  onNameChange,
+  onPriceChange,
+  onToggleParticipant,
+  onToggleAll,
+}: ItemRowProps) {
+  const allAssigned = participants.length > 0 && participants.every(p => item.assignedIds.has(p.id))
+
+  return (
+    <div className="border border-border rounded-lg p-3 space-y-2">
+      {/* Name + Price */}
+      <div className="flex gap-2 items-center">
+        <Input
+          value={item.name}
+          onChange={e => onNameChange(e.target.value)}
+          placeholder="Item name"
+          className="flex-1 h-8 text-sm"
+        />
+        <div className="relative">
+          <Input
+            inputMode="decimal"
+            value={item.price}
+            onChange={e => onPriceChange(e.target.value)}
+            placeholder="0.00"
+            className="w-20 h-8 text-sm text-right"
+          />
+        </div>
+      </div>
+
+      {/* Participant chips */}
+      <div className="flex flex-wrap gap-1.5 items-center">
+        {participants.map((p, pi) => {
+          const assigned = item.assignedIds.has(p.id)
+          return (
+            <button
+              key={p.id}
+              onClick={() => onToggleParticipant(p.id)}
+              className={[
+                'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-colors',
+                assigned
+                  ? `${getChipColor(pi)} text-white`
+                  : 'bg-muted text-muted-foreground border border-border',
+              ].join(' ')}
+              title={p.name}
+            >
+              {participantInitial(p.name)}
+              {p.name.split(' ')[0]}
+            </button>
+          )
+        })}
+
+        {/* "All" shortcut */}
+        {participants.length > 1 && (
+          <button
+            onClick={onToggleAll}
+            className={[
+              'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-colors border',
+              allAssigned
+                ? 'bg-foreground text-background border-foreground'
+                : 'bg-muted text-muted-foreground border-border',
+            ].join(' ')}
+            title="Toggle all"
+          >
+            <Users size={10} />
+            All
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/contexts/ReceiptContext.tsx
+++ b/src/contexts/ReceiptContext.tsx
@@ -1,0 +1,204 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { supabase } from '@/lib/supabase'
+import { ReceiptTask, ExtractedItem, MappedItem } from '@/types/receipt'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { withTimeout } from '@/lib/fetchWithTimeout'
+import { logger } from '@/lib/logger'
+
+interface ReceiptContextType {
+  pendingReceipts: ReceiptTask[]
+  loading: boolean
+  error: string | null
+  createReceiptTask: (tripId: string, imagePath?: string) => Promise<ReceiptTask | null>
+  updateReceiptTask: (id: string, updates: Partial<ReceiptTask>) => Promise<boolean>
+  completeReceiptTask: (id: string, expenseId: string) => Promise<boolean>
+  dismissReceiptTask: (id: string) => Promise<boolean>
+  refreshPendingReceipts: () => Promise<void>
+}
+
+const ReceiptContext = createContext<ReceiptContextType | undefined>(undefined)
+
+export function ReceiptProvider({ children }: { children: ReactNode }) {
+  const [pendingReceipts, setPendingReceipts] = useState<ReceiptTask[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const { currentTrip } = useCurrentTrip()
+
+  const fetchPendingReceipts = async () => {
+    if (!currentTrip) {
+      setPendingReceipts([])
+      return
+    }
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const { data, error: fetchError } = await withTimeout(
+        supabase
+          .from('receipt_tasks')
+          .select('*')
+          .eq('trip_id', currentTrip.id)
+          .in('status', ['review'])
+          .order('created_at', { ascending: false }),
+        15000,
+        'Loading receipts timed out.'
+      )
+
+      if (fetchError) {
+        setError('Failed to load pending receipts')
+        logger.error('Failed to fetch pending receipts', { error: fetchError.message })
+        return
+      }
+
+      setPendingReceipts((data as ReceiptTask[]) ?? [])
+    } catch (err) {
+      setError('Failed to load pending receipts')
+      logger.error('Unhandled error fetching receipts', { error: String(err) })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchPendingReceipts()
+  }, [currentTrip?.id])
+
+  const createReceiptTask = async (tripId: string, imagePath?: string): Promise<ReceiptTask | null> => {
+    try {
+      const { data, error: insertError } = await withTimeout(
+        supabase
+          .from('receipt_tasks')
+          .insert({
+            trip_id: tripId,
+            status: 'pending',
+            receipt_image_path: imagePath ?? null,
+          })
+          .select()
+          .single(),
+        15000,
+        'Creating receipt task timed out.'
+      )
+
+      if (insertError || !data) {
+        logger.error('Failed to create receipt task', { error: insertError?.message })
+        return null
+      }
+
+      logger.info('Receipt task created', { task_id: (data as ReceiptTask).id })
+      return data as ReceiptTask
+    } catch (err) {
+      logger.error('Unhandled error creating receipt task', { error: String(err) })
+      return null
+    }
+  }
+
+  const updateReceiptTask = async (id: string, updates: Partial<ReceiptTask>): Promise<boolean> => {
+    try {
+      const { error: updateError } = await withTimeout(
+        supabase
+          .from('receipt_tasks')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .update({ ...updates, updated_at: new Date().toISOString() } as any)
+          .eq('id', id),
+        15000,
+        'Updating receipt task timed out.'
+      )
+
+      if (updateError) {
+        logger.error('Failed to update receipt task', { error: updateError.message })
+        return false
+      }
+
+      // Refresh pending receipts in case status changed
+      await fetchPendingReceipts()
+      return true
+    } catch (err) {
+      logger.error('Unhandled error updating receipt task', { error: String(err) })
+      return false
+    }
+  }
+
+  const completeReceiptTask = async (id: string, expenseId: string): Promise<boolean> => {
+    try {
+      const { error: updateError } = await withTimeout(
+        supabase
+          .from('receipt_tasks')
+          .update({
+            status: 'complete',
+            expense_id: expenseId,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', id),
+        15000,
+        'Completing receipt task timed out.'
+      )
+
+      if (updateError) {
+        logger.error('Failed to complete receipt task', { error: updateError.message })
+        return false
+      }
+
+      setPendingReceipts(prev => prev.filter(r => r.id !== id))
+      return true
+    } catch (err) {
+      logger.error('Unhandled error completing receipt task', { error: String(err) })
+      return false
+    }
+  }
+
+  const dismissReceiptTask = async (id: string): Promise<boolean> => {
+    try {
+      const { error: updateError } = await withTimeout(
+        supabase
+          .from('receipt_tasks')
+          .update({
+            status: 'failed',
+            error_message: 'Dismissed by user',
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', id),
+        15000,
+        'Dismissing receipt task timed out.'
+      )
+
+      if (updateError) {
+        logger.error('Failed to dismiss receipt task', { error: updateError.message })
+        return false
+      }
+
+      setPendingReceipts(prev => prev.filter(r => r.id !== id))
+      return true
+    } catch (err) {
+      logger.error('Unhandled error dismissing receipt task', { error: String(err) })
+      return false
+    }
+  }
+
+  return (
+    <ReceiptContext.Provider
+      value={{
+        pendingReceipts,
+        loading,
+        error,
+        createReceiptTask,
+        updateReceiptTask,
+        completeReceiptTask,
+        dismissReceiptTask,
+        refreshPendingReceipts: fetchPendingReceipts,
+      }}
+    >
+      {children}
+    </ReceiptContext.Provider>
+  )
+}
+
+export function useReceiptContext() {
+  const ctx = useContext(ReceiptContext)
+  if (!ctx) throw new Error('useReceiptContext must be used within ReceiptProvider')
+  return ctx
+}
+
+// Re-export types for convenience
+export type { ExtractedItem, MappedItem }

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -273,6 +273,71 @@ export type Database = {
           },
         ]
       }
+      receipt_tasks: {
+        Row: {
+          id: string
+          trip_id: string
+          created_by: string | null
+          status: string
+          receipt_image_path: string | null
+          extracted_merchant: string | null
+          extracted_items: Json | null
+          extracted_total: number | null
+          extracted_currency: string | null
+          confirmed_total: number | null
+          tip_amount: number
+          mapped_items: Json | null
+          expense_id: string | null
+          error_message: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          trip_id: string
+          created_by?: string | null
+          status?: string
+          receipt_image_path?: string | null
+          extracted_merchant?: string | null
+          extracted_items?: Json | null
+          extracted_total?: number | null
+          extracted_currency?: string | null
+          confirmed_total?: number | null
+          tip_amount?: number
+          mapped_items?: Json | null
+          expense_id?: string | null
+          error_message?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          trip_id?: string
+          created_by?: string | null
+          status?: string
+          receipt_image_path?: string | null
+          extracted_merchant?: string | null
+          extracted_items?: Json | null
+          extracted_total?: number | null
+          extracted_currency?: string | null
+          confirmed_total?: number | null
+          tip_amount?: number
+          mapped_items?: Json | null
+          expense_id?: string | null
+          error_message?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "receipt_tasks_trip_id_fkey"
+            columns: ["trip_id"]
+            isOneToOne: false
+            referencedRelation: "trips"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       settlements: {
         Row: {
           amount: number

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -1,0 +1,36 @@
+export type ReceiptTaskStatus = 'pending' | 'processing' | 'review' | 'complete' | 'failed';
+
+export interface ExtractedItem {
+  name: string;
+  price: number;
+  qty: number;
+}
+
+export interface MappedItem {
+  item_index: number;
+  participant_ids: string[];
+}
+
+export interface ReceiptTask {
+  id: string;
+  trip_id: string;
+  created_by: string;
+  status: ReceiptTaskStatus;
+  receipt_image_path: string | null;
+  extracted_merchant: string | null;
+  extracted_items: ExtractedItem[] | null;
+  extracted_total: number | null;
+  extracted_currency: string | null;
+  confirmed_total: number | null;
+  tip_amount: number;
+  mapped_items: MappedItem[] | null;
+  expense_id: string | null;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateReceiptTaskInput {
+  trip_id: string;
+  receipt_image_path?: string;
+}

--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -1,0 +1,197 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts"
+import Anthropic from 'npm:@anthropic-ai/sdk@0.32.1'
+import { createClient } from 'npm:@supabase/supabase-js@2'
+import { createLogger } from '../_shared/logger.ts'
+import { createMetrics } from '../_shared/metrics.ts'
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+}
+
+const logger = createLogger('process-receipt')
+const metrics = createMetrics('process-receipt')
+
+const SYSTEM_PROMPT = `You are a receipt parser. Extract all line items from the receipt image.
+Return ONLY valid JSON with this exact structure:
+{
+  "merchant": "store name or null if unclear",
+  "items": [{"name": "item name", "price": 12.50, "qty": 1}],
+  "subtotal": 25.00,
+  "total": 27.50,
+  "currency": "USD"
+}
+Rules:
+- price is the total price for that line (qty * unit price), as a number
+- qty defaults to 1 if not shown
+- currency is the 3-letter ISO code (default "USD" if unclear)
+- If a value cannot be read, use null
+- Do NOT include tax lines as items — include them in total but not subtotal
+- Return ONLY the JSON object, no other text`
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders })
+  }
+
+  const requestStart = performance.now()
+
+  try {
+    logger.info('Request received', { method: req.method })
+
+    const anthropicKey = Deno.env.get("ANTHROPIC_API_KEY")
+    if (!anthropicKey) {
+      logger.error('ANTHROPIC_API_KEY not configured')
+      return new Response(
+        JSON.stringify({ error: "Anthropic API key not configured" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+    if (!supabaseUrl || !supabaseServiceKey) {
+      logger.error('Supabase config missing')
+      return new Response(
+        JSON.stringify({ error: "Server configuration error" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const { receipt_task_id, image_base64, mime_type } = await req.json()
+
+    if (!receipt_task_id || !image_base64) {
+      return new Response(
+        JSON.stringify({ error: "receipt_task_id and image_base64 are required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Mark task as processing
+    await supabase
+      .from('receipt_tasks')
+      .update({ status: 'processing', updated_at: new Date().toISOString() })
+      .eq('id', receipt_task_id)
+
+    logger.info('Calling Anthropic API', { task_id: receipt_task_id })
+    const anthropicStart = performance.now()
+
+    const anthropic = new Anthropic({ apiKey: anthropicKey })
+    const response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [{
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: (mime_type ?? 'image/jpeg') as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+              data: image_base64,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Please extract all line items from this receipt.',
+          },
+        ],
+      }],
+    })
+
+    const anthropicLatencyMs = Math.round(performance.now() - anthropicStart)
+    logger.info('Anthropic API responded', { latencyMs: anthropicLatencyMs })
+    metrics.push([
+      { name: 'anthropic_api_latency_ms', value: anthropicLatencyMs, labels: { service_name: 'process-receipt' }, type: 'gauge' },
+    ])
+
+    const rawText = response.content[0].type === 'text' ? response.content[0].text : ''
+
+    // Parse the JSON response
+    let extracted: {
+      merchant?: string | null
+      items?: Array<{ name: string; price: number; qty: number }>
+      subtotal?: number | null
+      total?: number | null
+      currency?: string | null
+    } = {}
+
+    try {
+      // Strip markdown code blocks if present
+      const jsonText = rawText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim()
+      extracted = JSON.parse(jsonText)
+    } catch {
+      logger.warn('Failed to parse Anthropic JSON response', { raw: rawText.slice(0, 200) })
+      await supabase
+        .from('receipt_tasks')
+        .update({
+          status: 'failed',
+          error_message: 'Could not parse receipt — please try a clearer photo',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', receipt_task_id)
+
+      metrics.push([{ name: 'receipt_extraction_total', value: 1, labels: { status: 'parse_error' }, type: 'counter' }])
+      return new Response(
+        JSON.stringify({ error: 'Could not parse receipt — please try a clearer photo' }),
+        { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const items = (extracted.items ?? []).map(item => ({
+      name: item.name ?? 'Unknown item',
+      price: typeof item.price === 'number' ? item.price : 0,
+      qty: typeof item.qty === 'number' ? item.qty : 1,
+    }))
+
+    const extractedTotal = typeof extracted.total === 'number' ? extracted.total : null
+    const extractedCurrency = extracted.currency ?? 'USD'
+    const extractedMerchant = extracted.merchant ?? null
+
+    // Save results and mark as ready for review
+    await supabase
+      .from('receipt_tasks')
+      .update({
+        status: 'review',
+        extracted_merchant: extractedMerchant,
+        extracted_items: items,
+        extracted_total: extractedTotal,
+        extracted_currency: extractedCurrency,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', receipt_task_id)
+
+    const totalMs = Math.round(performance.now() - requestStart)
+    logger.info('Receipt processed successfully', { task_id: receipt_task_id, itemCount: items.length, totalMs })
+    metrics.push([
+      { name: 'receipt_extraction_total', value: 1, labels: { status: 'success' }, type: 'counter' },
+      { name: 'function_latency_ms', value: totalMs, labels: { service_name: 'process-receipt', status: 'success' }, type: 'gauge' },
+    ])
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        merchant: extractedMerchant,
+        items,
+        total: extractedTotal,
+        currency: extractedCurrency,
+      }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    )
+  } catch (err) {
+    const totalMs = Math.round(performance.now() - requestStart)
+    console.error("Edge function error:", err)
+    logger.error('Unhandled exception', { error: String(err) })
+    metrics.push([
+      { name: 'receipt_extraction_total', value: 1, labels: { status: 'error' }, type: 'counter' },
+      { name: 'function_latency_ms', value: totalMs, labels: { service_name: 'process-receipt', status: 'error' }, type: 'gauge' },
+    ])
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    )
+  }
+})

--- a/supabase/migrations/020_receipt_tasks.sql
+++ b/supabase/migrations/020_receipt_tasks.sql
@@ -1,0 +1,43 @@
+-- Receipt tasks: tracks AI receipt scanning state and results
+CREATE TABLE receipt_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES auth.users(id),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'review', 'complete', 'failed')),
+  receipt_image_path TEXT,
+  extracted_merchant TEXT,
+  extracted_items JSONB,       -- [{ name: string, price: number, qty: number }]
+  extracted_total NUMERIC(10,2),
+  extracted_currency TEXT,
+  confirmed_total NUMERIC(10,2),
+  tip_amount NUMERIC(10,2) DEFAULT 0,
+  mapped_items JSONB,          -- [{ item_index: number, participant_ids: string[] }]
+  expense_id UUID REFERENCES expenses(id) ON DELETE SET NULL,
+  error_message TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE receipt_tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own receipt tasks"
+  ON receipt_tasks FOR ALL
+  USING (created_by = auth.uid());
+
+-- Private storage bucket for receipt images
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('receipts', 'receipts', false)
+ON CONFLICT DO NOTHING;
+
+CREATE POLICY "Authenticated users can upload receipts"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'receipts');
+
+CREATE POLICY "Users can read their own receipts"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (bucket_id = 'receipts');
+
+CREATE POLICY "Users can delete their own receipts"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (bucket_id = 'receipts');


### PR DESCRIPTION
## Summary

- **New `process-receipt` Edge Function** — calls Claude Haiku vision API with receipt image (base64), extracts merchant name, line items (name/price/qty), total, and currency as structured JSON; saves results to `receipt_tasks` table
- **`ReceiptCaptureSheet`** — bottom Sheet for image capture/upload with client-side JPEG compression → base64 → Edge Function invocation with loading state ("Analyzing receipt…")
- **`ReceiptReviewSheet`** — full review UI: inline-editable items, **chip-tap participant assignment** (item-centric: tap participant chips per item, "All" shortcut), tip input, confirmed total field, validation (all items must be assigned), builds `IndividualsDistribution` with amount splits scaled to confirmed total + equal tip split
- **Pending receipts banner** on Expenses page — tasks in `review` state persist if user exits; banner shows "Unreviewed receipt — [Merchant]" with Review/Dismiss actions
- **DB migration 020** — `receipt_tasks` table + RLS (users can only see their own tasks) + private `receipts` storage bucket
- **`ReceiptProvider`** wired into `Layout` and `QuickLayout` context trees
- **`database.types.ts`** — `receipt_tasks` Row/Insert/Update types added manually (migration not yet applied to Supabase, types will be regenerated after `supabase db push`)

## Decisions resolved

| Question | Decision |
|----------|----------|
| Q8: Sonnet or Haiku? | `claude-haiku-4-5-20251001` — fast and cheap; can upgrade to Sonnet if accuracy needs improvement |
| Q10: Store images permanently? | MVP: images not stored in bucket (base64 passed directly to edge function); extracted data persists in `receipt_tasks` for deferred review |

## How to deploy

1. Apply migration: `supabase db push` (interactive, confirms `020_receipt_tasks.sql`)
2. Set secret: `supabase secrets set ANTHROPIC_API_KEY=sk-ant-...`
3. Deploy edge function: `supabase functions deploy process-receipt`

## Test plan

- [ ] Tap "Scan Receipt" on Expenses page → ReceiptCaptureSheet opens
- [ ] Take photo or upload receipt image → "Analyzing receipt…" spinner appears
- [ ] Extracted items and total appear in ReceiptReviewSheet
- [ ] Tap participant chips to assign items; "All" shortcut assigns all
- [ ] Edit item names and prices inline
- [ ] Adjust confirmed total and tip
- [ ] Submit creates expense with correct per-participant split
- [ ] Exit review without submitting → pending receipt banner appears
- [ ] Resume from banner → ReceiptReviewSheet reopens with saved data
- [ ] Dismiss → removes from banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)