### PR TITLE
Add email & invitations foundation — Phase 4 (closes #144)

### DIFF
--- a/src/components/setup/IndividualsSetup.tsx
+++ b/src/components/setup/IndividualsSetup.tsx
@@ -1,8 +1,10 @@
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import { X, UserPlus } from 'lucide-react'
+import { X, UserPlus, Mail, Pencil, Check } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useAuth } from '@/contexts/AuthContext'
+import { supabase } from '@/lib/supabase'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -10,19 +12,77 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { fadeInUp } from '@/lib/animations'
+import type { Participant } from '@/types/participant'
+import { logger } from '@/lib/logger'
 
 interface IndividualsSetupProps {
   onComplete?: () => void
   hasSetup?: boolean
 }
 
+async function sendInvitation(params: {
+  participantId: string
+  participantEmail: string
+  participantName: string
+  tripId: string
+  tripCode: string
+  tripName: string
+  organiserName: string
+  inviterId: string
+}) {
+  try {
+    // Create invitation row
+    const { data: inv, error: invError } = await supabase
+      .from('invitations')
+      .insert([{
+        trip_id: params.tripId,
+        participant_id: params.participantId,
+        inviter_id: params.inviterId,
+      }])
+      .select('id, token')
+      .single()
+
+    if (invError || !inv) {
+      logger.warn('Failed to create invitation row', { error: String(invError) })
+      return
+    }
+
+    // Fire-and-forget: send email
+    supabase.functions.invoke('send-email', {
+      body: {
+        type: 'invitation',
+        invitation_id: inv.id,
+        trip_name: params.tripName,
+        trip_code: params.tripCode,
+        participant_name: params.participantName,
+        participant_email: params.participantEmail,
+        organiser_name: params.organiserName,
+        token: inv.token,
+      },
+    }).then(({ error }) => {
+      if (error) logger.warn('send-email edge fn returned error', { error: String(error) })
+    })
+  } catch (err) {
+    logger.warn('sendInvitation: unhandled error', { error: String(err) })
+  }
+}
+
 export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup = false }: IndividualsSetupProps = {}) {
   const { currentTrip } = useCurrentTrip()
-  const { participants, createParticipant, deleteParticipant } = useParticipantContext()
+  const { participants, createParticipant, updateParticipant, deleteParticipant } = useParticipantContext()
+  const { user, userProfile } = useAuth()
 
   const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
   const [isAdult, setIsAdult] = useState(true)
   const [adding, setAdding] = useState(false)
+
+  // Per-participant inline email editing
+  const [editingEmailId, setEditingEmailId] = useState<string | null>(null)
+  const [editEmailValue, setEditEmailValue] = useState('')
+  const [savingEmailId, setSavingEmailId] = useState<string | null>(null)
+
+  const organiserName = userProfile?.display_name || user?.email?.split('@')[0] || 'Organiser'
 
   const handleAdd = async (e: FormEvent) => {
     e.preventDefault()
@@ -31,14 +91,30 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
 
     setAdding(true)
     try {
-      await createParticipant({
+      const newParticipant = await createParticipant({
         trip_id: currentTrip.id,
         name: name.trim(),
         is_adult: isAdult,
         family_id: null,
+        email: email.trim() || null,
       })
       setName('')
+      setEmail('')
       setIsAdult(true)
+
+      // Send invitation if email provided
+      if (newParticipant && email.trim() && user) {
+        sendInvitation({
+          participantId: newParticipant.id,
+          participantEmail: email.trim(),
+          participantName: newParticipant.name,
+          tripId: currentTrip.id,
+          tripCode: currentTrip.trip_code,
+          tripName: currentTrip.name,
+          organiserName,
+          inviterId: user.id,
+        })
+      }
     } finally {
       setAdding(false)
     }
@@ -48,6 +124,36 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
     if (window.confirm('Remove this participant?')) {
       await deleteParticipant(id)
     }
+  }
+
+  const handleStartEditEmail = (participant: Participant) => {
+    setEditingEmailId(participant.id)
+    setEditEmailValue(participant.email || '')
+  }
+
+  const handleSaveEmail = async (participant: Participant) => {
+    setSavingEmailId(participant.id)
+    const newEmail = editEmailValue.trim() || null
+    const hadEmail = !!participant.email
+    await updateParticipant(participant.id, { email: newEmail })
+
+    // Send invitation if email is newly set
+    if (newEmail && !hadEmail && currentTrip && user) {
+      sendInvitation({
+        participantId: participant.id,
+        participantEmail: newEmail,
+        participantName: participant.name,
+        tripId: currentTrip.id,
+        tripCode: currentTrip.trip_code,
+        tripName: currentTrip.name,
+        organiserName,
+        inviterId: user.id,
+      })
+    }
+
+    setSavingEmailId(null)
+    setEditingEmailId(null)
+    setEditEmailValue('')
   }
 
   return (
@@ -72,6 +178,19 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
                 onChange={(e) => setName(e.target.value)}
                 placeholder="e.g., John Doe"
                 required
+                disabled={adding}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional — sends invite)</span></Label>
+              <Input
+                type="email"
+                inputMode="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="e.g., john@example.com"
                 disabled={adding}
               />
             </div>
@@ -115,24 +234,80 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
                   key={participant.id}
                   initial={{ opacity: 0, x: -10 }}
                   animate={{ opacity: 1, x: 0 }}
-                  className="flex items-center justify-between p-3 bg-accent/5 rounded-lg border border-accent/10"
+                  className="p-3 bg-accent/5 rounded-lg border border-accent/10"
                 >
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-foreground">
-                      {participant.name}
-                    </span>
-                    <Badge variant={participant.is_adult ? 'soft' : 'outline'}>
-                      {participant.is_adult ? 'Adult' : 'Child'}
-                    </Badge>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="font-medium text-foreground truncate">
+                        {participant.name}
+                      </span>
+                      <Badge variant={participant.is_adult ? 'soft' : 'outline'}>
+                        {participant.is_adult ? 'Adult' : 'Child'}
+                      </Badge>
+                    </div>
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      <Button
+                        onClick={() => handleStartEditEmail(participant)}
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        title={participant.email ? `Email: ${participant.email}` : 'Add email'}
+                      >
+                        <Mail size={15} className={participant.email ? 'text-accent' : 'text-muted-foreground'} />
+                      </Button>
+                      <Button
+                        onClick={() => handleDelete(participant.id)}
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+                      >
+                        <X size={16} />
+                      </Button>
+                    </div>
                   </div>
-                  <Button
-                    onClick={() => handleDelete(participant.id)}
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
-                  >
-                    <X size={16} />
-                  </Button>
+
+                  {/* Inline email editor */}
+                  {editingEmailId === participant.id && (
+                    <div className="mt-2 flex gap-2">
+                      <Input
+                        type="email"
+                        inputMode="email"
+                        value={editEmailValue}
+                        onChange={(e) => setEditEmailValue(e.target.value)}
+                        placeholder="Email address"
+                        className="h-8 text-sm flex-1"
+                        disabled={savingEmailId === participant.id}
+                      />
+                      <Button
+                        onClick={() => handleSaveEmail(participant)}
+                        size="sm"
+                        className="h-8 px-3"
+                        disabled={savingEmailId === participant.id}
+                      >
+                        <Check size={14} />
+                      </Button>
+                      <Button
+                        onClick={() => { setEditingEmailId(null); setEditEmailValue('') }}
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 px-2"
+                        disabled={savingEmailId === participant.id}
+                      >
+                        <X size={14} />
+                      </Button>
+                    </div>
+                  )}
+
+                  {/* Show email if set and not editing */}
+                  {participant.email && editingEmailId !== participant.id && (
+                    <button
+                      onClick={() => handleStartEditEmail(participant)}
+                      className="mt-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      <Pencil size={11} />
+                      {participant.email}
+                    </button>
+                  )}
                 </motion.div>
               ))}
             </div>

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -234,8 +234,45 @@ export type Database = {
           },
         ]
       }
+      invitations: {
+        Row: {
+          id: string
+          trip_id: string
+          participant_id: string
+          inviter_id: string | null
+          token: string
+          status: string
+          sent_at: string | null
+          accepted_at: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          trip_id: string
+          participant_id: string
+          inviter_id?: string | null
+          token?: string
+          status?: string
+          sent_at?: string | null
+          accepted_at?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          trip_id?: string
+          participant_id?: string
+          inviter_id?: string | null
+          token?: string
+          status?: string
+          sent_at?: string | null
+          accepted_at?: string | null
+          created_at?: string
+        }
+        Relationships: []
+      }
       participants: {
         Row: {
+          email: string | null
           family_id: string | null
           id: string
           is_adult: boolean
@@ -243,6 +280,7 @@ export type Database = {
           trip_id: string
         }
         Insert: {
+          email?: string | null
           family_id?: string | null
           id?: string
           is_adult?: boolean
@@ -250,6 +288,7 @@ export type Database = {
           trip_id: string
         }
         Update: {
+          email?: string | null
           family_id?: string | null
           id?: string
           is_adult?: boolean

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -13,6 +13,7 @@ export interface Participant {
   name: string
   is_adult: boolean
   user_id?: string | null
+  email?: string | null
 }
 
 export interface CreateFamilyInput {
@@ -27,6 +28,7 @@ export interface CreateParticipantInput {
   family_id?: string | null
   name: string
   is_adult: boolean
+  email?: string | null
 }
 
 export interface UpdateFamilyInput {
@@ -39,4 +41,5 @@ export interface UpdateParticipantInput {
   name?: string
   is_adult?: boolean
   family_id?: string | null
+  email?: string | null
 }

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,0 +1,350 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts"
+import { createClient } from 'npm:@supabase/supabase-js@2'
+import { createLogger } from '../_shared/logger.ts'
+import { createMetrics } from '../_shared/metrics.ts'
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+}
+
+const logger = createLogger('send-email')
+const metrics = createMetrics('send-email')
+
+const APP_URL = 'https://split.xtian.me'
+const FROM_ADDRESS = 'Spl1t <noreply@spl1t.me>'
+
+type SendEmailBody =
+  | {
+      type: 'invitation'
+      invitation_id: string
+      trip_name: string
+      trip_code: string
+      participant_name: string
+      participant_email: string
+      organiser_name: string
+      token: string
+    }
+  | {
+      type: 'payment_reminder'
+      trip_id: string
+      trip_name: string
+      trip_code: string
+      recipient_name: string
+      recipient_email: string
+      amount: number
+      currency: string
+      pay_to_name: string
+      organiser_name: string
+    }
+
+function invitationEmailHtml(params: {
+  participantName: string
+  organiserName: string
+  tripName: string
+  joinUrl: string
+  tripUrl: string
+}): string {
+  const { participantName, organiserName, tripName, joinUrl, tripUrl } = params
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>You've been added to ${tripName} on Spl1t</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8fafc;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border-radius:12px;border:1px solid #e2e8f0;overflow:hidden;">
+          <!-- Header -->
+          <tr>
+            <td style="background:linear-gradient(135deg,#6366f1,#8b5cf6);padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#ffffff;font-size:28px;font-weight:700;letter-spacing:-0.5px;">Spl1t</h1>
+              <p style="margin:8px 0 0;color:rgba(255,255,255,0.8);font-size:14px;">Fair cost splitting for groups</p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <h2 style="margin:0 0 8px;color:#1e293b;font-size:20px;font-weight:600;">Hi ${participantName}!</h2>
+              <p style="margin:0 0 24px;color:#475569;font-size:15px;line-height:1.6;">
+                <strong>${organiserName}</strong> has added you to <strong>${tripName}</strong> on Spl1t.
+                Click below to view your balance and see what's been split so far.
+              </p>
+              <!-- CTA Button -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding:8px 0 24px;">
+                    <a href="${joinUrl}" style="display:inline-block;background:#6366f1;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:8px;">
+                      View your balance &rarr;
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <!-- Divider -->
+              <hr style="border:none;border-top:1px solid #e2e8f0;margin:0 0 24px;">
+              <!-- Info Box -->
+              <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:16px;">
+                <p style="margin:0 0 8px;color:#64748b;font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">What is Spl1t?</p>
+                <p style="margin:0;color:#475569;font-size:14px;line-height:1.6;">
+                  Spl1t tracks shared expenses in trips and events, then calculates the fairest way to settle up. No account needed — just click the link above.
+                </p>
+              </div>
+              <p style="margin:20px 0 0;color:#94a3b8;font-size:13px;">
+                Want to see all your splits in one place? <a href="${tripUrl}" style="color:#6366f1;text-decoration:none;">Sign in with Google</a> to link your account.
+              </p>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="padding:16px 32px;border-top:1px solid #e2e8f0;text-align:center;">
+              <p style="margin:0;color:#94a3b8;font-size:12px;">
+                You received this email because ${organiserName} added you to a trip on Spl1t.<br>
+                <a href="${tripUrl}" style="color:#6366f1;text-decoration:none;">Open trip</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+}
+
+function paymentReminderEmailHtml(params: {
+  recipientName: string
+  organiserName: string
+  tripName: string
+  formattedAmount: string
+  payToName: string
+  tripUrl: string
+}): string {
+  const { recipientName, organiserName, tripName, formattedAmount, payToName, tripUrl } = params
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Payment reminder for ${tripName}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8fafc;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border-radius:12px;border:1px solid #e2e8f0;overflow:hidden;">
+          <!-- Header -->
+          <tr>
+            <td style="background:linear-gradient(135deg,#6366f1,#8b5cf6);padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#ffffff;font-size:28px;font-weight:700;letter-spacing:-0.5px;">Spl1t</h1>
+              <p style="margin:8px 0 0;color:rgba(255,255,255,0.8);font-size:14px;">Payment Reminder</p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <h2 style="margin:0 0 8px;color:#1e293b;font-size:20px;font-weight:600;">Hi ${recipientName}!</h2>
+              <p style="margin:0 0 24px;color:#475569;font-size:15px;line-height:1.6;">
+                This is a friendly reminder from <strong>${organiserName}</strong> about an outstanding balance from <strong>${tripName}</strong>.
+              </p>
+              <!-- Amount Box -->
+              <div style="background:#faf5ff;border:2px solid #e9d5ff;border-radius:12px;padding:24px;text-align:center;margin-bottom:24px;">
+                <p style="margin:0 0 4px;color:#7c3aed;font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">You owe</p>
+                <p style="margin:0 0 4px;color:#4c1d95;font-size:36px;font-weight:700;">${formattedAmount}</p>
+                <p style="margin:0;color:#7c3aed;font-size:14px;">to <strong>${payToName}</strong></p>
+              </div>
+              <!-- CTA Button -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding:0 0 24px;">
+                    <a href="${tripUrl}" style="display:inline-block;background:#6366f1;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:8px;">
+                      View details &rarr;
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0;color:#94a3b8;font-size:13px;text-align:center;">
+                Questions? Reply to this email or contact ${organiserName} directly.
+              </p>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="padding:16px 32px;border-top:1px solid #e2e8f0;text-align:center;">
+              <p style="margin:0;color:#94a3b8;font-size:12px;">
+                Sent by ${organiserName} via Spl1t &middot; <a href="${tripUrl}" style="color:#6366f1;text-decoration:none;">Open trip</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders })
+  }
+
+  const requestStart = performance.now()
+
+  try {
+    logger.info('Request received', { method: req.method })
+
+    const resendApiKey = Deno.env.get("RESEND_API_KEY")
+    if (!resendApiKey) {
+      logger.error('RESEND_API_KEY not configured')
+      return new Response(
+        JSON.stringify({ error: "Email service not configured" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+    if (!supabaseUrl || !supabaseServiceKey) {
+      logger.error('Supabase config missing')
+      return new Response(
+        JSON.stringify({ error: "Server configuration error" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const body = await req.json() as SendEmailBody
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    let subject: string
+    let html: string
+    let toEmail: string
+    let toName: string
+    let emailType: string
+    let tripId: string | null = null
+    let invitationId: string | null = null
+
+    if (body.type === 'invitation') {
+      const joinUrl = `${APP_URL}/join/${body.token}`
+      const tripUrl = `${APP_URL}/t/${body.trip_code}/quick`
+      subject = `You've been added to "${body.trip_name}" on Spl1t`
+      html = invitationEmailHtml({
+        participantName: body.participant_name,
+        organiserName: body.organiser_name,
+        tripName: body.trip_name,
+        joinUrl,
+        tripUrl,
+      })
+      toEmail = body.participant_email
+      toName = body.participant_name
+      emailType = 'invitation'
+      invitationId = body.invitation_id
+
+      // Look up trip_id from the invitation
+      const { data: inv } = await supabase
+        .from('invitations')
+        .select('trip_id')
+        .eq('id', body.invitation_id)
+        .single()
+      tripId = inv?.trip_id ?? null
+    } else if (body.type === 'payment_reminder') {
+      const formattedAmount = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: body.currency,
+      }).format(body.amount)
+      const tripUrl = `${APP_URL}/t/${body.trip_code}/quick`
+      subject = `Payment reminder for "${body.trip_name}"`
+      html = paymentReminderEmailHtml({
+        recipientName: body.recipient_name,
+        organiserName: body.organiser_name,
+        tripName: body.trip_name,
+        formattedAmount,
+        payToName: body.pay_to_name,
+        tripUrl,
+      })
+      toEmail = body.recipient_email
+      toName = body.recipient_name
+      emailType = 'payment_reminder'
+      tripId = body.trip_id
+    } else {
+      return new Response(
+        JSON.stringify({ error: "Unknown email type" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    logger.info('Sending email via Resend', { type: emailType, to: toEmail })
+    const resendStart = performance.now()
+
+    const resendResponse = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${resendApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: FROM_ADDRESS,
+        to: [toEmail],
+        subject,
+        html,
+      }),
+    })
+
+    const resendLatencyMs = Math.round(performance.now() - resendStart)
+    logger.info('Resend responded', { status: resendResponse.status, latencyMs: resendLatencyMs })
+    metrics.push([{ name: 'resend_api_latency_ms', value: resendLatencyMs, labels: { service_name: 'send-email' }, type: 'gauge' }])
+
+    const resendData = await resendResponse.json() as { id?: string; error?: { message: string } }
+    const emailStatus = resendResponse.ok ? 'sent' : 'failed'
+
+    // Write to email_log (fire-and-forget, don't block on failure)
+    supabase.from('email_log').insert([{
+      trip_id: tripId,
+      invitation_id: invitationId,
+      email_type: emailType,
+      recipient_email: toEmail,
+      recipient_name: toName,
+      status: emailStatus,
+      resend_message_id: resendData.id ?? null,
+      metadata: resendResponse.ok ? null : { resend_error: resendData.error?.message },
+    }]).then(({ error }) => {
+      if (error) logger.warn('Failed to write email_log', { error: String(error) })
+    })
+
+    if (!resendResponse.ok) {
+      logger.error('Resend API error', { status: resendResponse.status, error: resendData.error?.message })
+      metrics.push([{ name: 'email_send_total', value: 1, labels: { status: 'error', type: emailType }, type: 'counter' }])
+      return new Response(
+        JSON.stringify({ error: resendData.error?.message ?? 'Failed to send email' }),
+        { status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      )
+    }
+
+    const totalMs = Math.round(performance.now() - requestStart)
+    logger.info('Email sent', { type: emailType, messageId: resendData.id, totalMs })
+    metrics.push([
+      { name: 'email_send_total', value: 1, labels: { status: 'success', type: emailType }, type: 'counter' },
+      { name: 'function_latency_ms', value: totalMs, labels: { service_name: 'send-email', status: 'success' }, type: 'gauge' },
+    ])
+
+    return new Response(
+      JSON.stringify({ ok: true, message_id: resendData.id }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    )
+  } catch (err) {
+    const totalMs = Math.round(performance.now() - requestStart)
+    const errStr = String(err)
+    console.error("Edge function error:", err)
+    logger.error(`Unhandled exception: ${errStr}`, { error: errStr })
+    metrics.push([
+      { name: 'email_send_total', value: 1, labels: { status: 'error', type: 'unknown' }, type: 'counter' },
+      { name: 'function_latency_ms', value: totalMs, labels: { service_name: 'send-email', status: 'error' }, type: 'gauge' },
+    ])
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    )
+  }
+})

--- a/supabase/migrations/022_participant_email_and_invitations.sql
+++ b/supabase/migrations/022_participant_email_and_invitations.sql
@@ -1,0 +1,52 @@
+-- Migration 022: Participant email + invitations + email_log
+
+-- 1. Add email column to participants
+ALTER TABLE participants ADD COLUMN email TEXT;
+
+-- 2. Invitations table
+CREATE TABLE invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+  participant_id UUID NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+  inviter_id UUID REFERENCES auth.users(id),
+  token TEXT NOT NULL UNIQUE DEFAULT gen_random_uuid()::text,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted')),
+  sent_at TIMESTAMPTZ DEFAULT NOW(),
+  accepted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_invitations_token ON invitations(token);
+CREATE INDEX idx_invitations_participant ON invitations(participant_id);
+
+-- 3. Email audit log (written by edge function via service role)
+CREATE TABLE email_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id UUID REFERENCES trips(id) ON DELETE SET NULL,
+  invitation_id UUID REFERENCES invitations(id) ON DELETE SET NULL,
+  email_type TEXT NOT NULL, -- 'invitation' | 'payment_reminder'
+  recipient_email TEXT NOT NULL,
+  recipient_name TEXT,
+  status TEXT NOT NULL DEFAULT 'sent', -- 'sent' | 'failed'
+  resend_message_id TEXT,
+  sent_at TIMESTAMPTZ DEFAULT NOW(),
+  metadata JSONB
+);
+
+-- RLS on invitations
+ALTER TABLE invitations ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can look up an invitation by token (join page — no auth required)
+CREATE POLICY "Anyone can read invitations" ON invitations
+  FOR SELECT USING (true);
+
+CREATE POLICY "Authenticated users can create invitations" ON invitations
+  FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+CREATE POLICY "Authenticated users can update invitations" ON invitations
+  FOR UPDATE USING (auth.uid() IS NOT NULL);
+
+-- RLS on email_log: service role only (no browser access)
+ALTER TABLE email_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Service role only on email_log" ON email_log FOR ALL USING (false);


### PR DESCRIPTION
## Summary

- **Migration 022**: adds `participants.email` column, `invitations` table (token-based, anonymous-readable for join page), and `email_log` table (service-role only audit trail)
- **`send-email` Edge Function**: calls Resend API with two templates — invitation email (with join link) and payment reminder; writes to `email_log`; mirrors `create-github-issue` CORS/logger/metrics pattern
- **TypeScript types**: `email` field added to `Participant`, `CreateParticipantInput`, `UpdateParticipantInput`; `invitations` table + `participants.email` added to `database.types.ts`
- **`IndividualsSetup`**: optional Email input in Add form; Mail icon per participant for inline email edit with save/cancel; sends invitation on first email set
- **`FamiliesSetup`**: email field below each adult name in Add Family and Edit Family dialog; sends invitation when email is first saved for an adult

## Deployment required (before merging to production)
1. Create Resend account at resend.com, verify domain
2. `supabase secrets set RESEND_API_KEY=re_...`
3. `supabase functions deploy send-email`
4. `supabase db push` (applies migration 022)

## Test plan
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — 138 passing (1 pre-existing ShoppingContext failure)
- [ ] Add participant with email in IndividualsSetup → check Resend dashboard for sent email
- [ ] Check `invitations` table for new row with token
- [ ] Edit participant email (Mail icon) → verify invitation sent on first set
- [ ] Add family with adult email → invitation sent after save
- [ ] Edit family, add email to existing adult → invitation sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)