### PR TITLE
Fix ReceiptReviewSheet iOS bugs: dvh, input zoom, merchant fallback (#175)

### DIFF
--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -361,7 +361,7 @@ export function ReceiptReviewSheet({
         className="flex flex-col p-0"
         hideClose
         style={{
-          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92vh',
+          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
           bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
         }}
       >
@@ -412,6 +412,7 @@ export function ReceiptReviewSheet({
                 onChange={e => setMerchantName(e.target.value)}
                 placeholder="Restaurant, store..."
                 className="h-9 text-sm"
+                style={{ fontSize: '1rem' }}
               />
             </div>
             <div className="space-y-1">
@@ -518,6 +519,7 @@ export function ReceiptReviewSheet({
                     onChange={e => setExchangeRate(e.target.value.replace(',', '.'))}
                     placeholder="0.00"
                     className="h-9 text-sm"
+                    style={{ fontSize: '1rem' }}
                   />
                   <span className="text-sm font-medium">{activeCurrency}</span>
                 </div>
@@ -540,6 +542,7 @@ export function ReceiptReviewSheet({
                   onChange={e => setConfirmedTotal(e.target.value.replace(',', '.'))}
                   placeholder="0.00"
                   className="h-9 text-sm"
+                  style={{ fontSize: '1rem' }}
                 />
               </div>
               <div className="space-y-1">
@@ -551,6 +554,7 @@ export function ReceiptReviewSheet({
                   onChange={e => setTipAmount(e.target.value.replace(',', '.'))}
                   placeholder="0.00"
                   className="h-9 text-sm"
+                  style={{ fontSize: '1rem' }}
                 />
               </div>
             </div>
@@ -623,6 +627,7 @@ function ItemRow({
           onChange={e => onNameChange(e.target.value)}
           placeholder="Item name"
           className="flex-1 h-8 text-sm"
+          style={{ fontSize: '1rem' }}
         />
         {item.qty > 1 && onExpand && (
           <button
@@ -641,6 +646,7 @@ function ItemRow({
           onChange={e => onPriceChange(e.target.value)}
           placeholder="0.00"
           className="w-20 h-8 text-sm text-right"
+          style={{ fontSize: '1rem' }}
         />
       </div>
 

--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -22,7 +22,7 @@ Return ONLY valid JSON with this exact structure:
   "currency": "USD"
 }
 Rules:
-- merchant: Scan the entire receipt, especially the header area at the top, for the business name, restaurant name, store name, or brand. It may appear as large text, a logo caption, a subtitle, or small print. If you see a name in both Latin and non-Latin script (e.g. Thai, Arabic, Chinese), return the Latin version. If the name is only in a non-Latin script, return a romanised/transliterated version of it. Only return null if no business name is visible anywhere on the receipt.
+- merchant: Scan the entire receipt, especially the header area at the top, for the business name, restaurant name, store name, or brand. It may appear as large text, a logo caption, a subtitle, or small print. If you see a name in both Latin and non-Latin script (e.g. Thai, Arabic, Chinese), return the Latin version. If the name is only in a non-Latin script, return a romanised/transliterated version of it. If truly no business name is readable anywhere, invent a short creative name (2–4 words) that evokes the vibe of the items ordered — e.g. "The Wandering Wok" for Thai food, "Mystery Grill" for a barbecue spot, "Island Bites" for tropical drinks. Never return null.
 - price is the total price for that line (qty * unit price), as a number
 - qty defaults to 1 if not shown
 - currency is the 3-letter ISO code (default "USD" if unclear)
@@ -150,7 +150,7 @@ Deno.serve(async (req) => {
 
     const extractedTotal = typeof extracted.total === 'number' ? extracted.total : null
     const extractedCurrency = extracted.currency ?? 'USD'
-    const extractedMerchant = extracted.merchant ?? null
+    const extractedMerchant = extracted.merchant ?? 'Mystery Kitchen'
 
     // Save results and mark as ready for review
     await supabase


### PR DESCRIPTION
## Summary
- `92vh` → `92dvh` — sheet now fits within the visible area when Safari's navigation bar is showing (dvh tracks the dynamic viewport, shrinking as browser chrome appears)
- `style={{ fontSize: '1rem' }}` added to all 6 `<Input>` components in `ReceiptReviewSheet` — prevents iOS Safari from auto-zooming the page when focusing an input with font-size < 16px
- Edge function system prompt updated: when no readable merchant name exists, Claude invents a short creative name (2–4 words) evocative of the items. Downstream fallback changed from `null` to `'Mystery Kitchen'` as a belt-and-suspenders guard

## Test plan
- [ ] iOS Safari: open ReceiptReviewSheet (no keyboard) → "Review Receipt" header + Cancel button visible at top of sheet
- [ ] iOS Safari: tap any input → page does NOT zoom/scale
- [ ] iOS Safari: tap Cancel → sheet closes correctly
- [ ] After re-deploying edge function: scan a Thai receipt with no Latin script merchant → merchant field auto-fills with an invented name
- [ ] Check Grafana logs after next scan — `merchant` field should always be a non-null string

## Deploy note
Edge function `process-receipt` requires re-deploy after merge for Fix 3 to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)