### PR TITLE
feat: show linked account indicator on manage page (#216)

### DIFF
--- a/src/components/setup/FamiliesSetup.tsx
+++ b/src/components/setup/FamiliesSetup.tsx
@@ -1,6 +1,6 @@
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import { X, Plus, Users, User, Edit, Mail } from 'lucide-react'
+import { X, Plus, Users, User, Edit, Mail, UserCheck } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useAuth } from '@/contexts/AuthContext'
@@ -615,11 +615,16 @@ export function FamiliesSetup({ onComplete: _onComplete, hasSetup: _hasSetup = f
                       <div className="text-muted-foreground">
                         <strong className="text-foreground">Adults:</strong>{' '}
                         {adults.map(a => (
-                          <span key={a.id}>
+                          <span key={a.id} className="inline-flex items-center gap-1">
                             {a.name}
                             {a.email && (
-                              <span className="text-xs ml-1 opacity-60" title={a.email}>
+                              <span className="text-xs opacity-60" title={a.email}>
                                 <Mail size={10} className="inline" />
+                              </span>
+                            )}
+                            {a.user_id && (
+                              <span title="Account linked" className="shrink-0">
+                                <UserCheck size={10} className="text-positive" />
                               </span>
                             )}
                           </span>
@@ -655,7 +660,7 @@ export function FamiliesSetup({ onComplete: _onComplete, hasSetup: _hasSetup = f
                   className="p-4 bg-accent/5 rounded-lg border border-accent/10"
                 >
                   <div className="flex items-start justify-between">
-                    <div>
+                    <div className="flex items-center gap-2">
                       <h4 className="font-semibold text-foreground">
                         {individual.name}
                         {!individual.is_adult && (
@@ -664,6 +669,11 @@ export function FamiliesSetup({ onComplete: _onComplete, hasSetup: _hasSetup = f
                           </span>
                         )}
                       </h4>
+                      {individual.user_id && (
+                        <span title="Account linked" className="shrink-0">
+                          <UserCheck size={12} className="text-positive" />
+                        </span>
+                      )}
                     </div>
                     <div className="flex gap-1">
                       <Button

--- a/src/components/setup/IndividualsSetup.tsx
+++ b/src/components/setup/IndividualsSetup.tsx
@@ -1,6 +1,6 @@
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import { X, UserPlus, Mail, Pencil, Check } from 'lucide-react'
+import { X, UserPlus, Mail, Pencil, Check, UserCheck } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useAuth } from '@/contexts/AuthContext'
@@ -269,6 +269,11 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
                       <Badge variant={participant.is_adult ? 'soft' : 'outline'}>
                         {participant.is_adult ? 'Adult' : 'Child'}
                       </Badge>
+                      {participant.user_id && (
+                        <span title="Account linked" className="shrink-0">
+                          <UserCheck size={12} className="text-positive" />
+                        </span>
+                      )}
                     </div>
                     <div className="flex items-center gap-1 flex-shrink-0">
                       <Button


### PR DESCRIPTION
## Summary
- Add `UserCheck` icon from lucide-react next to participants who have `user_id` set
- Shown in `IndividualsSetup` (after Adult/Child badge) and `FamiliesSetup` (adults in family list + standalone individuals)
- Green `text-positive` color, `size=12` — subtle but clear
- Tooltip "Account linked" via wrapper `<span title="...">` (lucide doesn't accept `title` prop directly)

## Test plan
- [ ] Open manage page for a trip where some participants have linked their Google account → `UserCheck` icon visible next to their names only
- [ ] Participants without `user_id` show no icon
- [ ] Works in both individuals and families tracking modes

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)