### PR TITLE
Enforce unique email per trip; restrict family email to primary adult

### DIFF
--- a/supabase/migrations/023_participant_email_unique.sql
+++ b/supabase/migrations/023_participant_email_unique.sql
@@ -1,0 +1,6 @@
+-- Prevent two participants in the same trip from sharing an email.
+-- NULLs are excluded automatically (PostgreSQL treats NULLs as distinct in unique indexes).
+-- lower() ensures case-insensitive uniqueness (john@x.com = John@X.com).
+CREATE UNIQUE INDEX participants_trip_email_unique
+  ON participants (trip_id, lower(email))
+  WHERE email IS NOT NULL;


### PR DESCRIPTION
## Summary
- **Migration 023**: partial unique index on `(trip_id, lower(email))` — two participants in the same trip can't share an email; NULLs excluded so participants without email are unaffected; `lower()` makes the check case-insensitive
- **IndividualsSetup**: client-side duplicate-email guard on both add and inline-save; shows inline error instead of hitting the DB
- **FamiliesSetup**: email input now shown only for the first adult (add form + edit dialog); duplicate-email check before create and save; non-primary adults are always saved with `email: null`

## Test plan
- [ ] `npm run type-check` passes clean
- [ ] `supabase db push` applies migration 023
- [ ] IndividualsSetup: add participant A with email `x@x.com`, then add participant B with `X@X.com` → inline error, no DB call
- [ ] IndividualsSetup: inline-email edit on participant B → type `x@x.com` → inline error
- [ ] FamiliesSetup Add Family: only Adult 1 row shows email field; Adult 2+ show name only
- [ ] FamiliesSetup Edit Family: same — only Adult 1 shows email field
- [ ] FamiliesSetup: add family whose primary adult email matches an existing participant → inline error

🤖 Generated with [Claude Code](https://claude.com/claude-code)