### PR TITLE
test: add Playwright E2E smoke tests for all app views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ scripts/migrate.js
 
 # Supabase
 .supabase
+
+# Playwright
+test-results/
+playwright-report/
+/playwright/.cache/

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,7 +19,7 @@
 | Auth | Supabase Auth (Google OAuth, implicit flow) |
 | Observability | Grafana Cloud — Loki (logs) + OTLP (metrics) via `log-proxy` |
 | Deployment | Cloudflare Pages |
-| Tests | Vitest + Testing Library (139 tests) |
+| Tests | Vitest + Testing Library (139 unit tests), Playwright (26 E2E smoke tests) |
 | AI SDK | `@anthropic-ai/sdk@0.32.1` — **already installed, not yet used** |
 | PDF Export | jsPDF + jspdf-autotable |
 | Maps | Leaflet + react-leaflet |
@@ -529,3 +529,6 @@ Extends payment reminder emails with receipt data. PR #213 attached JPEG images;
 | 2026-02-22 | Bug fixes | #215 (PR #221): JoinPage calls refreshTrips() before navigate() so stale-list redirect after invite accept is fixed; #216 (PR #222): UserCheck icon in IndividualsSetup + FamiliesSetup for participants with user_id set; #217 (PR #223): receipt email highlights debtor's items — mapped_items + debtor_participant_ids passed from SettlementsPage, receiptTableHtml() applies faf5ff/8b5cf6 row highlight; send-email redeployed; #220 (PR #224): QuickCreateSheet + QuickParticipantSetupSheet — applied useKeyboardHeight fix |
 | 2026-02-22 | iOS sheet fixes | PR #227: QuickCreateSheet + QuickParticipantSetupSheet — two root causes fixed: (1) `vh`→`dvh` so sheet top no longer hides behind iOS browser chrome on initial open; (2) restructured to `flex flex-col` with `shrink-0` sticky header + `flex-1 overflow-y-auto` content, so title and X close button stay pinned regardless of scroll or input focus (same pattern as ReceiptReviewSheet) |
 | 2026-02-22 | Group members sheet | PR #229: `QuickGroupMembersSheet` — Users chip (absolute top-right on relative hero wrapper) opens bottom sheet listing all participants/families with balances, "You" badge, UserCheck for linked accounts, colour-coded amount + status text. Read-only sheet: no keyboard hook needed, fixed `75dvh`. `myParticipantId = myBalance?.id`. |
+| 2026-02-22 | Scan-first onboarding | PR #231: Scan button as primary entry on QuickHomeScreen. 0 groups → QuickScanCreateFlow. 1 group → navigate + openScan state. 2+ groups → QuickScanContextSheet. QuickParticipantPicker: recent people, Contacts API, manual form. Migration 024: extracted_date on receipt_tasks. |
+| 2026-02-22 | Abort stale requests | PR #234: `useAbortController` hook — cancels previous in-flight request on re-fetch. Applied to all 10 contexts + 3 page-level components. Added missing `withTimeout` to 20+ mutations. |
+| 2026-02-22 | E2E smoke tests | Playwright setup — 26 tests (13 routes × 2 viewports: mobile 375×812 + desktop 1280×720). Supabase fully mocked via `page.route()` interceptor + localStorage seeding. `npm run test:e2e` / `test:e2e:ui`. |

--- a/e2e/fixtures/mock-data.ts
+++ b/e2e/fixtures/mock-data.ts
@@ -1,0 +1,144 @@
+/**
+ * Mock data for Playwright E2E smoke tests.
+ *
+ * The real Supabase URL is read from .env.local at runtime (via dotenv)
+ * so the route interceptor matches the same origin the Vite app uses.
+ */
+import { config } from 'dotenv'
+import { resolve } from 'path'
+
+// Load .env.local the same way Vite does
+config({ path: resolve(process.cwd(), '.env.local') })
+
+export const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? ''
+export const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? ''
+
+/** Derive the Supabase project ref (subdomain) for auth localStorage key */
+export function getProjectRef(): string {
+  try {
+    return new URL(SUPABASE_URL).hostname.split('.')[0]
+  } catch {
+    return 'mock'
+  }
+}
+
+// ─── IDs ────────────────────────────────────────────────────────────────
+export const MOCK_USER_ID = 'e2e-user-0001-0001-0001-000000000001'
+export const MOCK_TRIP_ID = 'e2e-trip-0001-0001-0001-000000000001'
+export const MOCK_TRIP_CODE = 'test-trip-abc123'
+export const MOCK_PARTICIPANT_ID = 'e2e-part-0001-0001-0001-000000000001'
+export const MOCK_PARTICIPANT_2_ID = 'e2e-part-0002-0002-0002-000000000002'
+export const MOCK_EXPENSE_ID = 'e2e-exp-0001-0001-0001-000000000001'
+
+// ─── Mock objects ───────────────────────────────────────────────────────
+
+export const mockUser = {
+  id: MOCK_USER_ID,
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'test@example.com',
+  email_confirmed_at: '2025-01-01T00:00:00.000Z',
+  phone: '',
+  confirmed_at: '2025-01-01T00:00:00.000Z',
+  last_sign_in_at: '2025-01-01T00:00:00.000Z',
+  app_metadata: { provider: 'google', providers: ['google'] },
+  user_metadata: {
+    full_name: 'Test User',
+    name: 'Test User',
+    avatar_url: '',
+    picture: '',
+    email: 'test@example.com',
+  },
+  identities: [],
+  created_at: '2025-01-01T00:00:00.000Z',
+  updated_at: '2025-01-01T00:00:00.000Z',
+}
+
+export const mockSession = {
+  access_token: 'mock-access-token',
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  refresh_token: 'mock-refresh-token',
+  user: mockUser,
+}
+
+export const mockUserProfile = {
+  id: MOCK_USER_ID,
+  display_name: 'Test User',
+  email: 'test@example.com',
+  avatar_url: null,
+  bank_account_holder: null,
+  bank_iban: null,
+  created_at: '2025-01-01T00:00:00.000Z',
+  updated_at: '2025-01-01T00:00:00.000Z',
+}
+
+export const mockTrip = {
+  id: MOCK_TRIP_ID,
+  trip_code: MOCK_TRIP_CODE,
+  name: 'Test Trip',
+  start_date: '2025-06-01',
+  end_date: '2025-06-07',
+  event_type: 'trip',
+  tracking_mode: 'individuals',
+  default_currency: 'EUR',
+  exchange_rates: {},
+  enable_meals: true,
+  enable_activities: true,
+  enable_shopping: true,
+  default_split_all: true,
+  created_by: MOCK_USER_ID,
+  created_at: '2025-01-01T00:00:00.000Z',
+}
+
+export const mockParticipant = {
+  id: MOCK_PARTICIPANT_ID,
+  trip_id: MOCK_TRIP_ID,
+  family_id: null,
+  name: 'Test User',
+  is_adult: true,
+  user_id: MOCK_USER_ID,
+  email: 'test@example.com',
+}
+
+export const mockParticipant2 = {
+  id: MOCK_PARTICIPANT_2_ID,
+  trip_id: MOCK_TRIP_ID,
+  family_id: null,
+  name: 'Other Person',
+  is_adult: true,
+  user_id: null,
+  email: 'other@example.com',
+}
+
+export const mockExpense = {
+  id: MOCK_EXPENSE_ID,
+  trip_id: MOCK_TRIP_ID,
+  description: 'Test Dinner',
+  amount: 50.0,
+  currency: 'EUR',
+  paid_by: MOCK_PARTICIPANT_ID,
+  distribution: {
+    type: 'individuals',
+    participants: [MOCK_PARTICIPANT_ID, MOCK_PARTICIPANT_2_ID],
+  },
+  category: 'Food',
+  expense_date: '2025-06-02',
+  comment: null,
+  meal_id: null,
+  created_at: '2025-06-02T12:00:00.000Z',
+  updated_at: '2025-06-02T12:00:00.000Z',
+}
+
+export const mockUserPreferences = {
+  id: MOCK_USER_ID,
+  preferred_mode: 'full' as const,
+  default_trip_id: MOCK_TRIP_ID,
+}
+
+export const mockQuickUserPreferences = {
+  id: MOCK_USER_ID,
+  preferred_mode: 'quick' as const,
+  default_trip_id: MOCK_TRIP_ID,
+}

--- a/e2e/fixtures/supabase-interceptor.ts
+++ b/e2e/fixtures/supabase-interceptor.ts
@@ -1,0 +1,192 @@
+import { Page } from '@playwright/test'
+import {
+  SUPABASE_URL,
+  getProjectRef,
+  mockUser,
+  mockSession,
+  mockUserProfile,
+  mockTrip,
+  mockParticipant,
+  mockParticipant2,
+  mockExpense,
+  mockUserPreferences,
+  mockQuickUserPreferences,
+} from './mock-data'
+
+type Mode = 'full' | 'quick'
+
+/**
+ * Intercept all Supabase HTTP requests and return mock data.
+ * Call this BEFORE navigating to any page.
+ */
+export async function setupSupabaseInterceptor(page: Page, mode: Mode = 'full') {
+  const prefs = mode === 'quick' ? mockQuickUserPreferences : mockUserPreferences
+  const projectRef = getProjectRef()
+
+  // Seed localStorage before the page loads so:
+  //  - Supabase auth.getSession() finds a cached session (no network call)
+  //  - UserPreferencesContext reads the correct mode
+  await page.addInitScript(
+    ({ storageKey, session, preferences }) => {
+      localStorage.setItem(storageKey, JSON.stringify(session))
+      localStorage.setItem('spl1t:user-preferences', JSON.stringify(preferences))
+      // Also set old key — UserPreferencesContext checks it for initial loading state
+      localStorage.setItem('trip-splitter:user-preferences', JSON.stringify(preferences))
+    },
+    {
+      storageKey: `sb-${projectRef}-auth-token`,
+      session: mockSession,
+      preferences: prefs,
+    }
+  )
+
+  // Intercept all requests to the Supabase origin (or any *.supabase.co as fallback)
+  const pattern = SUPABASE_URL
+    ? `${SUPABASE_URL}/**`
+    : '**/supabase.co/**'
+
+  await page.route(pattern, (route) => {
+    const url = route.request().url()
+    const method = route.request().method()
+
+    // --- Auth endpoints ---
+    if (url.includes('/auth/v1/token')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockSession) })
+    }
+    if (url.includes('/auth/v1/user')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockUser) })
+    }
+    if (url.includes('/auth/v1/')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })
+    }
+
+    // --- Realtime WebSocket — abort so shopping list falls back to initial fetch ---
+    if (url.includes('/realtime/')) {
+      return route.abort()
+    }
+
+    // --- Edge Functions ---
+    if (url.includes('/functions/v1/')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) })
+    }
+
+    // --- Storage ---
+    if (url.includes('/storage/v1/')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })
+    }
+
+    // --- PostgREST (rest/v1/{table}) ---
+    if (url.includes('/rest/v1/')) {
+      return handlePostgREST(route, url, method)
+    }
+
+    // Fallback — unknown Supabase endpoint
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+}
+
+function handlePostgREST(
+  route: Parameters<Parameters<Page['route']>[1]>[0],
+  url: string,
+  method: string,
+) {
+  // Extract table name from /rest/v1/{table}?...
+  const pathAfterRest = url.split('/rest/v1/')[1]
+  const table = pathAfterRest?.split('?')[0] || ''
+
+  // Writes (POST/PATCH/DELETE) — return appropriate mock
+  if (method !== 'GET') {
+    if (table === 'user_profiles') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockUserProfile),
+      })
+    }
+    if (table === 'user_preferences') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockUserPreferences),
+      })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  }
+
+  // GET requests — return mock arrays per table
+  switch (table) {
+    case 'trips':
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([mockTrip]),
+      })
+
+    case 'participants':
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([mockParticipant, mockParticipant2]),
+      })
+
+    case 'families':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'expenses':
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([mockExpense]),
+      })
+
+    case 'settlements':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'meals':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'meal_shopping_items':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'shopping_items':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'activities':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'stays':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'user_profiles':
+      // .in() queries (e.g. bank details fetch) → return array
+      if (url.includes('in.')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([mockUserProfile]),
+        })
+      }
+      // .maybeSingle()/.single() requests → return single object
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockUserProfile),
+      })
+
+    case 'user_preferences':
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([mockUserPreferences]),
+      })
+
+    case 'receipt_tasks':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    case 'invitations':
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+
+    default:
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  }
+}

--- a/e2e/fixtures/test-fixtures.ts
+++ b/e2e/fixtures/test-fixtures.ts
@@ -1,0 +1,38 @@
+import { test as base, Page, expect } from '@playwright/test'
+import { setupSupabaseInterceptor } from './supabase-interceptor'
+
+/**
+ * Custom test fixtures that provide pre-configured pages:
+ * - fullModePage: localStorage seeded for "full" mode, Supabase mocked
+ * - quickModePage: localStorage seeded for "quick" mode, Supabase mocked
+ */
+export const test = base.extend<{
+  fullModePage: Page
+  quickModePage: Page
+}>({
+  fullModePage: async ({ page }, use) => {
+    await setupSupabaseInterceptor(page, 'full')
+    await use(page)
+  },
+  quickModePage: async ({ page }, use) => {
+    await setupSupabaseInterceptor(page, 'quick')
+    await use(page)
+  },
+})
+
+export { expect }
+
+/**
+ * Helper: wait for loading spinners to disappear (max 10s).
+ * Many pages show a spinner while contexts load data.
+ */
+export async function waitForLoadingToFinish(page: Page) {
+  // Give the page a moment to start rendering
+  await page.waitForTimeout(500)
+  // Wait for all spinners to disappear
+  const spinners = page.locator('.animate-spin')
+  const count = await spinners.count()
+  if (count > 0) {
+    await expect(spinners.first()).toBeHidden({ timeout: 10_000 })
+  }
+}

--- a/e2e/smoke/full-mode.spec.ts
+++ b/e2e/smoke/full-mode.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, waitForLoadingToFinish } from '../fixtures/test-fixtures'
+import { MOCK_TRIP_CODE } from '../fixtures/mock-data'
+
+test.describe('Full mode — smoke tests', () => {
+  let pageErrors: Error[]
+
+  test.beforeEach(async () => {
+    pageErrors = []
+  })
+
+  function trackErrors(page: import('@playwright/test').Page) {
+    page.on('pageerror', (err) => pageErrors.push(err))
+  }
+
+  test('/ — home page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto('/')
+    await waitForLoadingToFinish(page)
+    // In full mode, ConditionalHomePage renders HomePage in-place (no redirect)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/create-trip — create trip page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto('/create-trip')
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/expenses — expenses page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/expenses`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/settlements — settlements page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/settlements`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/planner — planner page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/planner`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/shopping — shopping page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/shopping`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/dashboard — dashboard page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/dashboard`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/manage — manage trip page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/manage`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+})

--- a/e2e/smoke/quick-mode.spec.ts
+++ b/e2e/smoke/quick-mode.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, waitForLoadingToFinish } from '../fixtures/test-fixtures'
+import { MOCK_TRIP_CODE } from '../fixtures/mock-data'
+
+test.describe('Quick mode — smoke tests', () => {
+  let pageErrors: Error[]
+
+  test.beforeEach(async () => {
+    pageErrors = []
+  })
+
+  function trackErrors(page: import('@playwright/test').Page) {
+    page.on('pageerror', (err) => pageErrors.push(err))
+  }
+
+  test('/quick — quick home screen loads', async ({ quickModePage: page }) => {
+    trackErrors(page)
+    await page.goto('/quick')
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/quick — quick group detail loads', async ({ quickModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/quick`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/t/:code/quick/history — quick history loads', async ({ quickModePage: page }) => {
+    trackErrors(page)
+    await page.goto(`/t/${MOCK_TRIP_CODE}/quick/history`)
+    await waitForLoadingToFinish(page)
+    await expect(page.locator('#root')).not.toBeEmpty()
+    expect(pageErrors).toHaveLength(0)
+  })
+})

--- a/e2e/smoke/standalone.spec.ts
+++ b/e2e/smoke/standalone.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect, waitForLoadingToFinish } from '../fixtures/test-fixtures'
+
+test.describe('Standalone pages — smoke tests', () => {
+  let pageErrors: Error[]
+
+  test.beforeEach(async () => {
+    pageErrors = []
+  })
+
+  function trackErrors(page: import('@playwright/test').Page) {
+    page.on('pageerror', (err) => pageErrors.push(err))
+  }
+
+  test('/trip-not-found/:code — 404 page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto('/trip-not-found/nonexistent-trip')
+    await waitForLoadingToFinish(page)
+    await expect(page.getByText('Trip Not Found')).toBeVisible({ timeout: 10_000 })
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test('/join/:token — join page loads', async ({ fullModePage: page }) => {
+    trackErrors(page)
+    await page.goto('/join/mock-invite-token')
+    await waitForLoadingToFinish(page)
+    // Join page renders content — check for any visible text content
+    await expect(page.locator('#root')).not.toBeEmpty({ timeout: 10_000 })
+    expect(pageErrors).toHaveLength(0)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "zustand": "^5.0.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1430,6 +1431,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6443,6 +6460,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "migrate": "node scripts/migrate.js",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
@@ -54,6 +56,7 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  timeout: 60_000,
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    navigationTimeout: 45_000,
+  },
+
+  projects: [
+    {
+      name: 'mobile',
+      use: {
+        ...devices['iPhone 13'],
+        viewport: { width: 375, height: 812 },
+      },
+    },
+    {
+      name: 'desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+})


### PR DESCRIPTION
## Summary
- Install Playwright with Chromium, add `test:e2e` and `test:e2e:ui` npm scripts
- 26 smoke tests covering all 13 routes at mobile (375×812) and desktop (1280×720) viewports
- Supabase backend fully mocked via `page.route()` interceptor + localStorage seeding (auth token + user preferences)

## Test coverage

| Suite | Routes | Tests |
|-------|--------|-------|
| Full mode | `/`, `/create-trip`, expenses, settlements, planner, shopping, dashboard, manage | 16 (8×2) |
| Quick mode | `/quick`, group detail, history | 6 (3×2) |
| Standalone | `/trip-not-found/:code`, `/join/:token` | 4 (2×2) |

## Files added
- `playwright.config.ts` — Chromium only, mobile + desktop projects, Vite dev server auto-start
- `e2e/fixtures/mock-data.ts` — Mock user, session, trip, participants, expenses
- `e2e/fixtures/supabase-interceptor.ts` — Intercepts all Supabase API calls (auth, PostgREST, edge functions, realtime, storage)
- `e2e/fixtures/test-fixtures.ts` — Custom `test` with `fullModePage` / `quickModePage` fixtures
- `e2e/smoke/full-mode.spec.ts` — Full mode route smoke tests
- `e2e/smoke/quick-mode.spec.ts` — Quick mode route smoke tests
- `e2e/smoke/standalone.spec.ts` — Standalone page smoke tests

## Test plan
- [x] `npm run test:e2e` — all 26 tests pass
- [x] `npm run type-check` — clean
- [ ] Verify no interference with existing `npm test` (Vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)