### PR TITLE
Fix send-email from address: noreply@xtian.me

### DIFF
--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -12,7 +12,7 @@ const logger = createLogger('send-email')
 const metrics = createMetrics('send-email')
 
 const APP_URL = 'https://split.xtian.me'
-const FROM_ADDRESS = 'Spl1t <noreply@spl1t.me>'
+const FROM_ADDRESS = 'Spl1t <noreply@xtian.me>'
 
 type SendEmailBody =
   | {


### PR DESCRIPTION
spl1t.me was not verified in Resend → 403. xtian.me is the verified sending domain. Redeployed.