### PR TITLE
Add explicit Cancel button to ReceiptReviewSheet header (#169)

### DIFF
--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -4,7 +4,7 @@ import { logger } from '@/lib/logger'
 import { supabase } from '@/lib/supabase'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { useScrollIntoView } from '@/hooks/useScrollIntoView'
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -359,15 +359,22 @@ export function ReceiptReviewSheet({
       <SheetContent
         side="bottom"
         className="flex flex-col p-0"
+        hideClose
         style={{
           height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92vh',
           bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
         }}
       >
-        <div className="px-4 pt-4 pb-2 border-b border-border">
-          <SheetHeader>
-            <SheetTitle>Review Receipt</SheetTitle>
-          </SheetHeader>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+          <SheetTitle className="text-base font-semibold">Review Receipt</SheetTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            className="text-muted-foreground -mr-2"
+          >
+            Cancel
+          </Button>
         </div>
 
         <div ref={contentRef} className="flex-1 overflow-y-auto">

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -48,12 +48,14 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  hideClose?: boolean
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, hideClose, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
@@ -61,10 +63,12 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <Cross2Icon className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
+      {!hideClose && (
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <Cross2Icon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      )}
       {children}
     </SheetPrimitive.Content>
   </SheetPortal>


### PR DESCRIPTION
## Summary
- Closes #169
- Adds `hideClose?: boolean` prop to `SheetContent` in `sheet.tsx` — when true, suppresses the default Shadcn X button
- Replaces the `ReceiptReviewSheet` header with a flex row: **"Review Receipt"** title on the left, labeled **Cancel** button on the right
- Cancel calls `onOpenChange(false)`, same as the X was doing

## Test plan
- [ ] Open ReceiptReviewSheet on mobile — header shows "Review Receipt" left, "Cancel" right, no X icon
- [ ] Tap Cancel → sheet closes cleanly
- [ ] Pinned "Add Expense" footer still visible and functional
- [ ] All other `SheetContent` usages (without `hideClose`) still render the default X button unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)