### PR TITLE
Surface real Supabase error when receipt task creation fails

### DIFF
--- a/src/components/receipts/ReceiptCaptureSheet.tsx
+++ b/src/components/receipts/ReceiptCaptureSheet.tsx
@@ -106,13 +106,8 @@ export function ReceiptCaptureSheet({ open, onOpenChange, onScanned }: ReceiptCa
       const compressed = await compressImage(selectedFile)
       const base64 = await blobToBase64(compressed)
 
-      // 2. Create receipt_tasks row (pending)
+      // 2. Create receipt_tasks row (pending) — throws with real error message on failure
       const task = await createReceiptTask(currentTrip.id)
-      if (!task) {
-        setError('Failed to create receipt task. Please try again.')
-        setScanning(false)
-        return
-      }
 
       // 3. Run bucket upload and edge function in parallel
       const uploadPath = `${task.id}.jpg`


### PR DESCRIPTION
## Summary
- `createReceiptTask` now throws with the actual `insertError.message` instead of silently returning `null`
- Removes the dead null-check guard in `ReceiptCaptureSheet` — the existing outer `catch` already handles thrown errors and calls `setError(err.message)`
- Real failure reason (RLS violation, missing table, timeout, JWT issue, etc.) now appears directly in the UI

## Test plan
- [ ] Trigger a scan — if it still fails, the actual Supabase error string is now shown instead of the generic "Failed to create receipt task" message
- [ ] Successful scan still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)