### PR TITLE
feat: scan-first onboarding & friction-free participant adding

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -1,0 +1,305 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { Plus, UserPlus, X, Users, Smartphone } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/contexts/AuthContext'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { logger } from '@/lib/logger'
+
+interface RecentPerson {
+  name: string
+  email: string | null
+}
+
+interface QuickParticipantPickerProps {
+  tripId: string
+  tripCode: string
+  tripName: string
+}
+
+export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickParticipantPickerProps) {
+  const { user, userProfile } = useAuth()
+  const { participants, createParticipant } = useParticipantContext()
+
+  const [recentPeople, setRecentPeople] = useState<RecentPerson[]>([])
+  const [addedNames, setAddedNames] = useState<string[]>([])
+  const [supportsContacts, setSupportsContacts] = useState(false)
+
+  // Manual add form state
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Check contacts API support on mount
+  useEffect(() => {
+    setSupportsContacts('contacts' in navigator && typeof (navigator as any).contacts?.select === 'function')
+  }, [])
+
+  // Fetch recent people from past trips by this user
+  useEffect(() => {
+    if (!user) return
+
+    const fetchRecent = async () => {
+      try {
+        // Fetch participants from trips created_by this user, excluding self
+        const { data, error: fetchError } = await supabase
+          .from('participants')
+          .select('name, email, trips!inner(created_by)')
+          .eq('trips.created_by', user.id)
+          .is('user_id', null)  // exclude self (linked participants)
+          .neq('user_id', user.id)
+          .order('created_at', { ascending: false })
+          .limit(50)
+
+        if (fetchError) {
+          logger.warn('Failed to fetch recent people', { error: fetchError.message })
+          return
+        }
+
+        // Deduplicate by email (preferred) or name
+        const seen = new Set<string>()
+        const deduped: RecentPerson[] = []
+        for (const row of (data ?? []) as any[]) {
+          const key = row.email?.toLowerCase() ?? row.name.toLowerCase()
+          if (!seen.has(key)) {
+            seen.add(key)
+            deduped.push({ name: row.name, email: row.email ?? null })
+          }
+          if (deduped.length >= 20) break
+        }
+
+        setRecentPeople(deduped)
+      } catch (err) {
+        logger.warn('Unhandled error fetching recent people', { error: String(err) })
+      }
+    }
+
+    fetchRecent()
+  }, [user?.id])
+
+  const organiserName = userProfile?.display_name || user?.email?.split('@')[0] || 'Organiser'
+
+  const sendInvitation = async (participantId: string, participantEmail: string, participantName: string) => {
+    try {
+      const { data: inv, error: invError } = await supabase
+        .from('invitations')
+        .insert([{ trip_id: tripId, participant_id: participantId, inviter_id: user!.id }])
+        .select('id, token')
+        .single()
+
+      if (invError || !inv) {
+        logger.warn('Failed to create invitation row', { error: String(invError) })
+        return
+      }
+
+      supabase.functions.invoke('send-email', {
+        body: {
+          type: 'invitation',
+          invitation_id: inv.id,
+          trip_name: tripName,
+          trip_code: tripCode,
+          participant_name: participantName,
+          participant_email: participantEmail,
+          organiser_name: organiserName,
+          token: (inv as any).token,
+        },
+      }).then(({ error }) => {
+        if (error) logger.warn('send-email returned error', { error: String(error) })
+      })
+    } catch (err) {
+      logger.warn('sendInvitation: unhandled error', { error: String(err) })
+    }
+  }
+
+  const addPerson = async (personName: string, personEmail: string | null) => {
+    const emailLower = personEmail?.trim().toLowerCase() ?? null
+    if (emailLower) {
+      const duplicate = participants.some(p => p.email?.toLowerCase() === emailLower)
+      if (duplicate) return // silently skip duplicate
+    }
+
+    const newParticipant = await createParticipant({
+      trip_id: tripId,
+      name: personName.trim(),
+      is_adult: true,
+      family_id: null,
+      email: emailLower || null,
+    })
+
+    if (newParticipant) {
+      setAddedNames(prev => [...prev, personName.trim()])
+      if (newParticipant.email && user) {
+        sendInvitation(newParticipant.id, newParticipant.email, newParticipant.name)
+      }
+    }
+  }
+
+  const handleAddRecent = async (person: RecentPerson) => {
+    await addPerson(person.name, person.email)
+  }
+
+  const handleAddFromContacts = async () => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const contacts = await (navigator as any).contacts.select(['name', 'email'], { multiple: true })
+      for (const contact of contacts ?? []) {
+        const personName = contact.name?.[0] ?? ''
+        const personEmail = contact.email?.[0] ?? null
+        if (personName.trim()) {
+          await addPerson(personName.trim(), personEmail)
+        }
+      }
+    } catch (err) {
+      // User dismissed picker or API error — ignore
+      logger.info('Contacts picker dismissed or errored', { error: String(err) })
+    }
+  }
+
+  const handleManualAdd = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!name.trim()) return
+
+    setError(null)
+    const emailLower = email.trim().toLowerCase()
+    if (emailLower) {
+      const duplicate = participants.some(p => p.email?.toLowerCase() === emailLower)
+      if (duplicate) {
+        setError('This email is already in the group.')
+        return
+      }
+    }
+
+    setAdding(true)
+    try {
+      await addPerson(name.trim(), email.trim() || null)
+      setName('')
+      setEmail('')
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const isAdded = (person: RecentPerson) =>
+    addedNames.includes(person.name) ||
+    participants.some(p => p.name === person.name && (
+      !person.email || p.email?.toLowerCase() === person.email?.toLowerCase()
+    ))
+
+  const currentParticipants = participants.filter(p => p.trip_id === tripId)
+
+  return (
+    <div className="space-y-5">
+      {/* Already added chips */}
+      {currentParticipants.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {currentParticipants.map(p => (
+            <span
+              key={p.id}
+              className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-primary/10 text-primary text-sm font-medium"
+            >
+              {p.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Section A: Recent people */}
+      {recentPeople.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <Users size={14} />
+            Recent
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {recentPeople.map((person, i) => {
+              const added = isAdded(person)
+              return (
+                <button
+                  key={i}
+                  onClick={() => !added && handleAddRecent(person)}
+                  disabled={added}
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm transition-colors ${
+                    added
+                      ? 'border-primary/30 bg-primary/10 text-primary cursor-default'
+                      : 'border-border hover:border-primary/50 hover:bg-accent/40 text-foreground'
+                  }`}
+                >
+                  {added ? null : <Plus size={12} />}
+                  {person.name}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Section B: Device contacts */}
+      {supportsContacts && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <Smartphone size={14} />
+            Contacts
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={handleAddFromContacts}
+          >
+            <Smartphone size={14} />
+            Add from Contacts
+          </Button>
+        </div>
+      )}
+
+      {/* Section C: Add manually */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          <UserPlus size={14} />
+          Add manually
+        </div>
+        <form onSubmit={handleManualAdd} className="space-y-2">
+          <div className="flex gap-2">
+            <Input
+              placeholder="Name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="flex-1"
+            />
+            <Button type="submit" size="sm" disabled={adding || !name.trim()}>
+              {adding ? '…' : 'Add'}
+            </Button>
+          </div>
+          <div>
+            <Label className="sr-only" htmlFor="picker-email">Email (optional)</Label>
+            <Input
+              id="picker-email"
+              type="email"
+              inputMode="email"
+              placeholder="Email (optional)"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+            />
+          </div>
+          {error && (
+            <p className="text-xs text-destructive">{error}</p>
+          )}
+        </form>
+      </div>
+
+      {/* Dismiss error */}
+      {error && (
+        <button
+          onClick={() => setError(null)}
+          className="text-xs text-muted-foreground flex items-center gap-1"
+        >
+          <X size={10} />
+          Dismiss
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/quick/QuickScanContextSheet.tsx
+++ b/src/components/quick/QuickScanContextSheet.tsx
@@ -1,0 +1,73 @@
+import { useNavigate } from 'react-router-dom'
+import { Plus, ScanLine } from 'lucide-react'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import type { Event } from '@/types/trip'
+
+interface QuickScanContextSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  trips: Event[]
+  onNewGroup: () => void
+}
+
+export function QuickScanContextSheet({
+  open,
+  onOpenChange,
+  trips,
+  onNewGroup,
+}: QuickScanContextSheetProps) {
+  const navigate = useNavigate()
+
+  const handleSelectTrip = (tripCode: string) => {
+    onOpenChange(false)
+    navigate(`/t/${tripCode}/quick`, { state: { openScan: true } })
+  }
+
+  const handleNewGroup = () => {
+    onOpenChange(false)
+    onNewGroup()
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="flex flex-col p-0 rounded-t-2xl"
+        style={{ height: '75dvh' }}
+      >
+        {/* Sticky header */}
+        <div className="px-6 py-4 border-b border-border shrink-0">
+          <SheetTitle className="flex items-center gap-2">
+            <ScanLine size={20} />
+            Scan a Receipt
+          </SheetTitle>
+          <p className="text-sm text-muted-foreground mt-0.5">Which group is this for?</p>
+        </div>
+
+        {/* Scrollable group list */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
+          {trips.map(trip => (
+            <button
+              key={trip.id}
+              onClick={() => handleSelectTrip(trip.trip_code)}
+              className="w-full text-left px-4 py-3 rounded-xl border border-border hover:bg-accent/40 transition-colors"
+            >
+              <span className="font-medium text-foreground">{trip.name}</span>
+            </button>
+          ))}
+
+          {/* New Group option */}
+          <Button
+            variant="outline"
+            className="w-full gap-2 mt-1"
+            onClick={handleNewGroup}
+          >
+            <Plus size={16} />
+            New Group
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -1,0 +1,379 @@
+import { useState, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Camera, Upload, Loader2, X, ScanLine, ChevronRight } from 'lucide-react'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { supabase } from '@/lib/supabase'
+import { useTripContext } from '@/contexts/TripContext'
+import { useReceiptContext } from '@/contexts/ReceiptContext'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
+import { QuickParticipantPicker } from './QuickParticipantPicker'
+import { logger } from '@/lib/logger'
+
+type Step = 'camera' | 'scanning' | 'participants'
+
+interface QuickScanCreateFlowProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function compressImage(file: File): Promise<Blob> {
+  return Promise.race([
+    new Promise<Blob>((resolve, reject) => {
+      const img = new Image()
+      const url = URL.createObjectURL(file)
+      img.onload = () => {
+        URL.revokeObjectURL(url)
+        const maxWidth = 1200
+        let { width, height } = img
+        if (width > maxWidth) {
+          height = Math.round((height * maxWidth) / width)
+          width = maxWidth
+        }
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext('2d')!
+        ctx.drawImage(img, 0, 0, width, height)
+        canvas.toBlob(
+          blob => (blob ? resolve(blob) : reject(new Error('Compression failed'))),
+          'image/jpeg',
+          0.8
+        )
+      }
+      img.onerror = () => {
+        URL.revokeObjectURL(url)
+        reject(new Error('Failed to load image'))
+      }
+      img.src = url
+    }),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Image compression timed out')), 10000)
+    ),
+  ])
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      resolve(result.split(',')[1])
+    }
+    reader.onerror = () => reject(new Error('Failed to convert image to base64'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+function formatDate(iso: string): string {
+  // Parse YYYY-MM-DD without timezone shift
+  const [year, month, day] = iso.split('-').map(Number)
+  const d = new Date(year, month - 1, day)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function todayISO(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowProps) {
+  const navigate = useNavigate()
+  const { createTrip, updateTrip } = useTripContext()
+  const { createReceiptTask, refreshPendingReceipts } = useReceiptContext()
+  const { refreshParticipants } = useParticipantContext()
+  const keyboard = useKeyboardHeight()
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const cameraInputRef = useRef<HTMLInputElement>(null)
+
+  const [step, setStep] = useState<Step>('camera')
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Created trip info (available from step 2 onwards)
+  const [createdTripId, setCreatedTripId] = useState<string | null>(null)
+  const [createdTripCode, setCreatedTripCode] = useState<string | null>(null)
+  const [createdTripName, setCreatedTripName] = useState<string | null>(null)
+
+  const handleFileSelected = (file: File) => {
+    setError(null)
+    setSelectedFile(file)
+    setPreviewUrl(URL.createObjectURL(file))
+  }
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) handleFileSelected(file)
+  }
+
+  const handleReset = () => {
+    setSelectedFile(null)
+    if (previewUrl) URL.revokeObjectURL(previewUrl)
+    setPreviewUrl(null)
+    setError(null)
+  }
+
+  const handleClose = () => {
+    if (createdTripCode) {
+      // If group was created, navigate to it before closing
+      onOpenChange(false)
+      navigate(`/t/${createdTripCode}/quick`)
+    } else {
+      onOpenChange(false)
+    }
+    // Reset state after close animation
+    setTimeout(() => {
+      setStep('camera')
+      handleReset()
+      setCreatedTripId(null)
+      setCreatedTripCode(null)
+      setCreatedTripName(null)
+    }, 300)
+  }
+
+  const handleScan = async () => {
+    if (!selectedFile) return
+    setStep('scanning')
+    setError(null)
+
+    try {
+      const today = todayISO()
+
+      // 1. Create the group with a placeholder name
+      const placeholder = `New Group · ${formatDate(today)}`
+      const newTrip = await createTrip({
+        name: placeholder,
+        start_date: today,
+        end_date: today,
+        event_type: 'event',
+        tracking_mode: 'individuals',
+      })
+
+      if (!newTrip) {
+        setError('Failed to create group. Please try again.')
+        setStep('camera')
+        return
+      }
+
+      setCreatedTripId(newTrip.id)
+      setCreatedTripCode(newTrip.trip_code)
+      setCreatedTripName(newTrip.name)
+
+      // 2. Compress image + create receipt task
+      const compressed = await compressImage(selectedFile)
+      const base64 = await blobToBase64(compressed)
+      const task = await createReceiptTask(newTrip.id)
+
+      // 3. Run bucket upload and edge function in parallel
+      const uploadPath = `${task.id}.jpg`
+      const [uploadResult, fnResult] = await Promise.allSettled([
+        supabase.storage.from('receipts').upload(uploadPath, compressed, { contentType: 'image/jpeg' }),
+        supabase.functions.invoke('process-receipt', {
+          body: {
+            receipt_task_id: task.id,
+            image_base64: base64,
+            mime_type: 'image/jpeg',
+          },
+        }),
+      ])
+
+      // Write image path to task row (non-blocking)
+      if (uploadResult.status === 'fulfilled' && !uploadResult.value.error) {
+        supabase.from('receipt_tasks').update({ receipt_image_path: uploadPath }).eq('id', task.id)
+      } else {
+        const errMsg =
+          uploadResult.status === 'rejected'
+            ? String(uploadResult.reason)
+            : (uploadResult.value.error?.message ?? 'Unknown error')
+        logger.warn('Receipt image upload failed (non-blocking)', { task_id: task.id, error: errMsg })
+      }
+
+      // Extract merchant + date from edge function result, update group name
+      let autoName = placeholder
+      if (fnResult.status === 'fulfilled' && !fnResult.value.error && fnResult.value.data?.ok) {
+        const { merchant, date } = fnResult.value.data as { merchant?: string; date?: string | null }
+        const displayDate = date ? formatDate(date) : formatDate(today)
+        autoName = `${merchant ?? 'Group'} · ${displayDate}`
+        // Update group name async — don't block the UI
+        updateTrip(newTrip.id, { name: autoName }).catch(err =>
+          logger.warn('Failed to update group name after scan', { error: String(err) })
+        )
+        setCreatedTripName(autoName)
+      } else {
+        const errDetail =
+          fnResult.status === 'rejected'
+            ? String(fnResult.reason)
+            : fnResult.value.error?.message ?? 'Unknown error'
+        logger.warn('process-receipt did not return ok', { error: errDetail })
+        // Non-fatal: group is created, just won't have a merchant name
+      }
+
+      await refreshPendingReceipts()
+      await refreshParticipants()
+
+      // Move to participant step
+      setStep('participants')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'An error occurred'
+      logger.error('QuickScanCreateFlow failed', { error: message })
+      setError(message)
+      setStep('camera')
+    }
+  }
+
+  const handleDone = () => {
+    if (createdTripCode) {
+      onOpenChange(false)
+      navigate(`/t/${createdTripCode}/quick`)
+    } else {
+      onOpenChange(false)
+    }
+    setTimeout(() => {
+      setStep('camera')
+      handleReset()
+      setCreatedTripId(null)
+      setCreatedTripCode(null)
+      setCreatedTripName(null)
+    }, 300)
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleClose}>
+      <SheetContent
+        side="bottom"
+        className="flex flex-col p-0 rounded-t-2xl"
+        style={{
+          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
+          bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
+        }}
+      >
+        {/* Sticky header */}
+        <div className="px-6 py-4 border-b border-border shrink-0 flex items-center justify-between">
+          <SheetTitle className="flex items-center gap-2">
+            <ScanLine size={20} />
+            {step === 'camera' && 'Scan a Receipt'}
+            {step === 'scanning' && 'Reading receipt…'}
+            {step === 'participants' && (createdTripName ?? 'Add People')}
+          </SheetTitle>
+          {step === 'participants' && (
+            <Button size="sm" onClick={handleDone} className="gap-1">
+              Done
+              <ChevronRight size={14} />
+            </Button>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {/* Step 1: Camera */}
+          {step === 'camera' && (
+            <div className="flex flex-col gap-4 h-full">
+              {!previewUrl ? (
+                <div className="flex-1 flex flex-col items-center justify-center gap-4 py-8">
+                  <div className="w-24 h-24 rounded-full bg-muted flex items-center justify-center">
+                    <Camera size={40} className="text-muted-foreground" />
+                  </div>
+                  <div className="text-center">
+                    <p className="font-medium text-foreground">Add a receipt photo</p>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      A new group will be created automatically
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2 w-full max-w-xs">
+                    <Button variant="default" className="gap-2" onClick={() => cameraInputRef.current?.click()}>
+                      <Camera size={16} />
+                      Take Photo
+                    </Button>
+                    <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()}>
+                      <Upload size={16} />
+                      Choose from Library
+                    </Button>
+                  </div>
+                  <input
+                    ref={cameraInputRef}
+                    type="file"
+                    accept="image/*"
+                    capture="environment"
+                    className="hidden"
+                    onChange={handleFileInputChange}
+                  />
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleFileInputChange}
+                  />
+                </div>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  <div className="relative rounded-lg overflow-hidden border border-border">
+                    <img
+                      src={previewUrl}
+                      alt="Receipt preview"
+                      className="w-full max-h-64 object-contain bg-muted"
+                    />
+                    <button
+                      onClick={handleReset}
+                      className="absolute top-2 right-2 rounded-full bg-background/80 p-1 border border-border"
+                      aria-label="Remove image"
+                    >
+                      <X size={16} />
+                    </button>
+                  </div>
+
+                  {error && (
+                    <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-3 py-2">
+                      {error}
+                    </div>
+                  )}
+
+                  <Button onClick={handleScan} size="lg" className="gap-2">
+                    <ScanLine size={16} />
+                    Scan & Create Group
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 2: Scanning */}
+          {step === 'scanning' && (
+            <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+              <div className="w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center">
+                <Loader2 size={36} className="animate-spin text-primary" />
+              </div>
+              <div>
+                <p className="font-medium text-foreground">Reading your receipt…</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Creating your group and extracting items
+                </p>
+              </div>
+              <p className="text-xs text-muted-foreground">Usually takes 5–10 seconds</p>
+            </div>
+          )}
+
+          {/* Step 3: Add participants */}
+          {step === 'participants' && createdTripId && createdTripCode && createdTripName && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Add people to split the receipt with. You can always add more later.
+              </p>
+              <QuickParticipantPicker
+                tripId={createdTripId}
+                tripCode={createdTripCode}
+                tripName={createdTripName}
+              />
+              <Button variant="ghost" className="w-full text-muted-foreground" onClick={handleDone}>
+                Skip for now
+              </Button>
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -323,6 +323,7 @@ export type Database = {
           extracted_items: Json | null
           extracted_total: number | null
           extracted_currency: string | null
+          extracted_date: string | null
           confirmed_total: number | null
           tip_amount: number
           mapped_items: Json | null
@@ -341,6 +342,7 @@ export type Database = {
           extracted_items?: Json | null
           extracted_total?: number | null
           extracted_currency?: string | null
+          extracted_date?: string | null
           confirmed_total?: number | null
           tip_amount?: number
           mapped_items?: Json | null
@@ -359,6 +361,7 @@ export type Database = {
           extracted_items?: Json | null
           extracted_total?: number | null
           extracted_currency?: string | null
+          extracted_date?: string | null
           confirmed_total?: number | null
           tip_amount?: number
           mapped_items?: Json | null

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -37,6 +37,7 @@ interface ReceiptReviewData {
 
 export function QuickGroupDetailPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { currentTrip, loading: tripLoading } = useCurrentTrip()
   const { myParticipant, isLinked } = useMyParticipant()
   const { participants, families, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
@@ -54,6 +55,15 @@ export function QuickGroupDetailPage() {
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [slowLoading, setSlowLoading] = useState(false)
   const [retrying, setRetrying] = useState(false)
+
+  // Open receipt capture sheet when navigated here with openScan state
+  useEffect(() => {
+    if ((location.state as any)?.openScan) {
+      setReceiptCaptureOpen(true)
+      // Clear the state so back-navigation doesn't re-open it
+      window.history.replaceState({}, '')
+    }
+  }, [location.state])
 
   const loading = participantsLoading || expensesLoading || settlementsLoading
   const contextError = participantError || expenseError || settlementError

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -21,6 +21,7 @@ export interface ReceiptTask {
   extracted_items: ExtractedItem[] | null;
   extracted_total: number | null;
   extracted_currency: string | null;
+  extracted_date: string | null;
   confirmed_total: number | null;
   tip_amount: number;
   mapped_items: MappedItem[] | null;

--- a/supabase/migrations/024_receipt_date.sql
+++ b/supabase/migrations/024_receipt_date.sql
@@ -1,0 +1,4 @@
+-- Add extracted_date column to receipt_tasks
+-- Stores the date extracted from the receipt (ISO date string, e.g. "2026-02-22")
+ALTER TABLE receipt_tasks
+  ADD COLUMN IF NOT EXISTS extracted_date TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary

- **Prominent Scan button** on QuickHomeScreen (above the group list) as primary entry point for new expense flows
  - 0 groups → `QuickScanCreateFlow`: camera → AI scan → group auto-created → add people
  - 1 group → navigates to that group and opens receipt capture immediately
  - 2+ groups → `QuickScanContextSheet`: pick group or "New Group" before camera
- **`QuickScanCreateFlow`** (new): multi-step bottom sheet — take photo → scanning state → participant picker
  - Group is created immediately with placeholder name `"New Group · Feb 22"`
  - Name updated to `"Nobu Tokyo · Feb 22"` when AI responds (non-blocking)
  - Proceeds to participant picker even on scan error (group is still created)
- **`QuickScanContextSheet`** (new): read-only group picker using `75dvh` fixed height pattern
- **`QuickParticipantPicker`** (new): three-source participant adder
  - Section A: Recent people from the user's past trips (deduplicated, max 20)
  - Section B: Native Web Contacts API button (progressive enhancement — hidden on desktop/Firefox)
  - Section C: Manual name + optional email form with duplicate detection + invitation sending
- **`extracted_date`** added to receipt processing pipeline
  - Migration `024_receipt_date.sql` adds `extracted_date TEXT` column
  - Claude prompt updated to extract receipt date as ISO `YYYY-MM-DD`
  - Edge function validates format, saves to DB, returns `date` in response
  - `database.types.ts` + `ReceiptTask` type updated
- **`QuickGroupDetailPage`**: opens receipt capture automatically when navigated with `{ state: { openScan: true } }`

## Test plan

- [ ] QuickHomeScreen: large scan button visible above group list
- [ ] 0 groups: scan tap → `QuickScanCreateFlow` sheet opens (no picker)
- [ ] 1 group: scan tap → navigates to group, receipt capture opens automatically
- [ ] 2+ groups: scan tap → group picker shows; select group → navigates + capture opens; "New Group" → flow
- [ ] `QuickScanCreateFlow`: take/upload photo → scanning state → group created in Supabase → name updates after AI → participant picker appears
- [ ] Participant picker — recent people chips appear if user has past trips
- [ ] Participant picker — contacts button visible on mobile, hidden on desktop
- [ ] Participant picker — manual add form works; email sends invitation
- [ ] Skip for now → lands on group detail with pending receipt banner
- [ ] `npm run type-check` passes clean ✅
- [ ] Migration `024` applies cleanly via `supabase db push`
- [ ] Deploy `process-receipt` edge function after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)