### PR TITLE
Fix issues phases 1-4: mobile bugs, copy/layout, reliability, onboarding

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,84 @@
+# Enhancements / Issues / Bugs — Phased Plan
+
+## Context
+
+15 user-reported issues (GitHub, 2026-02-20/21) need to be addressed. This document tracks them separately from `PLAN.md` (which covers feature phases like Email & Invitations).
+
+---
+
+## Phase 1 — Critical Mobile Bugs ✅
+
+**Goal:** Fix issues that completely block users from doing core tasks on mobile.
+
+| # | Title | Root Cause | Fix |
+|---|---|---|---|
+| #179 | Chrome iOS can't toggle to full mode | `ConditionalHomePage`: `shouldGoQuick = mode === 'quick' \|\| isMobile` — always redirects mobile back to quick, even after user explicitly clicked "Full" | Changed to `mode === 'quick' \|\| (isMobile && mode !== 'full')` |
+| #178 | Fresh browser doesn't see groups | `QuickHomeScreen` has no distinct loading state — when auth finishes but trips are still fetching, the empty-state ("no trips") flashes immediately | Show `Loader2` spinner in `QuickHomeScreen` while `tripsLoading && user` |
+
+**Files:** `src/pages/ConditionalHomePage.tsx`, `src/pages/QuickHomeScreen.tsx`
+
+---
+
+## Phase 2 — Copy, Naming & Layout Polish ✅
+
+**Goal:** Fix visual/copy issues that erode trust or confuse users. All low-risk.
+
+| # | Title | Root Cause | Fix |
+|---|---|---|---|
+| #142 | Landing page says "Family Trip" | `HomePage.tsx` h1 still says "Family Trip Cost Splitter" | Updated to "Split costs with anyone" |
+| #146 | Event name lost in quick mode | QuickLayout header shows "Loading..." and never derives entity label | Show `currentTrip?.name` once loaded; derive "Trip"/"Event" label from `event_type` |
+| #176 | Inconsistent naming in quick mode | `QuickGroupDetailPage` hardcodes "Trip not found" / "Go to My Trips" | Use `entityLabel` (same pattern as ManageTripPage) for entity-aware strings |
+| #145 | Currency box too narrow on desktop | `ExpenseForm` has `SelectTrigger className="w-24"` vs `w-28` in mobile wizard | Changed to `w-28` |
+| #148 | Sidebar shows at trips list root | `Layout.tsx` always renders sidebar + `lg:ml-64` main margin | Hide sidebar and remove margin when `tripCode` is absent |
+| #174 | Expenses page stretches full-width on desktop | `ExpensesPage` content has no `max-w-*` | Wrapped content in `max-w-4xl mx-auto` |
+
+**Files:** `src/pages/HomePage.tsx`, `src/components/QuickLayout.tsx`, `src/pages/QuickGroupDetailPage.tsx`, `src/components/expenses/ExpenseForm.tsx`, `src/components/Layout.tsx`, `src/pages/ExpensesPage.tsx`
+
+---
+
+## Phase 3 — Reliability ✅
+
+**Goal:** Reduce frustration from errors that leave users stuck.
+
+| # | Title | Root Cause | Fix |
+|---|---|---|---|
+| #136 | Timeout when posting expense; reload required | After 15 s timeout the error shows but no retry affordance exists | Added "Try again" button to `ExpenseForm`/`MobileWizard` error state; form is not reset on timeout failure |
+| #147 | 0.02 rounding discrepancy in Dashboard | Floating-point accumulation across many expenses; individual splits rounded to 2dp but totals aren't | Round net balance values to `Math.round(v * 100) / 100` before display in `DashboardPage` |
+
+**Files:** `src/components/expenses/ExpenseForm.tsx`, `src/components/expenses/ExpenseWizard.tsx`, `src/pages/DashboardPage.tsx`
+
+---
+
+## Phase 4 — Onboarding & Participant Flow ✅
+
+**Goal:** Make it easier for new users to get started after creating an event.
+
+| # | Title | Root Cause | Fix |
+|---|---|---|---|
+| #143 | Participants section at bottom of Manage page | ManageTripPage renders participants after Details, Features, Currency cards | Moved participants card to top position; added empty-state callout "Add participants to get started" |
+| #144 | No email field when adding participants | `IndividualsSetup` / `CreateParticipantInput` has no `email` field | Deferred to Phase 4 (Email & Invitations) in PLAN.md — the email capture is part of the invitation flow |
+
+**Files:** `src/pages/ManageTripPage.tsx`
+
+---
+
+## Phase 5 — Investigate / Deferred
+
+Issues that need more live testing before a fix is committed.
+
+| # | Title | Status | Notes |
+|---|---|---|---|
+| #162 | Receipt item chips not visually distinct | Investigate | `CHIP_COLORS` palette already implemented in `ReceiptReviewSheet` (lines 42-55). Needs live testing to confirm if contrast is actually the problem before changing anything |
+| #158 | Keyboard hides expense form on iOS (full mode) | Deferred | Desktop `Dialog` doesn't apply `useKeyboardHeight` unlike `MobileWizard`. Complex fix — warrants its own spike once Phases 1–4 ship |
+
+---
+
+## Verification per Phase
+
+| Phase | How to verify |
+|---|---|
+| 1 | On iPhone Chrome: tap "Full" in ModeToggle → stays in full mode. On fresh browser while authenticated → spinner shows instead of empty state |
+| 2 | Desktop Chrome wide window: expenses page has max-width; root `/` has no sidebar; currency box wider. Quick view for an event entity shows correct label. Landing page no longer says "Family" |
+| 3 | Throttle network in DevTools; submit expense → timeout error shows "Try again" button. Dashboard settlement amounts are exact round cents |
+| 4 | Create new event → manage page shows participants first. Empty-state callout visible |
+| 5 | (After live test) receipt item chips clearly distinguishable per participant |

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -187,7 +187,7 @@ export function Layout() {
       </header>
 
       {/* Main content */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 lg:ml-64 mt-20">
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 ${tripCode ? 'lg:ml-64' : ''} mt-20`}>
         <ParticipantProvider>
           <ExpenseProvider>
             <SettlementProvider>
@@ -324,7 +324,7 @@ export function Layout() {
       </nav>
 
       {/* Side navigation (desktop) */}
-      <aside className="hidden lg:block fixed left-0 top-20 bottom-0 w-64 bg-card border-r border-border soft-shadow">
+      {tripCode && <aside className="hidden lg:block fixed left-0 top-20 bottom-0 w-64 bg-card border-r border-border soft-shadow">
         <nav className="px-3 py-6 space-y-1">
           {desktopNavItems.map((item) => {
             const Icon = iconMap[item.label as keyof typeof iconMap]
@@ -360,7 +360,7 @@ export function Layout() {
             )
           })}
         </nav>
-      </aside>
+      </aside>}
 
       {/* Toast notifications */}
       <Toaster />

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -65,9 +65,16 @@ export function QuickLayout() {
                   <Link to={backTo} className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}>
                     <ArrowLeft size={20} />
                   </Link>
-                  <h1 className={`text-lg font-semibold truncate ${onGradient ? 'text-white drop-shadow-md' : 'text-foreground'}`}>
-                    {currentTrip?.name || 'Loading...'}
-                  </h1>
+                  <div className="min-w-0">
+                    <h1 className={`text-lg font-semibold truncate leading-tight ${onGradient ? 'text-white drop-shadow-md' : 'text-foreground'}`}>
+                      {currentTrip?.name}
+                    </h1>
+                    {currentTrip && (
+                      <p className={`text-xs leading-tight ${onGradient ? 'text-white/60' : 'text-muted-foreground'}`}>
+                        {currentTrip.event_type === 'event' ? 'Event' : 'Trip'}
+                      </p>
+                    )}
+                  </div>
                 </>
               ) : (
                 <div className="flex items-center gap-2">

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -240,8 +240,7 @@ export function ExpenseForm({
     setFamilySplitValues({})
   }
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault()
+  const executeSubmit = async () => {
     if (loading) return
     setError(null)
 
@@ -432,6 +431,11 @@ export function ExpenseForm({
     }
   }
 
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    await executeSubmit()
+  }
+
   return (
     <motion.form
       onSubmit={handleSubmit}
@@ -446,7 +450,19 @@ export function ExpenseForm({
           animate={{ opacity: 1, y: 0 }}
           className="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm"
         >
-          {error}
+          <div className="flex items-start justify-between gap-2">
+            <span>{error}</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={executeSubmit}
+              disabled={loading}
+              className="shrink-0 text-xs h-7 border-destructive/40 text-destructive hover:bg-destructive/10"
+            >
+              Try again
+            </Button>
+          </div>
           {errorDetail && (
             <pre className="mt-2 text-xs whitespace-pre-wrap break-all opacity-80">{errorDetail}</pre>
           )}
@@ -488,7 +504,7 @@ export function ExpenseForm({
             onValueChange={setCurrency}
             disabled={loading}
           >
-            <SelectTrigger className="w-24">
+            <SelectTrigger className="w-28">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -502,7 +502,17 @@ function MobileWizard({
 
         {error && (
           <div className="mb-4 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
-            {error}
+            <div className="flex items-start justify-between gap-2">
+              <span>{error}</span>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+                className="shrink-0 text-xs underline underline-offset-2 opacity-80 hover:opacity-100 disabled:opacity-40"
+              >
+                Try again
+              </button>
+            </div>
             {errorDetail && (
               <pre className="mt-2 text-xs whitespace-pre-wrap break-all opacity-80">{errorDetail}</pre>
             )}

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -22,7 +22,7 @@ export function ConditionalHomePage() {
   const { trips, loading: tripsLoading } = useTripContext()
 
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
-  const shouldGoQuick = mode === 'quick' || isMobile
+  const shouldGoQuick = mode === 'quick' || (isMobile && mode !== 'full')
 
   const isLoading = prefsLoading || (shouldGoQuick && tripsLoading)
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -52,6 +52,12 @@ export function DashboardPage() {
     currentTrip.exchange_rates
   )
 
+  // Round display balances to 2dp to avoid floating-point accumulation artefacts
+  const displayBalances = balanceCalculation.balances.map(b => ({
+    ...b,
+    balance: Math.round(b.balance * 100) / 100,
+  }))
+
   const handleExportPDF = () => {
     exportTripSummaryToPDF(currentTrip, expenses, participants, balanceCalculation.balances)
   }
@@ -130,7 +136,7 @@ export function DashboardPage() {
                 style: 'currency',
                 currency: currentTrip.default_currency,
               }).format(
-                Math.abs(balanceCalculation.balances
+                Math.abs(displayBalances
                   .filter(b => b.balance < 0)
                   .reduce((sum, b) => sum + b.balance, 0))
               )}
@@ -165,7 +171,7 @@ export function DashboardPage() {
           Current Balances
         </h3>
 
-        {balanceCalculation.balances.length === 0 ? (
+        {displayBalances.length === 0 ? (
           <Card>
             <CardContent className="pt-6">
               <div className="text-center py-8">
@@ -178,7 +184,7 @@ export function DashboardPage() {
           </Card>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {balanceCalculation.balances.map(balance => (
+            {displayBalances.map(balance => (
               <BalanceCard key={balance.id} balance={balance} currency={currentTrip.default_currency} onClick={() => setSelectedBalance(balance)} />
             ))}
           </div>

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -133,7 +133,7 @@ export function ExpensesPage() {
 
   return (
     <>
-      <div className="space-y-4">
+      <div className="max-w-4xl mx-auto space-y-4">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-y-2">
           <h2 className="text-xl font-bold text-foreground">Expenses</h2>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -47,7 +47,7 @@ export function HomePage() {
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-foreground mb-2">
-            Family Trip Cost Splitter
+            Split costs with anyone
           </h1>
           <p className="text-muted-foreground">
             Split costs fairly among groups with real-time collaboration

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -233,6 +233,30 @@ export function ManageTripPage() {
         <p className="text-sm text-muted-foreground mt-1">{currentTrip.name}</p>
       </div>
 
+      {/* Participants Section — top position for easy onboarding */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-foreground">
+          Participants & Families
+        </h3>
+        {participants.length === 0 && (
+          <Card className="border-dashed border-primary/40 bg-primary/5">
+            <CardContent className="pt-4 pb-4">
+              <p className="text-sm text-primary font-medium">
+                Add participants to get started
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Participants are required before you can add expenses.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+        {currentTrip.tracking_mode === 'individuals' ? (
+          <IndividualsSetup />
+        ) : (
+          <FamiliesSetup />
+        )}
+      </div>
+
       {/* Details Card */}
       <Card>
         <CardHeader>
@@ -422,18 +446,6 @@ export function ManageTripPage() {
           </Button>
         </CardContent>
       </Card>
-
-      {/* Participants Section */}
-      <div className="space-y-4">
-        <h3 className="text-lg font-semibold text-foreground">
-          Participants & Families
-        </h3>
-        {currentTrip.tracking_mode === 'individuals' ? (
-          <IndividualsSetup />
-        ) : (
-          <FamiliesSetup />
-        )}
-      </div>
 
       {/* Accommodations Section */}
       <StaySection />

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -73,6 +73,8 @@ export function QuickGroupDetailPage() {
     }
   }
 
+  const entityLabel = currentTrip?.event_type === 'event' ? 'Event' : 'Trip'
+
   if (tripLoading) {
     return (
       <div className="max-w-lg mx-auto px-4 py-6">
@@ -88,9 +90,9 @@ export function QuickGroupDetailPage() {
       <div className="max-w-lg mx-auto px-4 py-6">
         <Card>
           <CardContent className="pt-6 text-center">
-            <p className="text-muted-foreground mb-4">Trip not found</p>
+            <p className="text-muted-foreground mb-4">{entityLabel} not found</p>
             <Button onClick={() => navigate('/quick')} variant="outline" size="sm">
-              Go to My Trips
+              My Groups
             </Button>
           </CardContent>
         </Card>
@@ -252,7 +254,7 @@ export function QuickGroupDetailPage() {
           onClick={() => navigate('/quick')}
         >
           <ArrowLeftRight size={16} />
-          My Trips
+          My Groups
         </Button>
         <Button
           variant="outline"

--- a/src/pages/QuickHomeScreen.tsx
+++ b/src/pages/QuickHomeScreen.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
+import { useTripContext } from '@/contexts/TripContext'
 import { useMyTripBalances } from '@/hooks/useMyTripBalances'
 import { formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
 import { getHiddenTripCodes, showTrip } from '@/lib/mutedTripsStorage'
@@ -13,8 +14,10 @@ import { motion } from 'framer-motion'
 
 export function QuickHomeScreen() {
   const navigate = useNavigate()
-  const { userProfile } = useAuth()
-  const { tripBalances, loading } = useMyTripBalances()
+  const { user, userProfile } = useAuth()
+  const { loading: tripsLoading } = useTripContext()
+  const { tripBalances, loading: balancesLoading } = useMyTripBalances()
+  const loading = balancesLoading || (!!user && tripsLoading)
   const [hiddenCodes, setHiddenCodes] = useState(() => new Set(getHiddenTripCodes()))
   const [showHidden, setShowHidden] = useState(false)
 


### PR DESCRIPTION
## Summary

- **Phase 1 (Critical mobile):** Fix Chrome iOS stuck in quick mode after tapping "Full" (#179); fix empty-state flash on fresh browser load (#178)
- **Phase 2 (Copy/layout):** Landing page heading (#142); QuickLayout shows entity type label (#146); entity-aware strings in QuickGroupDetailPage (#176); wider currency selector on desktop (#145); hide sidebar when no trip selected (#148); max-width on Expenses page (#174)
- **Phase 3 (Reliability):** "Try again" button in ExpenseForm and MobileWizard error state (#136); round balance values in Dashboard to eliminate floating-point artefacts (#147)
- **Phase 4 (Onboarding):** Move Participants section to top of Manage page with empty-state callout (#143)

Also adds `ISSUES.md` tracking document to the project root.

## Test plan

- [ ] iPhone Chrome: tap "Full" in ModeToggle → stays in full mode (doesn't bounce back to quick)
- [ ] Fresh authenticated browser on quick home → spinner shows until trips load, no premature empty state
- [ ] Landing page (`/`) heading reads "Split costs with anyone"
- [ ] Quick view for an event shows "Event" label below name in header
- [ ] QuickGroupDetailPage: "My Groups" button, entity-aware not-found state
- [ ] Desktop ExpenseForm: currency dropdown is wider (w-28)
- [ ] Full-mode root `/`: no sidebar visible on desktop
- [ ] Expenses page: content has max-width on wide screens
- [ ] Throttle network → submit expense → timeout error shows "Try again" button; form data preserved
- [ ] Dashboard balance cards show clean rounded numbers (no 0.02 drift)
- [ ] Manage Trip/Event page: participants section appears at top with empty-state callout when no participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)