### PR TITLE
fix: keep sheet header and X always visible on iOS in quick-mode sheets

### DIFF
--- a/src/components/quick/QuickCreateSheet.tsx
+++ b/src/components/quick/QuickCreateSheet.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTripContext } from '@/contexts/TripContext'
 import { EventForm } from '@/components/EventForm'
 import { CreateEventInput } from '@/types/trip'
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 
 interface QuickCreateSheetProps {
@@ -27,19 +27,24 @@ export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) 
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
-        className="rounded-t-2xl overflow-y-auto"
+        className="flex flex-col p-0 rounded-t-2xl"
         style={{
-          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92vh',
+          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
           bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
         }}
       >
-        <SheetHeader className="mb-4">
+        {/* Sticky header — never scrolls */}
+        <div className="px-6 py-4 border-b border-border shrink-0">
           <SheetTitle>Create New</SheetTitle>
-        </SheetHeader>
-        <EventForm
-          onSubmit={handleCreate}
-          onCancel={() => onOpenChange(false)}
-        />
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          <EventForm
+            onSubmit={handleCreate}
+            onCancel={() => onOpenChange(false)}
+          />
+        </div>
       </SheetContent>
     </Sheet>
   )

--- a/src/components/quick/QuickParticipantSetupSheet.tsx
+++ b/src/components/quick/QuickParticipantSetupSheet.tsx
@@ -1,7 +1,7 @@
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { IndividualsSetup } from '@/components/setup/IndividualsSetup'
 import { FamiliesSetup } from '@/components/setup/FamiliesSetup'
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 
@@ -20,24 +20,29 @@ export function QuickParticipantSetupSheet({ open, onOpenChange }: QuickParticip
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
-        className="rounded-t-2xl overflow-y-auto"
+        className="flex flex-col p-0 rounded-t-2xl"
         style={{
-          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92vh',
+          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
           bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
         }}
       >
-        <SheetHeader className="mb-4">
+        {/* Sticky header — never scrolls */}
+        <div className="px-6 py-4 border-b border-border shrink-0">
           <SheetTitle>Set up your group</SheetTitle>
-          <SheetDescription>Add the people sharing costs on this trip</SheetDescription>
-        </SheetHeader>
-        {currentTrip.tracking_mode === 'individuals' ? (
-          <IndividualsSetup />
-        ) : (
-          <FamiliesSetup />
-        )}
-        <Button className="w-full mt-4" onClick={() => onOpenChange(false)}>
-          Done
-        </Button>
+          <SheetDescription className="mt-0.5">Add the people sharing costs on this trip</SheetDescription>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+          {currentTrip.tracking_mode === 'individuals' ? (
+            <IndividualsSetup />
+          ) : (
+            <FamiliesSetup />
+          )}
+          <Button className="w-full" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </div>
       </SheetContent>
     </Sheet>
   )


### PR DESCRIPTION
## Root causes

**1. `vh` vs `dvh`**
`92vh` is calculated from the **layout viewport** (full screen including iOS browser chrome — status bar, address bar, bottom toolbar). On iPhone, the browser chrome can consume ~15% of screen height, so the top `~36px` of the sheet extends behind the address bar and is invisible. The X close button and title sit in that hidden zone.

`92dvh` (dynamic viewport height) is calculated from the **visual viewport** — the area actually visible to the user. It automatically accounts for browser chrome, so the sheet fits perfectly within the visible area from the moment it opens.

**2. `overflow-y-auto` on the whole `SheetContent`**
With the entire SheetContent scrollable, iOS can auto-scroll the header out of view when an input is focused (the browser scrolls the container to reveal the focused element). The title and X button disappear as the user scrolls or focuses inputs.

## Fix
Both `QuickCreateSheet` and `QuickParticipantSetupSheet`:
- `'92vh'` → `'92dvh'` in the keyboard-closed height fallback
- Restructured to `flex flex-col p-0`: sticky `shrink-0` header div (always pinned), `flex-1 overflow-y-auto` scrollable content area below — same pattern as `ReceiptReviewSheet`

## Test plan
- [ ] On iPhone (no keyboard): open "Create New" sheet → header and X button visible immediately on open
- [ ] On iPhone (no keyboard): open "Add group" sheet → header and X button visible immediately
- [ ] Tap an input → keyboard opens → sheet repositions → header stays visible throughout
- [ ] Scroll the content → header and X remain fixed at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)