### PR TITLE
Fix receipt UX issues (#156)

### DIFF
--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -10,6 +10,7 @@ import {
   Trash2,
   Calendar,
   Tag,
+  ScanLine,
 } from 'lucide-react'
 import { Expense } from '@/types/expense'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -23,9 +24,10 @@ interface ExpenseCardProps {
   expense: Expense
   onEdit: () => void
   onDelete: () => void
+  onViewReceipt?: () => void
 }
 
-export function ExpenseCard({ expense, onEdit, onDelete }: ExpenseCardProps) {
+export function ExpenseCard({ expense, onEdit, onDelete, onViewReceipt }: ExpenseCardProps) {
   const { participants, families } = useParticipantContext()
   const { currentTrip } = useCurrentTrip()
 
@@ -162,6 +164,17 @@ export function ExpenseCard({ expense, onEdit, onDelete }: ExpenseCardProps) {
               )}
             </div>
             <div className="flex gap-1">
+              {onViewReceipt && (
+                <Button
+                  onClick={onViewReceipt}
+                  variant="ghost"
+                  size="sm"
+                  className="h-10 w-10 p-0 text-muted-foreground"
+                  title="View receipt"
+                >
+                  <ScanLine size={16} />
+                </Button>
+              )}
               <Button
                 onClick={onEdit}
                 variant="ghost"

--- a/src/components/receipts/ReceiptDetailsSheet.tsx
+++ b/src/components/receipts/ReceiptDetailsSheet.tsx
@@ -1,0 +1,59 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { ScanLine } from 'lucide-react'
+import { ReceiptTask } from '@/types/receipt'
+
+interface ReceiptDetailsSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  task: ReceiptTask
+}
+
+export function ReceiptDetailsSheet({ open, onOpenChange, task }: ReceiptDetailsSheetProps) {
+  const items = task.extracted_items ?? []
+  const currency = task.extracted_currency ?? '—'
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[75vh] flex flex-col p-0">
+        <div className="px-4 pt-4 pb-2 border-b border-border">
+          <SheetHeader>
+            <SheetTitle className="flex items-center gap-2">
+              <ScanLine size={18} />
+              Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
+            </SheetTitle>
+          </SheetHeader>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          <div className="px-4 py-3 space-y-3">
+            {items.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-6">No items extracted.</p>
+            ) : (
+              <div className="space-y-1">
+                <div className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs font-medium text-muted-foreground pb-1 border-b border-border">
+                  <span>Item</span>
+                  <span className="text-center">Qty</span>
+                  <span className="text-right">Price</span>
+                </div>
+                {items.map((item, i) => (
+                  <div key={i} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-sm py-1.5 border-b border-border/50 last:border-0">
+                    <span className="break-words">{item.name}</span>
+                    <span className="text-center text-muted-foreground">{item.qty}</span>
+                    <span className="text-right tabular-nums">{currency} {item.price.toFixed(2)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {task.extracted_total != null && (
+              <div className="flex items-center justify-between font-semibold text-sm border-t border-border pt-2">
+                <span>Total</span>
+                <span className="tabular-nums">{currency} {task.extracted_total.toFixed(2)}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -11,6 +11,8 @@ import { ExpenseWizard } from '@/components/expenses/ExpenseWizard'
 import { ExpenseCard } from '@/components/ExpenseCard'
 import { ReceiptCaptureSheet } from '@/components/receipts/ReceiptCaptureSheet'
 import { ReceiptReviewSheet } from '@/components/receipts/ReceiptReviewSheet'
+import { ReceiptDetailsSheet } from '@/components/receipts/ReceiptDetailsSheet'
+import { ReceiptTask } from '@/types/receipt'
 import { CreateExpenseInput, ExpenseCategory, Expense } from '@/types/expense'
 import { ExtractedItem } from '@/types/receipt'
 import { Button } from '@/components/ui/button'
@@ -46,7 +48,7 @@ export function ExpensesPage() {
   const { expenses, loading, error, createExpense, updateExpense, deleteExpense } = useExpenseContext()
   const { participants, families } = useParticipantContext()
   const { settlements } = useSettlementContext()
-  const { pendingReceipts, dismissReceiptTask } = useReceiptContext()
+  const { pendingReceipts, receiptByExpenseId, dismissReceiptTask } = useReceiptContext()
 
   const [showForm, setShowForm] = useState(false)
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null)
@@ -55,6 +57,7 @@ export function ExpensesPage() {
   const [deletingExpenseId, setDeletingExpenseId] = useState<string | null>(null)
   const [showReceiptCapture, setShowReceiptCapture] = useState(false)
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
+  const [viewingReceiptTask, setViewingReceiptTask] = useState<ReceiptTask | null>(null)
 
   const handleCreateExpense = async (input: CreateExpenseInput) => {
     const result = await createExpense(input)
@@ -152,7 +155,7 @@ export function ExpensesPage() {
               title="Scan a receipt"
             >
               <ScanLine size={16} />
-              <span className="hidden sm:inline">Scan Receipt</span>
+              Scan Receipt
             </Button>
             <Button onClick={() => setShowForm(!showForm)} size="sm">
               <Plus size={16} className="mr-2" />
@@ -315,6 +318,10 @@ export function ExpensesPage() {
                       setEditingExpense(expense)
                     }}
                     onDelete={() => setDeletingExpenseId(expense.id)}
+                    onViewReceipt={receiptByExpenseId[expense.id]
+                      ? () => setViewingReceiptTask(receiptByExpenseId[expense.id])
+                      : undefined
+                    }
                   />
                 ))}
               </div>
@@ -347,6 +354,15 @@ export function ExpensesPage() {
           extractedTotal={receiptReviewData.total}
           currency={receiptReviewData.currency}
           onDone={() => setReceiptReviewData(null)}
+        />
+      )}
+
+      {/* Receipt Details (read-only) */}
+      {viewingReceiptTask && (
+        <ReceiptDetailsSheet
+          open={!!viewingReceiptTask}
+          onOpenChange={open => { if (!open) setViewingReceiptTask(null) }}
+          task={viewingReceiptTask}
         />
       )}
 


### PR DESCRIPTION
Fixes #156.

## Changes

### 1. Split qty>1 items (assign each beer to a different person)
When the AI extracts an item with `qty > 1` (e.g. "Chang Beer ×2"), a small **×2** chip button appears next to the name. Tapping it splits the item into two individual rows (each at the per-unit price), which can then be assigned to different people independently.

### 2. Left-side label clipping on iOS Safari
Labels in the currency/totals section were getting clipped on the left when scrolling. Root cause: `overflow-y-auto` with `px-4` on the same element — iOS Safari doesn't honour horizontal padding on scroll containers. Fixed by wrapping content in an inner div that holds the padding.

### 3. Submit errors now logged to Grafana
Added `logger.error` in the `handleSubmit` catch block so failures appear in the Grafana error rate panel.

### 4. Consistent icon sizing in full-mode header
"Scan Receipt" text was hidden on mobile (`hidden sm:inline`), leaving an icon-only button that was visually smaller than adjacent buttons. Text now always shown.

### 5. View receipt from expense card
- `ReceiptContext` now fetches both `review` and `complete` tasks and exposes `receiptByExpenseId` (a map of `expense_id → ReceiptTask`)
- `ExpenseCard` accepts an optional `onViewReceipt` prop — renders a `ScanLine` icon button when provided
- `ExpensesPage` passes the callback for any expense that has a linked receipt task
- New `ReceiptDetailsSheet`: read-only bottom sheet showing merchant + extracted items table + total

## Test plan
- [ ] Scan a receipt with a repeated item (e.g. 2 beers) — ×2 chip appears, tap splits into 2 rows
- [ ] Open currency rate input — labels no longer clipped on left
- [ ] After adding a receipt expense, its card shows a ScanLine icon — tap opens item list
- [ ] Submit error (e.g. cut network) — toast shown + error visible in Grafana logs
- [ ] "Scan Receipt" button text visible on mobile in full mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)