### PR TITLE
Fix issues #187, #158, #186, #162: keyboard/dialog, bank details, chip colors

### DIFF
--- a/src/components/ReportIssueDialog.tsx
+++ b/src/components/ReportIssueDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react'
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { useToast } from '@/hooks/use-toast'
 import { supabase } from '@/lib/supabase'
 import {
@@ -59,6 +60,7 @@ const MAX_SCREENSHOTS = 5
 
 export function ReportIssueDialog({ open, onOpenChange }: ReportIssueDialogProps) {
   const { toast } = useToast()
+  const keyboard = useKeyboardHeight()
   const [subject, setSubject] = useState('')
   const [description, setDescription] = useState('')
   const [screenshots, setScreenshots] = useState<File[]>([])
@@ -166,7 +168,10 @@ export function ReportIssueDialog({ open, onOpenChange }: ReportIssueDialogProps
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        style={keyboard.isVisible ? { marginBottom: keyboard.keyboardHeight } : undefined}
+      >
         <DialogHeader>
           <DialogTitle>Report an Issue</DialogTitle>
           <DialogDescription>
@@ -183,7 +188,6 @@ export function ReportIssueDialog({ open, onOpenChange }: ReportIssueDialogProps
               value={subject}
               onChange={(e) => setSubject(e.target.value)}
               required
-              autoFocus
             />
           </div>
 

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -279,7 +279,11 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                               </p>
                             )
                           }
-                          return null
+                          return (
+                            <p className="mt-2 text-xs text-muted-foreground italic">
+                              Ask {tx.toName} to join Spl1t to share payment details
+                            </p>
+                          )
                         })()}
                       </div>
                       <Button

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -40,18 +40,18 @@ interface ReceiptReviewSheetProps {
 
 // Participant chip color palette (consistent across rerenders)
 const CHIP_COLORS = [
-  'bg-blue-500',
-  'bg-emerald-500',
-  'bg-violet-500',
-  'bg-amber-500',
-  'bg-rose-500',
-  'bg-cyan-500',
-  'bg-fuchsia-500',
-  'bg-teal-500',
+  { on: 'bg-blue-500 text-white',    off: 'bg-blue-100 text-blue-700 border border-blue-300 dark:bg-blue-900/40 dark:text-blue-300 dark:border-blue-700' },
+  { on: 'bg-emerald-500 text-white', off: 'bg-emerald-100 text-emerald-700 border border-emerald-300 dark:bg-emerald-900/40 dark:text-emerald-300 dark:border-emerald-700' },
+  { on: 'bg-violet-500 text-white',  off: 'bg-violet-100 text-violet-700 border border-violet-300 dark:bg-violet-900/40 dark:text-violet-300 dark:border-violet-700' },
+  { on: 'bg-amber-500 text-white',   off: 'bg-amber-100 text-amber-700 border border-amber-300 dark:bg-amber-900/40 dark:text-amber-300 dark:border-amber-700' },
+  { on: 'bg-rose-500 text-white',    off: 'bg-rose-100 text-rose-700 border border-rose-300 dark:bg-rose-900/40 dark:text-rose-300 dark:border-rose-700' },
+  { on: 'bg-cyan-500 text-white',    off: 'bg-cyan-100 text-cyan-700 border border-cyan-300 dark:bg-cyan-900/40 dark:text-cyan-300 dark:border-cyan-700' },
+  { on: 'bg-fuchsia-500 text-white', off: 'bg-fuchsia-100 text-fuchsia-700 border border-fuchsia-300 dark:bg-fuchsia-900/40 dark:text-fuchsia-300 dark:border-fuchsia-700' },
+  { on: 'bg-teal-500 text-white',    off: 'bg-teal-100 text-teal-700 border border-teal-300 dark:bg-teal-900/40 dark:text-teal-300 dark:border-teal-700' },
 ]
 
-function getChipColor(index: number) {
-  return CHIP_COLORS[index % CHIP_COLORS.length]
+function getChipColor(index: number, assigned: boolean) {
+  return CHIP_COLORS[index % CHIP_COLORS.length][assigned ? 'on' : 'off']
 }
 
 
@@ -651,9 +651,7 @@ function ItemRow({
               onClick={() => onToggleParticipant(p.id)}
               className={[
                 'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-colors',
-                assigned
-                  ? `${getChipColor(pi)} text-white`
-                  : 'bg-muted text-muted-foreground border border-border',
+                getChipColor(pi, assigned),
               ].join(' ')}
               title={p.name}
             >


### PR DESCRIPTION
## Summary

- **#187 / #158 — iOS keyboard covers ReportIssueDialog:** Removed `autoFocus` from the subject input (was triggering the keyboard on open before the user tapped anything). Added `useKeyboardHeight` + `marginBottom: keyboardHeight` on `DialogContent` so the modal shifts up when the keyboard is open.
- **#186 — Settlement sheet missing bank details for unlinked recipients:** Added a third fallback branch — when the recipient has no linked account (`!isLinked`), the card now shows *"Ask {name} to join Spl1t to share payment details"* instead of silence.
- **#162 — Receipt item chips indistinguishable when unassigned:** Replaced the flat `CHIP_COLORS` string array with an `{ on, off }` pair per color. Unassigned chips now show a tinted low-opacity variant of their person's color (e.g. blue-100 bg / blue-700 text) instead of a uniform gray, so each person remains visually identifiable regardless of assignment state.

## Test plan
- [ ] Open ReportIssueDialog on iOS — keyboard should not pop on open; tapping Subject input should raise the dialog above the keyboard
- [ ] Settlement sheet with an unlinked recipient — verify the "Ask … to join Spl1t" message appears
- [ ] Receipt review — tap chips to assign/unassign; each person should have a distinct tinted color in both states

🤖 Generated with [Claude Code](https://claude.com/claude-code)