### PR TITLE
Fix timeout coverage gaps and blocking patterns

### DIFF
--- a/src/contexts/ActivityContext.tsx
+++ b/src/contexts/ActivityContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
-import { useTripContext } from './TripContext'
 import type { Activity, CreateActivityInput, UpdateActivityInput } from '@/types/activity'
 
 interface ActivityContextValue {
@@ -30,7 +29,6 @@ export function ActivityProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true)
   const [initialLoadDone, setInitialLoadDone] = useState(false)
   const { currentTrip, tripCode } = useCurrentTrip()
-  const { trips } = useTripContext()
 
   const fetchActivities = async () => {
     if (!currentTrip) {
@@ -71,7 +69,7 @@ export function ActivityProvider({ children }: { children: ReactNode }) {
       setInitialLoadDone(false)
       fetchActivities()
     }
-  }, [tripCode, currentTrip?.id, trips.length])
+  }, [tripCode, currentTrip?.id])
 
   const createActivity = async (input: CreateActivityInput): Promise<Activity | null> => {
     try {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -85,6 +85,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       setLoading(false)
+    }).catch((err) => {
+      logger.error('Auth init failed', { error: err instanceof Error ? err.message : String(err) })
+      setLoading(false)
     })
 
     // Listen for auth changes — skip the INITIAL_SESSION event that fires
@@ -142,7 +145,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           bank_iban: iban || null,
         })
         .eq('id', user.id),
-      15000,
+      35000,
       'Saving bank details timed out. Please check your connection and try again.'
     )
 

--- a/src/contexts/MealContext.tsx
+++ b/src/contexts/MealContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
-import { useTripContext } from './TripContext'
 import type { Meal, CreateMealInput, UpdateMealInput, MealWithIngredients } from '@/types/meal'
 import { logger } from '@/lib/logger'
 
@@ -25,7 +24,6 @@ export function MealProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true)
   const [initialLoadDone, setInitialLoadDone] = useState(false)
   const { currentTrip, tripCode } = useCurrentTrip()
-  const { trips } = useTripContext()
 
   const fetchMeals = async () => {
     if (!currentTrip) {
@@ -67,7 +65,7 @@ export function MealProvider({ children }: { children: ReactNode }) {
       setInitialLoadDone(false)
       fetchMeals()
     }
-  }, [tripCode, currentTrip?.id, trips.length])
+  }, [tripCode, currentTrip?.id])
 
   const createMeal = async (input: CreateMealInput): Promise<Meal | null> => {
     try {

--- a/src/contexts/ReceiptContext.tsx
+++ b/src/contexts/ReceiptContext.tsx
@@ -132,8 +132,8 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
         return false
       }
 
-      // Refresh pending receipts in case status changed
-      await fetchPendingReceipts()
+      // Refresh pending receipts in case status changed — fire-and-forget
+      fetchPendingReceipts()
       return true
     } catch (err) {
       logger.error('Unhandled error updating receipt task', { error: String(err) })
@@ -162,8 +162,8 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
       }
 
       setPendingReceipts(prev => prev.filter(r => r.id !== id))
-      // Refresh to pick up the now-complete task in completedReceipts
-      await fetchPendingReceipts()
+      // Refresh to pick up the now-complete task in completedReceipts — fire-and-forget
+      fetchPendingReceipts()
       return true
     } catch (err) {
       logger.error('Unhandled error completing receipt task', { error: String(err) })


### PR DESCRIPTION
## Summary

- **TripContext**: All DB operations now wrapped in `withTimeout` (15s for fetch, 35s for mutations). `createTrip` participant auto-link made fire-and-forget so the function returns immediately after the trip insert instead of blocking on a second sequential DB call.
- **ShoppingContext**: All DB operations wrapped in `withTimeout` (15s fetch, 35s mutations, 10s best-effort junction ops). Removed `trips.length` from the `useEffect` dep array — this was causing the real-time subscription to tear down and re-subscribe whenever any trip was added or deleted anywhere in the app, creating race conditions with in-progress mutations.
- **AuthContext**: Added `.catch()` to the `getSession().then()` chain — if `getSession` rejects (browser quirks, localStorage corruption), `setLoading(false)` was never called, freezing the entire app on the loading screen permanently. Raised `updateBankDetails` timeout from 15s → 35s (was missed in PR #197).
- **ReceiptContext**: `fetchPendingReceipts()` inside `updateReceiptTask` and `completeReceiptTask` changed from `await` to fire-and-forget. The optimistic `setPendingReceipts` filter already handles the common case; the re-fetch was adding an unnecessary sequential round trip that extended the mutation's blocking window.
- **MealContext / ActivityContext**: Removed `trips.length` from dep arrays (same spurious re-fetch pattern as ShoppingContext). Dropped now-unused `useTripContext` import.

## Test plan

- [x] `npm run type-check` passes clean
- [x] `npm test` — 138/139 pass (1 pre-existing `AuthContext` test failure unrelated to these changes)
- [ ] Manual: create trip → expense → settlement on throttled mobile connection (DevTools → Slow 4G) — none should hang
- [ ] Grafana: mutation error/timeout rates drop after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)