### PR TITLE
fix: cancel stale Supabase requests to prevent connection pool exhaustion

### DIFF
--- a/src/hooks/useAbortController.ts
+++ b/src/hooks/useAbortController.ts
@@ -1,0 +1,21 @@
+import { useRef, useEffect } from 'react'
+
+export function useAbortController() {
+  const ref = useRef<AbortController | null>(null)
+
+  // Cancel on unmount
+  useEffect(() => () => { ref.current?.abort() }, [])
+
+  /** Cancel any in-flight request and return a fresh AbortSignal for the new one. */
+  function newSignal(): AbortSignal {
+    ref.current?.abort()
+    const controller = new AbortController()
+    ref.current = controller
+    return controller.signal
+  }
+
+  /** Explicitly cancel the current in-flight request (e.g. from useEffect cleanup). */
+  const cancel = () => ref.current?.abort()
+
+  return { newSignal, cancel }
+}


### PR DESCRIPTION
## Summary

- Add `useAbortController` hook (`src/hooks/useAbortController.ts`) — `newSignal()` atomically cancels the previous in-flight request and hands back a fresh `AbortSignal`; `cancel()` for explicit teardown; unmount auto-cancels via `useEffect`
- Apply `.abortSignal(signal)` to all read-fetches across all 10 contexts + 3 page-level components, with `if (signal.aborted) return` guards in catch/finally so stale results are silently discarded
- `useEffect` cleanup now returns `cancel` so abort fires on dependency change AND on unmount
- Add `withTimeout(35000)` to all mutations that were missing it (ParticipantContext 8 mutations, MealContext 5, ActivityContext 3, StayContext 3, UserPreferencesContext upsert, QuickParticipantPicker invitation insert, JoinPage link+accept)
- Add `withTimeout(15000)` to read-fetches in MealContext, ActivityContext, StayContext that were missing it

## Why

Soft navigation accumulates in-flight Supabase requests that hold HTTP connections. Old requests were never cancelled — each held a connection for up to 30 s. Each "Retry" click stacked 3 more on top. After a few retries, new requests queued and hit the 15 s `withTimeout` limit before a connection slot opened. Hard refresh fixed it because the browser cancelled all in-flight requests.

## Test plan

- [ ] Open trip page — data loads normally
- [ ] Click Retry multiple times rapidly — no accumulation; each cancels the previous (Network tab shows cancelled requests)
- [ ] Navigate between trips quickly — no timeout errors
- [ ] Navigate quick → full mode → back — contexts remount cleanly, no zombie connections
- [ ] Submit a form and immediately navigate away — write completes, no errors in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)