### PR TITLE
feat: quick-mode event creation and participant setup via sheets

### DIFF
--- a/src/components/quick/QuickCreateSheet.tsx
+++ b/src/components/quick/QuickCreateSheet.tsx
@@ -1,0 +1,37 @@
+import { useNavigate } from 'react-router-dom'
+import { useTripContext } from '@/contexts/TripContext'
+import { EventForm } from '@/components/EventForm'
+import { CreateEventInput } from '@/types/trip'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+
+interface QuickCreateSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) {
+  const navigate = useNavigate()
+  const { createTrip } = useTripContext()
+
+  const handleCreate = async (input: CreateEventInput) => {
+    const newEvent = await createTrip(input)
+    if (newEvent) {
+      onOpenChange(false)
+      navigate(`/t/${newEvent.trip_code}/quick`)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[92vh] rounded-t-2xl overflow-y-auto">
+        <SheetHeader className="mb-4">
+          <SheetTitle>Create New</SheetTitle>
+        </SheetHeader>
+        <EventForm
+          onSubmit={handleCreate}
+          onCancel={() => onOpenChange(false)}
+        />
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/quick/QuickParticipantSetupSheet.tsx
+++ b/src/components/quick/QuickParticipantSetupSheet.tsx
@@ -1,0 +1,35 @@
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { IndividualsSetup } from '@/components/setup/IndividualsSetup'
+import { FamiliesSetup } from '@/components/setup/FamiliesSetup'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+
+interface QuickParticipantSetupSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function QuickParticipantSetupSheet({ open, onOpenChange }: QuickParticipantSetupSheetProps) {
+  const { currentTrip } = useCurrentTrip()
+
+  if (!currentTrip) return null
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[92vh] rounded-t-2xl overflow-y-auto">
+        <SheetHeader className="mb-4">
+          <SheetTitle>Set up your group</SheetTitle>
+          <SheetDescription>Add the people sharing costs on this trip</SheetDescription>
+        </SheetHeader>
+        {currentTrip.tracking_mode === 'individuals' ? (
+          <IndividualsSetup />
+        ) : (
+          <FamiliesSetup />
+        )}
+        <Button className="w-full mt-4" onClick={() => onOpenChange(false)}>
+          Done
+        </Button>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -14,6 +14,7 @@ import { QuickExpenseSheet } from '@/components/quick/QuickExpenseSheet'
 import { QuickSettlementSheet } from '@/components/quick/QuickSettlementSheet'
 import { ReceiptCaptureSheet } from '@/components/receipts/ReceiptCaptureSheet'
 import { ReceiptReviewSheet } from '@/components/receipts/ReceiptReviewSheet'
+import { QuickParticipantSetupSheet } from '@/components/quick/QuickParticipantSetupSheet'
 import { ExtractedItem } from '@/types/receipt'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -47,6 +48,7 @@ export function QuickGroupDetailPage() {
   const [expenseOpen, setExpenseOpen] = useState(false)
   const [settlementOpen, setSettlementOpen] = useState(false)
   const [receiptCaptureOpen, setReceiptCaptureOpen] = useState(false)
+  const [participantSetupOpen, setParticipantSetupOpen] = useState(false)
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [slowLoading, setSlowLoading] = useState(false)
   const [retrying, setRetrying] = useState(false)
@@ -218,6 +220,19 @@ export function QuickGroupDetailPage() {
         </div>
       )}
 
+      {/* Participant setup nudge */}
+      {!loading && !contextError && participants.length <= 1 && (
+        <Card className="mb-4 border-amber-200 bg-amber-50 dark:bg-amber-950/20">
+          <CardContent className="pt-4 pb-4 flex items-center justify-between">
+            <div>
+              <p className="font-medium text-sm">Set up your group</p>
+              <p className="text-xs text-muted-foreground">Add the people sharing costs</p>
+            </div>
+            <Button size="sm" onClick={() => setParticipantSetupOpen(true)}>Add</Button>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Action buttons */}
       <div className="space-y-3 mb-6">
         <QuickActionButton
@@ -302,6 +317,12 @@ export function QuickGroupDetailPage() {
           onDone={() => setReceiptReviewData(null)}
         />
       )}
+
+      {/* Participant setup sheet */}
+      <QuickParticipantSetupSheet
+        open={participantSetupOpen}
+        onOpenChange={setParticipantSetupOpen}
+      />
     </div>
   )
 }

--- a/src/pages/QuickHomeScreen.tsx
+++ b/src/pages/QuickHomeScreen.tsx
@@ -7,6 +7,7 @@ import { formatBalance, getBalanceColorClass } from '@/services/balanceCalculato
 import { getHiddenTripCodes, showTrip } from '@/lib/mutedTripsStorage'
 import { getActiveTripId } from '@/lib/activeTripDetection'
 import { GroupActions } from '@/components/quick/GroupActions'
+import { QuickCreateSheet } from '@/components/quick/QuickCreateSheet'
 import { Card, CardContent } from '@/components/ui/card'
 import { Loader2, ChevronRight, Plus, Eye, ChevronDown, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -20,6 +21,7 @@ export function QuickHomeScreen() {
   const loading = balancesLoading || (!!user && tripsLoading)
   const [hiddenCodes, setHiddenCodes] = useState(() => new Set(getHiddenTripCodes()))
   const [showHidden, setShowHidden] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
 
   const firstName = userProfile?.display_name?.split(' ')[0] || 'there'
 
@@ -85,7 +87,7 @@ export function QuickHomeScreen() {
                 <p className="text-muted-foreground mb-4">
                   No groups yet. Create a trip or event, or join one via a shared link.
                 </p>
-                <Button onClick={() => navigate('/create-trip')} className="gap-2">
+                <Button onClick={() => setCreateOpen(true)} className="gap-2">
                   <Plus size={18} />
                   Create New
                 </Button>
@@ -155,7 +157,7 @@ export function QuickHomeScreen() {
         {/* Create trip button */}
         {visibleTrips.length > 0 && (
           <div className="mt-6 text-center">
-            <Button variant="outline" onClick={() => navigate('/create-trip')} className="gap-2">
+            <Button variant="outline" onClick={() => setCreateOpen(true)} className="gap-2">
               <Plus size={16} />
               Create New
             </Button>
@@ -215,6 +217,8 @@ export function QuickHomeScreen() {
           </div>
         )}
       </div>
+
+      <QuickCreateSheet open={createOpen} onOpenChange={setCreateOpen} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **QuickCreateSheet**: \"Create New\" in Quick mode now opens a bottom sheet (wrapping `EventForm`) instead of navigating away to `/create-trip`. After creation, navigates to `/t/{code}/quick` — user stays in Quick mode throughout.
- **QuickParticipantSetupSheet**: New bottom sheet wrapping `IndividualsSetup` or `FamiliesSetup` (chosen by `tracking_mode`), with a "Done" button to close.
- **QuickHomeScreen**: Both "Create New" buttons (empty state card + bottom FAB-style button) now open `QuickCreateSheet` instead of navigating.
- **QuickGroupDetailPage**: Amber nudge card appears when `participants.length <= 1` (just the auto-linked creator or empty), with an "Add" button that opens `QuickParticipantSetupSheet`. Card disappears once the group has more than 1 participant.

Full-mode flow via `TripsPage` is unchanged.

## Test plan

- [ ] Quick mode → "Create New" → sheet opens (no page navigation)
- [ ] Fill form and submit → navigates to `/t/{code}/quick`
- [ ] "Set up your group" amber card visible on fresh trip detail page
- [ ] Tap "Add" → sheet opens with IndividualsSetup (individuals mode) or FamiliesSetup (families mode)
- [ ] Add a participant → appears in list; close sheet
- [ ] When group has 2+ participants, nudge card disappears
- [ ] `npm run type-check` passes clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)