### PR TITLE
Fix RLS violation on receipt_tasks insert

### DIFF
--- a/supabase/migrations/021_receipt_tasks_created_by_default.sql
+++ b/supabase/migrations/021_receipt_tasks_created_by_default.sql
@@ -1,0 +1,4 @@
+-- Set created_by to auth.uid() by default so browser inserts without
+-- an explicit created_by never violate the RLS policy.
+ALTER TABLE receipt_tasks
+  ALTER COLUMN created_by SET DEFAULT auth.uid();


### PR DESCRIPTION
## Problem

`createReceiptTask` failed with:
> new row violates row-level security policy for table "receipt_tasks"

The RLS policy is `USING (created_by = auth.uid())`. For INSERT, PostgreSQL applies the `USING` expression as a `WITH CHECK`. The insert was omitting `created_by`, leaving it `NULL`. Since `NULL = auth.uid()` is `NULL` (not `TRUE`), the policy blocked the insert.

## Fix

- **Migration 021**: `ALTER COLUMN created_by SET DEFAULT auth.uid()` — any insert that omits `created_by` now automatically gets the authenticated user's ID from the JWT context
- **`ReceiptContext`**: explicitly sets `created_by: user.id` in the insert (belt-and-suspenders); also imports `useAuth` and bails early with a logged error if the user is unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)