### PR TITLE
fix: balance sign, mobile stat grid, pie chart legend (#236 #237 #239)

### DIFF
--- a/src/components/ExpenseByCategoryChart.tsx
+++ b/src/components/ExpenseByCategoryChart.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts'
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
 import type { Expense } from '@/types/expense'
 import { convertToBaseCurrency } from '@/services/balanceCalculator'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -88,7 +88,7 @@ export function ExpenseByCategoryChart({ expenses, currency = 'EUR', exchangeRat
         <CardTitle>Expenses by Category</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={300}>
+        <ResponsiveContainer width="100%" height={260}>
           <PieChart>
             <Pie
               data={dataWithPercentages}
@@ -108,20 +108,27 @@ export function ExpenseByCategoryChart({ expenses, currency = 'EUR', exchangeRat
               ))}
             </Pie>
             <Tooltip content={<CustomTooltip />} />
-            <Legend
-              verticalAlign="bottom"
-              height={36}
-              formatter={(value, entry: any) => (
-                <span className="text-sm text-foreground">
-                  {value} ({new Intl.NumberFormat('en-US', {
-                    style: 'currency',
-                    currency: currency,
-                  }).format(entry.payload.value)})
-                </span>
-              )}
-            />
           </PieChart>
         </ResponsiveContainer>
+        <div className="flex flex-wrap gap-x-4 gap-y-2 mt-3 justify-center">
+          {dataWithPercentages.map((entry) => (
+            <div key={entry.name} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span
+                className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                style={{ backgroundColor: CATEGORY_COLORS[entry.name as keyof typeof CATEGORY_COLORS] }}
+              />
+              <span>{entry.name}</span>
+              <span className="font-medium text-foreground tabular-nums">
+                {new Intl.NumberFormat('en-US', {
+                  style: 'currency',
+                  currency,
+                  notation: 'compact',
+                  maximumFractionDigits: 1,
+                }).format(entry.value)}
+              </span>
+            </div>
+          ))}
+        </div>
       </CardContent>
     </Card>
   )

--- a/src/components/quick/QuickBalanceHero.tsx
+++ b/src/components/quick/QuickBalanceHero.tsx
@@ -35,7 +35,7 @@ export function QuickBalanceHero({ balance }: QuickBalanceHeroProps) {
       <p className={`text-4xl font-bold tabular-nums ${getBalanceColorClass(balance.balance)}`}>
         {isSettled
           ? formatBalance(0)
-          : formatBalance(Math.abs(balance.balance))
+          : formatBalance(balance.balance).replace(/^[+-]/, '')
         }
       </p>
       {balance.isFamily && (

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -91,11 +91,11 @@ export function DashboardPage() {
       </div>
 
       {/* Trip Overview Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
           <CardContent className="pt-6">
             <div className="text-sm text-muted-foreground mb-1">Total Expenses</div>
-            <div className="text-2xl font-bold text-foreground tabular-nums">
+            <div className="text-xl md:text-2xl font-bold text-foreground tabular-nums">
               {new Intl.NumberFormat('en-US', {
                 style: 'currency',
                 currency: currentTrip.default_currency,
@@ -110,7 +110,7 @@ export function DashboardPage() {
         <Card>
           <CardContent className="pt-6">
             <div className="text-sm text-muted-foreground mb-1">Participants</div>
-            <div className="text-2xl font-bold text-foreground tabular-nums">
+            <div className="text-xl md:text-2xl font-bold text-foreground tabular-nums">
               {currentTrip.tracking_mode === 'families'
                 ? families.length + participants.filter(p => p.family_id === null).length
                 : participants.length}
@@ -131,7 +131,7 @@ export function DashboardPage() {
         <Card>
           <CardContent className="pt-6">
             <div className="text-sm text-muted-foreground mb-1">Unsettled Balance</div>
-            <div className="text-2xl font-bold text-foreground tabular-nums">
+            <div className="text-xl md:text-2xl font-bold text-foreground tabular-nums">
               {new Intl.NumberFormat('en-US', {
                 style: 'currency',
                 currency: currentTrip.default_currency,
@@ -150,7 +150,7 @@ export function DashboardPage() {
         <Card>
           <CardContent className="pt-6">
             <div className="text-sm text-muted-foreground mb-1">Settlements</div>
-            <div className="text-2xl font-bold text-foreground tabular-nums">
+            <div className="text-xl md:text-2xl font-bold text-foreground tabular-nums">
               {settlements.length}
             </div>
             <div className="text-xs text-muted-foreground mt-1">


### PR DESCRIPTION
## Summary

- **#239** `QuickBalanceHero`: strip `+/-` prefix from the absolute balance display — "You owe €144.81" instead of "You owe +€144.81". The label already communicates direction.
- **#237** `DashboardPage`: stat cards now render in a 2×2 grid on mobile (`grid-cols-2`) instead of stacking 4 vertically; values downsized to `text-xl` on mobile so numbers fit narrow cards.
- **#236** `ExpenseByCategoryChart`: removed the fixed-height Recharts `<Legend>` (clips on mobile); replaced with a custom flex-wrap HTML legend below the chart using compact currency notation (`1.2K`); chart height reduced 300→260 to reclaim space.

Closes #236, Closes #237, Closes #239

## Test plan
- [ ] Quick mode trip page with negative balance: label shows "You owe €X" (no + sign)
- [ ] Quick mode trip page with positive balance: label shows "You are owed €X" (no + sign)
- [ ] Dashboard on mobile (≤767px): 4 stat cards appear as 2×2 grid, numbers readable
- [ ] Dashboard with multiple expense categories: legend wraps cleanly below chart, no clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)