### PR TITLE
fix: member chip count matches sheet (#233), clarify Create button label (#232)

### DIFF
--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -178,13 +178,13 @@ export function QuickGroupDetailPage() {
       ) : (
         <div className="relative">
           <QuickBalanceHero balance={myBalance} />
-          {participants.length > 0 && (
+          {balanceCalc.balances.length > 0 && (
             <button
               onClick={() => setMembersOpen(true)}
               className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-background/80 backdrop-blur-sm border border-border text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               <Users size={13} />
-              <span>{participants.length}</span>
+              <span>{balanceCalc.balances.length}</span>
             </button>
           )}
         </div>

--- a/src/pages/QuickHomeScreen.tsx
+++ b/src/pages/QuickHomeScreen.tsx
@@ -128,7 +128,7 @@ export function QuickHomeScreen() {
                 </p>
                 <Button onClick={() => setCreateOpen(true)} className="gap-2">
                   <Plus size={18} />
-                  Create New
+                  New Trip or Event
                 </Button>
               </div>
             </CardContent>
@@ -198,7 +198,7 @@ export function QuickHomeScreen() {
           <div className="mt-6 text-center">
             <Button variant="outline" onClick={() => setCreateOpen(true)} className="gap-2">
               <Plus size={16} />
-              Create New
+              New Trip or Event
             </Button>
           </div>
         )}


### PR DESCRIPTION
## Summary

- **#233 — Group mode participant list is off**: In families mode the chip badge showed `participants.length` (10 individuals) while the sheet title showed `balanceCalc.balances.length` (4 families). Fixed by using `balanceCalc.balances.length` for the chip count so badge and sheet title always agree.

- **#232 — Obvious?**: Renamed "Create New" → "New Trip or Event" on the home screen so new users immediately understand what the button does.

## Test plan
- [ ] In families mode: chip badge count matches "Group (N members)" sheet title
- [ ] "New Trip or Event" button label appears on home screen (both empty state and below group list)
- [ ] Closing issues #232 and #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)