### PR TITLE
fix: update test mocks for abortSignal chains + ShoppingContext loading bug

### DIFF
--- a/src/contexts/ActivityContext.test.tsx
+++ b/src/contexts/ActivityContext.test.tsx
@@ -69,7 +69,7 @@ describe('ActivityContext', () => {
     mockSupabase.from.mockReturnValue({
       select: () => ({
         eq: () => ({
-          order: () => Promise.resolve({ data: activities, error: null }),
+          order: () => ({ abortSignal: () => Promise.resolve({ data: activities, error: null }) }),
         }),
       }),
     })

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -19,6 +19,7 @@ const mockSupabase = vi.hoisted(() => {
       signInWithIdToken: fn().mockResolvedValue({ error: null }),
       signOut: fn().mockResolvedValue({ error: null }),
     },
+    functions: { invoke: fn().mockResolvedValue({ data: null, error: null }) },
     channel: fn(),
     removeChannel: fn(),
   }

--- a/src/contexts/ExpenseContext.test.tsx
+++ b/src/contexts/ExpenseContext.test.tsx
@@ -79,7 +79,7 @@ describe('ExpenseContext', () => {
       select: () => ({
         eq: () => ({
           order: () => ({
-            order: () => Promise.resolve({ data: sampleExpenses, error: null }),
+            order: () => ({ abortSignal: () => Promise.resolve({ data: sampleExpenses, error: null }) }),
           }),
         }),
       }),

--- a/src/contexts/ShoppingContext.test.tsx
+++ b/src/contexts/ShoppingContext.test.tsx
@@ -57,6 +57,19 @@ function TestConsumer() {
   )
 }
 
+/** Build the select→eq→order→order→abortSignal chain for shopping item fetches */
+function mockSelectChain(data: ShoppingItem[]) {
+  return {
+    select: () => ({
+      eq: () => ({
+        order: () => ({
+          order: () => ({ abortSignal: () => Promise.resolve({ data, error: null }) }),
+        }),
+      }),
+    }),
+  }
+}
+
 describe('ShoppingContext', () => {
   beforeEach(() => {
     mockCurrentTrip.currentTrip = null
@@ -86,15 +99,7 @@ describe('ShoppingContext', () => {
     mockCurrentTrip.currentTrip = { id: 'trip-1' }
     mockCurrentTrip.tripCode = 'test-trip-Ab1234'
 
-    mockSupabase.from.mockReturnValue({
-      select: () => ({
-        eq: () => ({
-          order: () => ({
-            order: () => Promise.resolve({ data: sampleItems, error: null }),
-          }),
-        }),
-      }),
-    })
+    mockSupabase.from.mockReturnValue(mockSelectChain(sampleItems))
 
     render(
       <ShoppingProvider>
@@ -115,13 +120,7 @@ describe('ShoppingContext', () => {
     mockCurrentTrip.tripCode = 'test-trip-Ab1234'
 
     mockSupabase.from.mockReturnValue({
-      select: () => ({
-        eq: () => ({
-          order: () => ({
-            order: () => Promise.resolve({ data: [...sampleItems], error: null }),
-          }),
-        }),
-      }),
+      ...mockSelectChain([...sampleItems]),
       update: () => ({
         eq: () => ({
           select: () => ({
@@ -172,15 +171,7 @@ describe('ShoppingContext', () => {
     mockCurrentTrip.currentTrip = { id: 'trip-1' }
     mockCurrentTrip.tripCode = 'test-trip-Ab1234'
 
-    mockSupabase.from.mockReturnValue({
-      select: () => ({
-        eq: () => ({
-          order: () => ({
-            order: () => Promise.resolve({ data: [], error: null }),
-          }),
-        }),
-      }),
-    })
+    mockSupabase.from.mockReturnValue(mockSelectChain([]))
 
     const { unmount } = render(
       <ShoppingProvider>

--- a/src/contexts/ShoppingContext.tsx
+++ b/src/contexts/ShoppingContext.tsx
@@ -90,6 +90,7 @@ export function ShoppingProvider({ children }: { children: ReactNode }) {
         setChannel(null)
       }
       setShoppingItems([])
+      setLoading(false)
       return cancel
     }
 

--- a/src/contexts/StayContext.test.tsx
+++ b/src/contexts/StayContext.test.tsx
@@ -68,7 +68,7 @@ describe('StayContext', () => {
     mockSupabase.from.mockReturnValue({
       select: () => ({
         eq: () => ({
-          order: () => Promise.resolve({ data: [stay1, stay2], error: null }),
+          order: () => ({ abortSignal: () => Promise.resolve({ data: [stay1, stay2], error: null }) }),
         }),
       }),
     })
@@ -96,7 +96,7 @@ describe('StayContext', () => {
     mockSupabase.from.mockReturnValue({
       select: () => ({
         eq: () => ({
-          order: () => Promise.resolve({ data: [stay1, stay2], error: null }),
+          order: () => ({ abortSignal: () => Promise.resolve({ data: [stay1, stay2], error: null }) }),
         }),
       }),
     })

--- a/src/contexts/TripContext.test.tsx
+++ b/src/contexts/TripContext.test.tsx
@@ -56,7 +56,7 @@ describe('TripContext', () => {
   it('waits for authLoading=false before fetching', async () => {
     mockAuth.loading = true
     mockSupabase.from.mockReturnValue({
-      select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
+      select: () => ({ order: () => ({ abortSignal: () => Promise.resolve({ data: [], error: null }) }) }),
     })
 
     render(
@@ -76,7 +76,7 @@ describe('TripContext', () => {
     ]
 
     mockSupabase.from.mockReturnValue({
-      select: () => ({ order: () => Promise.resolve({ data: trips, error: null }) }),
+      select: () => ({ order: () => ({ abortSignal: () => Promise.resolve({ data: trips, error: null }) }) }),
     })
 
     render(
@@ -96,7 +96,7 @@ describe('TripContext', () => {
 
   it('getTripById returns undefined when not found', async () => {
     mockSupabase.from.mockReturnValue({
-      select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
+      select: () => ({ order: () => ({ abortSignal: () => Promise.resolve({ data: [], error: null }) }) }),
     })
 
     render(


### PR DESCRIPTION
## Summary
- Update 5 context test files to include `.abortSignal()` at the end of mock Supabase query chains (required since PR #234 added `useAbortController`)
- Fix real bug in `ShoppingContext.tsx`: `setLoading(false)` was missing in the no-trip branch of the `useEffect`, causing `loading` to stay `true` forever when no trip was active
- Add missing `functions.invoke` mock in `AuthContext.test.tsx` to prevent unhandled rejection from logger

## Test plan
- [x] `npm run type-check` passes clean
- [x] All 139 unit tests pass (was 130/139 before)
- [x] No production behavior changes (only test mocks + one loading state fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)