### PR TITLE
Fix merchant extraction: romanise non-Latin names, explicit user message (#168)

### DIFF
--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -15,14 +15,14 @@ const metrics = createMetrics('process-receipt')
 const SYSTEM_PROMPT = `You are a receipt parser. Extract all line items from the receipt image.
 Return ONLY valid JSON with this exact structure:
 {
-  "merchant": "store name or null if not found",
+  "merchant": "store name or null if truly not found",
   "items": [{"name": "item name", "price": 12.50, "qty": 1}],
   "subtotal": 25.00,
   "total": 27.50,
   "currency": "USD"
 }
 Rules:
-- merchant: Look for the business name, restaurant name, store name, or brand — it usually appears at the top of the receipt, sometimes as a header, logo text, or subtitle. It may appear in a non-Latin script (Thai, Arabic, Chinese, etc.) alongside or instead of a Latin transliteration — if a Latin/English name is present use that; if only non-Latin script is present, return null rather than guessing a transliteration. Return null only if no business name is visible at all.
+- merchant: Scan the entire receipt, especially the header area at the top, for the business name, restaurant name, store name, or brand. It may appear as large text, a logo caption, a subtitle, or small print. If you see a name in both Latin and non-Latin script (e.g. Thai, Arabic, Chinese), return the Latin version. If the name is only in a non-Latin script, return a romanised/transliterated version of it. Only return null if no business name is visible anywhere on the receipt.
 - price is the total price for that line (qty * unit price), as a number
 - qty defaults to 1 if not shown
 - currency is the 3-letter ISO code (default "USD" if unclear)
@@ -97,7 +97,7 @@ Deno.serve(async (req) => {
           },
           {
             type: 'text',
-            text: 'Please extract all line items from this receipt.',
+            text: 'Please extract all line items from this receipt. Pay special attention to the business or restaurant name at the top of the receipt — include it even if it is in a non-Latin script.',
           },
         ],
       }],


### PR DESCRIPTION
## Summary
- Fixes the regression introduced in #172 — previous prompt said to return `null` for non-Latin-only names, which made Thai restaurant receipts *worse*
- Now instructs Claude to romanise/transliterate non-Latin names and only return `null` if truly nothing is visible anywhere on the receipt
- Also adds an explicit mention of the business/restaurant name in the user-turn message so the model pays closer attention to the receipt header

## Deployment required after merge
```
supabase functions deploy process-receipt
```

## Test plan
- [ ] Scan a Thai restaurant receipt → banner shows a romanised merchant name
- [ ] Scan a receipt with no visible business name → banner shows "Unreviewed receipt"
- [ ] Items and total extraction unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)