### PR TITLE
Delete receipt task on dismiss

### DIFF
--- a/src/contexts/ReceiptContext.tsx
+++ b/src/contexts/ReceiptContext.tsx
@@ -168,21 +168,17 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
 
   const dismissReceiptTask = async (id: string): Promise<boolean> => {
     try {
-      const { error: updateError } = await withTimeout(
+      const { error: deleteError } = await withTimeout(
         supabase
           .from('receipt_tasks')
-          .update({
-            status: 'failed',
-            error_message: 'Dismissed by user',
-            updated_at: new Date().toISOString(),
-          })
+          .delete()
           .eq('id', id),
         15000,
         'Dismissing receipt task timed out.'
       )
 
-      if (updateError) {
-        logger.error('Failed to dismiss receipt task', { error: updateError.message })
+      if (deleteError) {
+        logger.error('Failed to dismiss receipt task', { error: deleteError.message })
         return false
       }
 


### PR DESCRIPTION
## Summary
- `dismissReceiptTask` now calls `.delete()` instead of `.update({ status: 'failed', ... })`
- Dismissed receipts were never read again — no reason to keep them in the DB
- Optimistic state removal and error handling unchanged

## Test plan
- [ ] Tap Dismiss on a pending receipt banner → row is gone from Supabase `receipt_tasks` table
- [ ] No JS errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)