### PR TITLE
Fix receipt scan failure + add quick mode entry point (closes #152)

### DIFF
--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -80,7 +80,7 @@ Deno.serve(async (req) => {
 
     const anthropic = new Anthropic({ apiKey: anthropicKey })
     const response = await anthropic.messages.create({
-      model: 'claude-haiku-4-5-20251001',
+      model: 'claude-sonnet-4-6',
       max_tokens: 1024,
       system: SYSTEM_PROMPT,
       messages: [{
@@ -183,8 +183,9 @@ Deno.serve(async (req) => {
     )
   } catch (err) {
     const totalMs = Math.round(performance.now() - requestStart)
+    const errStr = String(err)
     console.error("Edge function error:", err)
-    logger.error('Unhandled exception', { error: String(err) })
+    logger.error(`Unhandled exception: ${errStr}`, { error: errStr })
     metrics.push([
       { name: 'receipt_extraction_total', value: 1, labels: { status: 'error' }, type: 'counter' },
       { name: 'function_latency_ms', value: totalMs, labels: { service_name: 'process-receipt', status: 'error' }, type: 'gauge' },


### PR DESCRIPTION
Fixes #152

## Root causes

**Scan not working:**
- `claude-haiku-4-5-20251001` may not yet be a live model ID — switched to `claude-sonnet-4-6` (confirmed working, better vision accuracy for receipts anyway)
- When the edge function returned 4xx/5xx, the actual error message was lost — Supabase wraps these in `FunctionsHttpError` and the JSON body is only accessible via `fnError.context.json()`. The user always saw "FunctionsFetchError" with no detail
- Edge function catch block logged `{ error: String(err) }` in the context field only — Grafana query showed the message field as "Unhandled exception" without the actual error. Now included in the message string directly

**Feature only in full mode:**
- `QuickGroupDetailPage` had no receipt entry point at all

## Changes

- `process-receipt/index.ts`: model → `claude-sonnet-4-6`, error string in log message subject
- `ReceiptCaptureSheet`: proper extraction of JSON body from `FunctionsHttpError.context` — real error message now shown to user
- `QuickGroupDetailPage`: "Scan a receipt" `QuickActionButton` + pending receipts banner + `ReceiptCaptureSheet` / `ReceiptReviewSheet` wired up

## Test plan

- [ ] Tap "Scan a receipt" in quick mode → capture sheet opens
- [ ] Scan a receipt → AI processes it → review sheet opens
- [ ] Submit → expense appears in history
- [ ] If scan fails, user sees the actual error message (not "FunctionsFetchError")

🤖 Generated with [Claude Code](https://claude.com/claude-code)