### PR TITLE
fix: prevent iOS keyboard from clipping quick-mode sheet tops (#220)

### DIFF
--- a/src/components/quick/QuickCreateSheet.tsx
+++ b/src/components/quick/QuickCreateSheet.tsx
@@ -3,6 +3,7 @@ import { useTripContext } from '@/contexts/TripContext'
 import { EventForm } from '@/components/EventForm'
 import { CreateEventInput } from '@/types/trip'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 
 interface QuickCreateSheetProps {
   open: boolean
@@ -12,6 +13,7 @@ interface QuickCreateSheetProps {
 export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) {
   const navigate = useNavigate()
   const { createTrip } = useTripContext()
+  const keyboard = useKeyboardHeight()
 
   const handleCreate = async (input: CreateEventInput) => {
     const newEvent = await createTrip(input)
@@ -23,7 +25,14 @@ export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) 
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="h-[92vh] rounded-t-2xl overflow-y-auto">
+      <SheetContent
+        side="bottom"
+        className="rounded-t-2xl overflow-y-auto"
+        style={{
+          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92vh',
+          bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
+        }}
+      >
         <SheetHeader className="mb-4">
           <SheetTitle>Create New</SheetTitle>
         </SheetHeader>

--- a/src/components/quick/QuickParticipantSetupSheet.tsx
+++ b/src/components/quick/QuickParticipantSetupSheet.tsx
@@ -3,6 +3,7 @@ import { IndividualsSetup } from '@/components/setup/IndividualsSetup'
 import { FamiliesSetup } from '@/components/setup/FamiliesSetup'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 
 interface QuickParticipantSetupSheetProps {
   open: boolean
@@ -11,12 +12,20 @@ interface QuickParticipantSetupSheetProps {
 
 export function QuickParticipantSetupSheet({ open, onOpenChange }: QuickParticipantSetupSheetProps) {
   const { currentTrip } = useCurrentTrip()
+  const keyboard = useKeyboardHeight()
 
   if (!currentTrip) return null
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="h-[92vh] rounded-t-2xl overflow-y-auto">
+      <SheetContent
+        side="bottom"
+        className="rounded-t-2xl overflow-y-auto"
+        style={{
+          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92vh',
+          bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
+        }}
+      >
         <SheetHeader className="mb-4">
           <SheetTitle>Set up your group</SheetTitle>
           <SheetDescription>Add the people sharing costs on this trip</SheetDescription>


### PR DESCRIPTION
## Root cause

`QuickCreateSheet` and `QuickParticipantSetupSheet` both use a static `h-[92vh]` Tailwind class with no keyboard-aware compensation.

On iOS Safari, the **layout viewport** (`window.innerHeight`) does not shrink when the software keyboard opens — only `visualViewport.height` does. The sheet stays `position:fixed; bottom:0`, so when a text input is focused (event name, participant name), iOS pushes the sheet up to keep the input visible. Since the sheet height is still `92vh` of the full layout viewport, the top of the sheet goes off-screen — the header and close button disappear.

## Fix

Apply the same `useKeyboardHeight` pattern already used in `ExpenseWizard` and `ReceiptReviewSheet`:
- Replace static `h-[92vh]` className with an inline `style`
- When keyboard is visible: `height = visualViewport.height`, `bottom = keyboardHeight`
- When keyboard is hidden: `height = 92vh`, `bottom = undefined` (Tailwind `bottom-0` takes over)

## Test plan
- [ ] On iPhone: open "Create New" sheet → tap the event name input → keyboard opens → sheet header stays visible
- [ ] On iPhone: open "Set up group" sheet → tap a participant name input → sheet header stays visible
- [ ] On desktop: sheets open and close normally at 92vh

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)