### PR TITLE
Fix ReceiptReviewSheet inputs hidden behind iOS keyboard (#161)

### DIFF
--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { Loader2, Users, ChevronDown, ChevronUp, AlertCircle, SplitSquareHorizontal, Image } from 'lucide-react'
 import { logger } from '@/lib/logger'
 import { supabase } from '@/lib/supabase'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
+import { useScrollIntoView } from '@/hooks/useScrollIntoView'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -136,6 +137,8 @@ export function ReceiptReviewSheet({
   onDone,
 }: ReceiptReviewSheetProps) {
   const keyboard = useKeyboardHeight()
+  const contentRef = useRef<HTMLDivElement>(null)
+  useScrollIntoView(contentRef, { enabled: keyboard.isVisible, offset: 20 })
   const { currentTrip } = useCurrentTrip()
   const { participants, getAdultParticipants } = useParticipantContext()
   const { createExpense } = useExpenseContext()
@@ -367,7 +370,7 @@ export function ReceiptReviewSheet({
           </SheetHeader>
         </div>
 
-        <div className="flex-1 overflow-y-auto">
+        <div ref={contentRef} className="flex-1 overflow-y-auto">
         <div className="px-4 py-3 space-y-4">
           {/* Receipt image thumbnail (collapsible) */}
           {receiptImageUrl && (
@@ -554,7 +557,7 @@ export function ReceiptReviewSheet({
         </div>
 
         {/* Submit */}
-        <div className="px-4 py-3 border-t border-border">
+        <div className="px-4 py-3 border-t border-border" style={{ flexShrink: 0 }}>
           <Button
             onClick={handleSubmit}
             disabled={!canSubmit || submitting}


### PR DESCRIPTION
## Summary

- Add `useRef` + `useScrollIntoView` to `ReceiptReviewSheet` — focused inputs (tip, total, item price, merchant) now auto-scroll into view after the iOS keyboard animation settles
- Add `flexShrink: 0` to the footer div so the **Add Expense** button is never clipped when the sheet shrinks

## Root cause

Issue #161 was prematurely closed in PR #160. The `SheetContent` already had the correct resize pattern (`height: availableHeight`, `bottom: keyboardHeight`) but was missing the two pieces `MobileWizard` has to make it fully functional:
1. A ref on the scrollable container + `useScrollIntoView` to scroll the focused input into the now-smaller visible area
2. `flexShrink: 0` on the footer to prevent the button from being clipped

## Test plan

- [ ] Open a pending receipt for review on iOS Safari (or responsive DevTools iPhone emulation)
- [ ] Tap the **Tip** input → keyboard opens → sheet resizes, tip input is visible and scrolled into view
- [ ] Same for item price inputs, confirmed total, and merchant name
- [ ] **Add Expense** button remains visible at the bottom (not clipped)
- [ ] `npm run type-check` passes clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)