### PR TITLE
feat: add group members sheet in quick mode

### DIFF
--- a/src/components/quick/QuickGroupMembersSheet.tsx
+++ b/src/components/quick/QuickGroupMembersSheet.tsx
@@ -1,0 +1,90 @@
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { UserCheck } from 'lucide-react'
+import { ParticipantBalance, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { Participant } from '@/types/participant'
+
+interface QuickGroupMembersSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  balances: ParticipantBalance[]
+  myParticipantId: string | null
+  currency: string
+  participants: Participant[]
+}
+
+export function QuickGroupMembersSheet({
+  open,
+  onOpenChange,
+  balances,
+  myParticipantId,
+  currency,
+  participants,
+}: QuickGroupMembersSheetProps) {
+  function isLinked(balanceId: string): boolean {
+    return !!participants.find(p => p.id === balanceId || p.family_id === balanceId)?.user_id
+  }
+
+  function statusText(balance: number): string {
+    if (Math.abs(balance) < 0.005) return 'Settled up'
+    const amount = formatBalance(Math.abs(balance), currency)
+    return balance > 0 ? `Owed ${amount}` : `Owes ${amount}`
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="flex flex-col p-0 rounded-t-2xl"
+        style={{ height: '75dvh' }}
+      >
+        {/* Sticky header */}
+        <div className="px-6 py-4 border-b border-border shrink-0">
+          <SheetTitle>Group ({balances.length} {balances.length === 1 ? 'member' : 'members'})</SheetTitle>
+        </div>
+
+        {/* Scrollable list */}
+        <div className="flex-1 overflow-y-auto">
+          {balances.map((b, i) => {
+            const isMe = b.id === myParticipantId
+            const linked = isLinked(b.id)
+            const settled = Math.abs(b.balance) < 0.005
+
+            return (
+              <div key={b.id}>
+                <div className="flex items-center justify-between px-6 py-3.5 gap-3">
+                  {/* Left: name + badges */}
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-medium truncate">{b.name}</span>
+                    {linked && (
+                      <span title="Account linked">
+                        <UserCheck size={12} className="text-green-600 dark:text-green-400 shrink-0" />
+                      </span>
+                    )}
+                    {isMe && (
+                      <span className="text-xs bg-accent/20 text-accent-foreground px-1.5 py-0.5 rounded shrink-0">
+                        You
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Right: amount + status */}
+                  <div className="text-right shrink-0">
+                    <p className={`font-medium tabular-nums text-sm ${settled ? 'text-muted-foreground' : getBalanceColorClass(b.balance)}`}>
+                      {settled ? '—' : formatBalance(b.balance, currency)}
+                    </p>
+                    <p className={`text-xs mt-0.5 ${settled ? 'text-muted-foreground' : getBalanceColorClass(b.balance)}`}>
+                      {statusText(b.balance)}
+                    </p>
+                  </div>
+                </div>
+                {i < balances.length - 1 && (
+                  <div className="border-b border-border mx-6" />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -15,13 +15,14 @@ import { QuickSettlementSheet } from '@/components/quick/QuickSettlementSheet'
 import { ReceiptCaptureSheet } from '@/components/receipts/ReceiptCaptureSheet'
 import { ReceiptReviewSheet } from '@/components/receipts/ReceiptReviewSheet'
 import { QuickParticipantSetupSheet } from '@/components/quick/QuickParticipantSetupSheet'
+import { QuickGroupMembersSheet } from '@/components/quick/QuickGroupMembersSheet'
 import { ExtractedItem } from '@/types/receipt'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useToast } from '@/hooks/use-toast'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
-  ExternalLink, ArrowLeftRight, Loader2, RefreshCw, AlertCircle
+  ExternalLink, ArrowLeftRight, Loader2, RefreshCw, AlertCircle, Users
 } from 'lucide-react'
 
 
@@ -49,6 +50,7 @@ export function QuickGroupDetailPage() {
   const [settlementOpen, setSettlementOpen] = useState(false)
   const [receiptCaptureOpen, setReceiptCaptureOpen] = useState(false)
   const [participantSetupOpen, setParticipantSetupOpen] = useState(false)
+  const [membersOpen, setMembersOpen] = useState(false)
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [slowLoading, setSlowLoading] = useState(false)
   const [retrying, setRetrying] = useState(false)
@@ -164,7 +166,18 @@ export function QuickGroupDetailPage() {
           </CardContent>
         </Card>
       ) : (
-        <QuickBalanceHero balance={myBalance} />
+        <div className="relative">
+          <QuickBalanceHero balance={myBalance} />
+          {participants.length > 0 && (
+            <button
+              onClick={() => setMembersOpen(true)}
+              className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-background/80 backdrop-blur-sm border border-border text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Users size={13} />
+              <span>{participants.length}</span>
+            </button>
+          )}
+        </div>
       )}
 
       {/* Pending receipts banner */}
@@ -322,6 +335,16 @@ export function QuickGroupDetailPage() {
       <QuickParticipantSetupSheet
         open={participantSetupOpen}
         onOpenChange={setParticipantSetupOpen}
+      />
+
+      {/* Group members sheet */}
+      <QuickGroupMembersSheet
+        open={membersOpen}
+        onOpenChange={setMembersOpen}
+        balances={balanceCalc.balances}
+        myParticipantId={myBalance?.id ?? null}
+        currency={currentTrip.default_currency}
+        participants={participants}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- Adds a `Users` icon chip in the top-right corner of the balance hero on `QuickGroupDetailPage` showing the participant count
- Tapping the chip opens a new `QuickGroupMembersSheet` bottom sheet listing all group members with their balances
- Each row shows: name, "You" badge for the current user, `UserCheck` icon for linked accounts, colour-coded balance amount, and status text ("Owed X" / "Owes X" / "Settled up")
- Follows the established `flex flex-col + dvh + sticky header + scrollable body` sheet pattern
- Chip only renders when `participants.length > 0`

## Test plan
- [ ] Open quick mode for a trip with ≥2 participants → chip visible in top-right of balance hero with correct count
- [ ] Tap chip → sheet opens listing all members, balances colour-coded green/red/muted
- [ ] Own row shows "You" badge
- [ ] Participant with linked account shows `UserCheck` icon
- [ ] Zero-balance participant shows "—" and "Settled up" in muted colour
- [ ] Families mode: family names shown correctly
- [ ] `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)