### PR TITLE
Fix receipt UI: widen price input and expand merchant name in banner (#182)

### DIFF
--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -636,7 +636,7 @@ function ItemRow({
           value={item.price}
           onChange={e => onPriceChange(e.target.value)}
           placeholder="0.00"
-          className="w-20 h-8 text-sm text-right"
+          className="w-24 h-8 text-sm text-right"
           style={{ fontSize: '1rem' }}
         />
       </div>

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -174,40 +174,47 @@ export function ExpensesPage() {
             {pendingReceipts.map(task => (
               <div
                 key={task.id}
-                className="flex items-center justify-between gap-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-3"
+                className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-3"
               >
+                <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2 text-sm text-amber-800 dark:text-amber-300 min-w-0">
                   <ScanLine size={16} className="shrink-0" />
-                  <span className="truncate">
-                    Unreviewed receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
-                  </span>
+                  <div className="min-w-0">
+                    <span className="font-medium">Unreviewed receipt</span>
+                    {task.extracted_merchant && (
+                      <p className="text-xs text-amber-600 dark:text-amber-400 truncate mt-0.5">
+                        {task.extracted_merchant}
+                      </p>
+                    )}
+                  </div>
                 </div>
-                <div className="flex items-center gap-2 shrink-0">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-7 text-xs"
-                    onClick={() =>
-                      setReceiptReviewData({
-                        taskId: task.id,
-                        merchant: task.extracted_merchant,
-                        items: task.extracted_items ?? [],
-                        total: task.extracted_total,
-                        currency: task.extracted_currency ?? currentTrip?.default_currency ?? 'USD',
-                        imagePath: task.receipt_image_path ?? null,
-                      })
-                    }
-                  >
-                    Review
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-7 text-xs text-muted-foreground"
-                    onClick={() => dismissReceiptTask(task.id)}
-                  >
-                    Dismiss
-                  </Button>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs"
+                      onClick={() =>
+                        setReceiptReviewData({
+                          taskId: task.id,
+                          merchant: task.extracted_merchant,
+                          items: task.extracted_items ?? [],
+                          total: task.extracted_total,
+                          currency: task.extracted_currency ?? currentTrip?.default_currency ?? 'USD',
+                          imagePath: task.receipt_image_path ?? null,
+                        })
+                      }
+                    >
+                      Review
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 text-xs text-muted-foreground"
+                      onClick={() => dismissReceiptTask(task.id)}
+                    >
+                      Dismiss
+                    </Button>
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -169,40 +169,47 @@ export function QuickGroupDetailPage() {
           {pendingReceipts.map(task => (
             <div
               key={task.id}
-              className="flex items-center justify-between gap-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl px-4 py-3"
+              className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl px-4 py-3"
             >
-              <div className="flex items-center gap-2 text-sm text-amber-800 dark:text-amber-300 min-w-0">
-                <ScanLine size={16} className="shrink-0" />
-                <span className="truncate">
-                  Unreviewed receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
-                </span>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7 text-xs"
-                  onClick={() =>
-                    setReceiptReviewData({
-                      taskId: task.id,
-                      merchant: task.extracted_merchant,
-                      items: task.extracted_items ?? [],
-                      total: task.extracted_total,
-                      currency: task.extracted_currency ?? currentTrip.default_currency,
-                      imagePath: task.receipt_image_path ?? null,
-                    })
-                  }
-                >
-                  Review
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 text-xs text-muted-foreground"
-                  onClick={() => dismissReceiptTask(task.id)}
-                >
-                  Dismiss
-                </Button>
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2 text-sm text-amber-800 dark:text-amber-300 min-w-0">
+                  <ScanLine size={16} className="shrink-0" />
+                  <div className="min-w-0">
+                    <span className="font-medium">Unreviewed receipt</span>
+                    {task.extracted_merchant && (
+                      <p className="text-xs text-amber-600 dark:text-amber-400 truncate mt-0.5">
+                        {task.extracted_merchant}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() =>
+                      setReceiptReviewData({
+                        taskId: task.id,
+                        merchant: task.extracted_merchant,
+                        items: task.extracted_items ?? [],
+                        total: task.extracted_total,
+                        currency: task.extracted_currency ?? currentTrip.default_currency,
+                        imagePath: task.receipt_image_path ?? null,
+                      })
+                    }
+                  >
+                    Review
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 text-xs text-muted-foreground"
+                    onClick={() => dismissReceiptTask(task.id)}
+                  >
+                    Dismiss
+                  </Button>
+                </div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary

- **ReceiptReviewSheet**: Price input widened from `w-20` → `w-24` (text area grows from 48px to 64px), so "200.00" no longer clips at the right edge
- **Pending receipt banner** (Quick + Expenses pages): Merchant name moved to its own `<p>` line below "Unreviewed receipt", giving it ~187px instead of ~46px — "The Sai Ko Terrace" now shows in full

Fixes #182.

## Test plan

- [ ] Open a trip with a pending receipt with a long merchant name on mobile
- [ ] **Banner**: "Unreviewed receipt" on line 1; merchant name fully visible on line 2 below
- [ ] **ReceiptReviewSheet**: Tap Review → item prices "200.00", "360.00" display without clipping
- [ ] `npm run type-check` passes clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)