### PR TITLE
Improve merchant name extraction for non-western receipts (#168)

### DIFF
--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -15,13 +15,14 @@ const metrics = createMetrics('process-receipt')
 const SYSTEM_PROMPT = `You are a receipt parser. Extract all line items from the receipt image.
 Return ONLY valid JSON with this exact structure:
 {
-  "merchant": "store name or null if unclear",
+  "merchant": "store name or null if not found",
   "items": [{"name": "item name", "price": 12.50, "qty": 1}],
   "subtotal": 25.00,
   "total": 27.50,
   "currency": "USD"
 }
 Rules:
+- merchant: Look for the business name, restaurant name, store name, or brand — it usually appears at the top of the receipt, sometimes as a header, logo text, or subtitle. It may appear in a non-Latin script (Thai, Arabic, Chinese, etc.) alongside or instead of a Latin transliteration — if a Latin/English name is present use that; if only non-Latin script is present, return null rather than guessing a transliteration. Return null only if no business name is visible at all.
 - price is the total price for that line (qty * unit price), as a number
 - qty defaults to 1 if not shown
 - currency is the 3-letter ISO code (default "USD" if unclear)


### PR DESCRIPTION
## Summary
- Closes #168
- Expands the `SYSTEM_PROMPT` in `process-receipt` edge function with explicit merchant extraction guidance:
  - Look at the top of the receipt for business name, restaurant name, store name, or brand
  - For non-Latin scripts (Thai, Arabic, Chinese, etc.) prefer the Latin/English transliteration if present; return `null` if only non-Latin text exists (avoids garbled transliterations)
  - Return `null` only when truly no business name is visible

## Deployment required
After merging, the edge function must be re-deployed:
```
supabase functions deploy process-receipt
```

## Test plan
- [ ] Scan a receipt from a named restaurant → banner shows the merchant name
- [ ] Scan a receipt with only Thai script header → banner shows "Unreviewed receipt" (null merchant) rather than a bad transliteration
- [ ] Items and total extraction unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)