### PR TITLE
Fix receipt keyboard layout shifts and defer review to banner flow

### DIFF
--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Loader2, Users, ChevronDown, ChevronUp, AlertCircle, SplitSquareHorizontal } from 'lucide-react'
 import { logger } from '@/lib/logger'
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -131,6 +132,7 @@ export function ReceiptReviewSheet({
   currency,
   onDone,
 }: ReceiptReviewSheetProps) {
+  const keyboard = useKeyboardHeight()
   const { currentTrip } = useCurrentTrip()
   const { participants, getAdultParticipants } = useParticipantContext()
   const { createExpense } = useExpenseContext()
@@ -327,7 +329,14 @@ export function ReceiptReviewSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="h-[92vh] flex flex-col p-0">
+      <SheetContent
+        side="bottom"
+        className="flex flex-col p-0"
+        style={{
+          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92vh',
+          bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
+        }}
+      >
         <div className="px-4 pt-4 pb-2 border-b border-border">
           <SheetHeader>
             <SheetTitle>Review Receipt</SheetTitle>

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Plus, Search, Receipt, FileDown, ScanLine } from 'lucide-react'
+import { useToast } from '@/hooks/use-toast'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -49,6 +50,7 @@ export function ExpensesPage() {
   const { participants, families } = useParticipantContext()
   const { settlements } = useSettlementContext()
   const { pendingReceipts, receiptByExpenseId, dismissReceiptTask } = useReceiptContext()
+  const { toast } = useToast()
 
   const [showForm, setShowForm] = useState(false)
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null)
@@ -336,9 +338,9 @@ export function ExpensesPage() {
           open={showReceiptCapture}
           onOpenChange={setShowReceiptCapture}
           tripId={currentTrip.id}
-          onProcessed={(taskId, data) => {
+          onScanned={(_taskId) => {
             setShowReceiptCapture(false)
-            setReceiptReviewData({ taskId, ...data })
+            toast({ title: 'Receipt scanned', description: 'Review it using the banner above.' })
           }}
         />
       )}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -14,13 +14,15 @@ import { QuickExpenseSheet } from '@/components/quick/QuickExpenseSheet'
 import { QuickSettlementSheet } from '@/components/quick/QuickSettlementSheet'
 import { ReceiptCaptureSheet } from '@/components/receipts/ReceiptCaptureSheet'
 import { ReceiptReviewSheet } from '@/components/receipts/ReceiptReviewSheet'
+import { ExtractedItem } from '@/types/receipt'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { ExtractedItem } from '@/types/receipt'
+import { useToast } from '@/hooks/use-toast'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
   ExternalLink, ArrowLeftRight, Loader2, RefreshCw, AlertCircle
 } from 'lucide-react'
+
 
 interface ReceiptReviewData {
   taskId: string
@@ -39,6 +41,7 @@ export function QuickGroupDetailPage() {
   const { settlements, loading: settlementsLoading, error: settlementError, refreshSettlements } = useSettlementContext()
 
   const { pendingReceipts, dismissReceiptTask } = useReceiptContext()
+  const { toast } = useToast()
 
   const [expenseOpen, setExpenseOpen] = useState(false)
   const [settlementOpen, setSettlementOpen] = useState(false)
@@ -268,9 +271,9 @@ export function QuickGroupDetailPage() {
       <ReceiptCaptureSheet
         open={receiptCaptureOpen}
         onOpenChange={setReceiptCaptureOpen}
-        onProcessed={(taskId, data) => {
+        onScanned={(_taskId) => {
           setReceiptCaptureOpen(false)
-          setReceiptReviewData({ taskId, ...data })
+          toast({ title: 'Receipt scanned', description: 'Review it using the banner above.' })
         }}
       />
 


### PR DESCRIPTION
## Summary

- **ReceiptReviewSheet**: wires `useKeyboardHeight` so the sheet pushes above the iOS keyboard when the user taps an input (merchant, total, tip, exchange rate). Removes the fixed `h-[92vh]` class and replaces it with inline `style={{ height, bottom }}` — the same pattern used by `MobileWizard` and every other sheet in the app.

- **ReceiptCaptureSheet**: renames `onProcessed(taskId, data)` → `onScanned(taskId)`. After the edge function succeeds, calls `refreshPendingReceipts()` so the pending banner appears immediately, then closes. The extracted data is no longer passed to the parent — the parent reads it from the pending receipts list when the user taps "Review".

- **QuickGroupDetailPage + ExpensesPage**: updated to the new `onScanned` prop. After scanning, the capture sheet closes and shows a toast ("Review it using the banner above."). The review sheet is still opened exactly as before by tapping the "Review" button in the pending receipts banner.

## Test plan
- [ ] `npm run type-check` passes clean
- [ ] Scan a receipt → capture sheet closes → toast appears → pending banner is visible
- [ ] Tap "Review" on banner → review sheet opens with correct data
- [ ] Tap merchant / total / tip input in review sheet on iOS → sheet pushes above keyboard, no layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)