### PR TITLE
Show all user's groups on any device (server-side trip membership)

### DIFF
--- a/src/hooks/useMyTripBalances.ts
+++ b/src/hooks/useMyTripBalances.ts
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
-import { getMyTrips } from '@/lib/myTripsStorage'
 import { calculateBalances, ParticipantBalance } from '@/services/balanceCalculator'
 import { Trip } from '@/types/trip'
 import { Participant, Family } from '@/types/participant'
@@ -36,15 +35,9 @@ export function useMyTripBalances() {
     const fetchBalances = async () => {
       setLoading(true)
 
-      // Get user's "My Trips" from localStorage
-      const myTrips = getMyTrips()
-      const myTripCodes = new Set(myTrips.map(t => t.tripCode))
-
-      // Filter to trips that exist in both DB and My Trips
-      const relevantTrips = trips.filter(t => myTripCodes.has(t.trip_code))
-
+      // TripContext already returns only user's trips when authenticated; use directly.
       const balances: TripBalance[] = await Promise.all(
-        relevantTrips.map(async (trip) => {
+        trips.map(async (trip) => {
           try {
             // Parallel fetch all data for this trip
             const [participantsRes, familiesRes, expensesRes, settlementsRes] = await Promise.all([

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -30,9 +30,12 @@ export function ConditionalHomePage() {
     if (isLoading) return
     if (!shouldGoQuick) return
 
-    // For quick mode, auto-detect active trip from user's linked trips
-    const myTripCodes = new Set(getMyTrips().map(t => t.tripCode))
-    const myTrips = trips.filter(t => myTripCodes.has(t.trip_code))
+    // For quick mode, auto-detect active trip from user's linked trips.
+    // When signed in, TripContext already returns only user's trips; use directly.
+    // When not signed in, fall back to localStorage for anonymous use.
+    const myTrips = user
+      ? trips
+      : trips.filter(t => new Set(getMyTrips().map(e => e.tripCode)).has(t.trip_code))
     const activeTripId = getActiveTripId(myTrips)
 
     if (activeTripId) {


### PR DESCRIPTION
## Summary

- **TripContext.fetchTrips()**: When authenticated, queries `participants.user_id` + `trips.created_by` to scope the trips list to only the user's groups. Anonymous users still get all trips so `/t/:tripCode` URL access keeps working.
- **useMyTripBalances**: Removed `getMyTrips()` localStorage filter — TripContext already returns user-scoped trips, so the filter was redundant and blocked cross-device discovery.
- **ConditionalHomePage**: Active-trip detection now uses TripContext trips directly when signed in; falls back to localStorage Set only for anonymous users.
- **HomePage**: Authenticated users see server trips (from TripContext); anonymous users see localStorage trips. Card layout preserved for both paths.

## Test plan

- [ ] `npm run type-check` — passes clean
- [ ] `npm test` — 138/139 (pre-existing AuthContext logger failure unrelated)
- [ ] **New machine**: sign in on a browser with empty localStorage → all server-side groups appear
- [ ] **Anonymous**: open `/t/:tripCode` without signing in → still works; home shows localStorage trips
- [ ] **Create trip**: create while signed in → appears immediately (optimistic update via `created_by` match)
- [ ] **Join via link**: JoinPage flow unaffected (uses direct Supabase calls, bypasses TripContext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)