### PR TITLE
feat: highlight debtor's items in receipt reminder email (#217)

### DIFF
--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -173,12 +173,18 @@ export function SettlementsPage() {
         ? participants.filter(p => p.family_id === transaction.toId).map(p => p.id)
         : [transaction.toId]
     )
+    const debtorParticipantIds =
+      currentTrip.tracking_mode === 'families'
+        ? participants.filter(p => p.family_id === transaction.fromId).map(p => p.id)
+        : [transaction.fromId]
     const receipts: Array<{
       merchant: string | null
       items: Array<{ name: string; price: number; qty: number }> | null
       confirmed_total: number | null
       tip_amount: number
       currency: string | null
+      mapped_items: Array<{ item_index: number; participant_ids: string[] }> | null
+      debtor_participant_ids: string[]
     }> = []
     for (const expense of expenses) {
       if (receipts.length >= 3) break
@@ -191,6 +197,8 @@ export function SettlementsPage() {
           confirmed_total: receipt.confirmed_total,
           tip_amount: receipt.tip_amount,
           currency: receipt.extracted_currency ?? currentTrip.default_currency,
+          mapped_items: receipt.mapped_items,
+          debtor_participant_ids: debtorParticipantIds,
         })
       }
     }


### PR DESCRIPTION
## Summary
- `SettlementsPage.handleRemind()` now computes `debtorParticipantIds` (mirroring existing `creditorParticipantIds`) and passes `mapped_items` + `debtor_participant_ids` with each receipt
- `send-email` edge function: `ReceiptEmailData` type updated with optional `mapped_items` and `debtor_participant_ids` fields
- `receiptTableHtml()` checks each item row against `isDebtorItem()` — rows the debtor ordered get `background:#faf5ff;border-left:3px solid #8b5cf6` highlight
- Backward compat: receipts without `mapped_items` (older scans, or items not tapped) render exactly as before

## Test plan
- [ ] Send a payment reminder on a trip with a completed receipt scan that has mapped items → email shows highlighted rows for the debtor's items; tip/total rows render normally
- [ ] Receipts with no `mapped_items` render as before (no highlights)
- [ ] Families mode: debtor family members' items are highlighted correctly
- [ ] After merging: deploy edge function (`supabase functions deploy send-email`)

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)