### PR TITLE
Store receipt images in bucket and show collapsible thumbnail

### DIFF
--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -42,6 +42,7 @@ interface ReceiptReviewData {
   items: ExtractedItem[]
   total: number | null
   currency: string
+  imagePath: string | null
 }
 
 export function ExpensesPage() {
@@ -200,6 +201,7 @@ export function ExpensesPage() {
                         items: task.extracted_items ?? [],
                         total: task.extracted_total,
                         currency: task.extracted_currency ?? currentTrip?.default_currency ?? 'USD',
+                        imagePath: task.receipt_image_path ?? null,
                       })
                     }
                   >
@@ -355,6 +357,7 @@ export function ExpensesPage() {
           items={receiptReviewData.items}
           extractedTotal={receiptReviewData.total}
           currency={receiptReviewData.currency}
+          imagePath={receiptReviewData.imagePath}
           onDone={() => setReceiptReviewData(null)}
         />
       )}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -30,6 +30,7 @@ interface ReceiptReviewData {
   items: ExtractedItem[]
   total: number | null
   currency: string
+  imagePath: string | null
 }
 
 export function QuickGroupDetailPage() {
@@ -188,6 +189,7 @@ export function QuickGroupDetailPage() {
                       items: task.extracted_items ?? [],
                       total: task.extracted_total,
                       currency: task.extracted_currency ?? currentTrip.default_currency,
+                      imagePath: task.receipt_image_path ?? null,
                     })
                   }
                 >
@@ -287,6 +289,7 @@ export function QuickGroupDetailPage() {
           items={receiptReviewData.items}
           extractedTotal={receiptReviewData.total}
           currency={receiptReviewData.currency}
+          imagePath={receiptReviewData.imagePath}
           onDone={() => setReceiptReviewData(null)}
         />
       )}


### PR DESCRIPTION
## Summary
- **ReceiptCaptureSheet**: after creating the task row, runs bucket upload (`receipts/{task_id}.jpg`) and the `process-receipt` edge function **in parallel** (`Promise.allSettled`). If the upload succeeds, writes `receipt_image_path` back to the task row. Upload failure is logged as a warning — never shown to the user and never blocks the AI flow.
- **ReceiptReviewSheet**: accepts new `imagePath?` prop; generates a 1-hour signed URL when the sheet opens; renders a collapsible "Receipt photo" toggle above the items section (collapsed by default).
- **ReceiptDetailsSheet**: same signed URL + collapsible thumbnail pattern.
- **ExpensesPage + QuickGroupDetailPage**: extend local `ReceiptReviewData` interface with `imagePath`, populate from `task.receipt_image_path`, pass to `ReceiptReviewSheet`.
- No migrations needed — `receipts` bucket and `receipt_image_path` column already exist from migration 020.

## Test plan
- [ ] Scan a receipt → check Supabase Storage dashboard shows a `{task_id}.jpg` file in `receipts` bucket
- [ ] Open review sheet → "Receipt photo" toggle appears; tapping expands the thumbnail
- [ ] Complete the receipt → open expense via "view receipt" button → thumbnail toggle appears in ReceiptDetailsSheet
- [ ] Simulate upload failure (e.g. revoke bucket policy) → AI processing still completes, no user-facing error shown
- [ ] `npm run type-check` passes clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)