### PR TITLE
Fix receipt UI overflow and Cancel button inconsistency (#180)

### DIFF
--- a/src/components/receipts/ReceiptDetailsSheet.tsx
+++ b/src/components/receipts/ReceiptDetailsSheet.tsx
@@ -41,9 +41,11 @@ export function ReceiptDetailsSheet({ open, onOpenChange, task }: ReceiptDetails
       <SheetContent side="bottom" className="h-[75vh] flex flex-col p-0">
         <div className="px-4 pt-4 pb-2 border-b border-border">
           <SheetHeader>
-            <SheetTitle className="flex items-center gap-2">
-              <ScanLine size={18} />
-              Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
+            <SheetTitle className="flex items-center gap-2 min-w-0">
+              <ScanLine size={18} className="shrink-0" />
+              <span className="truncate">
+                Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
+              </span>
             </SheetTitle>
           </SheetHeader>
         </div>
@@ -84,9 +86,9 @@ export function ReceiptDetailsSheet({ open, onOpenChange, task }: ReceiptDetails
                 </div>
                 {items.map((item, i) => (
                   <div key={i} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-sm py-1.5 border-b border-border/50 last:border-0">
-                    <span className="break-words">{item.name}</span>
+                    <span className="break-words min-w-0">{item.name}</span>
                     <span className="text-center text-muted-foreground">{item.qty}</span>
-                    <span className="text-right tabular-nums">{currency} {item.price.toFixed(2)}</span>
+                    <span className="text-right tabular-nums whitespace-nowrap">{currency} {item.price.toFixed(2)}</span>
                   </div>
                 ))}
               </div>

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -359,22 +359,13 @@ export function ReceiptReviewSheet({
       <SheetContent
         side="bottom"
         className="flex flex-col p-0"
-        hideClose
         style={{
           height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
           bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
         }}
       >
-        <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+        <div className="px-4 py-3 border-b border-border shrink-0">
           <SheetTitle className="text-base font-semibold">Review Receipt</SheetTitle>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => onOpenChange(false)}
-            className="text-muted-foreground -mr-2"
-          >
-            Cancel
-          </Button>
         </div>
 
         <div ref={contentRef} className="flex-1 overflow-y-auto">

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -176,14 +176,13 @@ export function ExpensesPage() {
                 key={task.id}
                 className="flex items-center justify-between gap-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-3"
               >
-                <div className="flex items-center gap-2 text-sm text-amber-800 dark:text-amber-300">
-                  <ScanLine size={16} />
-                  <span>
-                    Unreviewed receipt
-                    {task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
+                <div className="flex items-center gap-2 text-sm text-amber-800 dark:text-amber-300 min-w-0">
+                  <ScanLine size={16} className="shrink-0" />
+                  <span className="truncate">
+                    Unreviewed receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
                   </span>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 shrink-0">
                   <Button
                     size="sm"
                     variant="outline"


### PR DESCRIPTION
## Summary

- **ExpensesPage**: pending receipt banner merchant name now truncates with ellipsis (`min-w-0` + `truncate`); icon and buttons container get `shrink-0` so they never get squished
- **ReceiptDetailsSheet**: SheetTitle merchant name truncates; items grid item name cell gets `min-w-0`, price cell gets `whitespace-nowrap` to prevent amounts from wrapping on narrow screens
- **ReceiptReviewSheet**: removed `hideClose` and custom "Cancel" `<Button>` — the built-in shadcn/ui X icon now shows consistently with every other sheet in the app

## Test plan

- [ ] Open a trip in full mode with a pending receipt with a long merchant name → name truncates, Review/Dismiss buttons stay on the right
- [ ] Open ReceiptDetailsSheet for a completed receipt with long merchant name → SheetTitle truncates; prices don't wrap
- [ ] Open ReceiptReviewSheet → header shows "Review Receipt" + X icon top-right (no "Cancel" text button)
- [ ] `npm run type-check` passes clean ✅

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)