### PR TITLE
fix: pill colors (#241), scan group picker (#242), cancel nav (#244), global scan shortcut

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,11 +3,12 @@ import React from 'react'
 import { useState } from 'react'
 import {
   Home, DollarSign, CreditCard, CalendarDays,
-  ShoppingCart, BarChart3, Settings2, MoreHorizontal
+  ShoppingCart, BarChart3, Settings2, MoreHorizontal, ScanLine
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
+import { useTripContext } from '@/contexts/TripContext'
 import { ParticipantProvider } from '@/contexts/ParticipantContext'
 import { ExpenseProvider } from '@/contexts/ExpenseContext'
 import { SettlementProvider } from '@/contexts/SettlementContext'
@@ -22,6 +23,8 @@ import { SignInButton } from '@/components/auth/SignInButton'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { ModeToggle } from '@/components/quick/ModeToggle'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
+import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
+import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
 import {
   Sheet,
   SheetContent,
@@ -50,7 +53,18 @@ export function Layout() {
   const location = useLocation()
   const { currentTrip, tripCode } = useCurrentTrip()
   const { user } = useAuth()
+  const { trips } = useTripContext()
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
+  const [scanContextOpen, setScanContextOpen] = useState(false)
+  const [scanCreateOpen, setScanCreateOpen] = useState(false)
+
+  const handleScanTap = () => {
+    if (trips.length === 0) {
+      setScanCreateOpen(true)
+    } else {
+      setScanContextOpen(true)
+    }
+  }
 
   const manageLabel = currentTrip?.event_type === 'event' ? 'Manage Event' : 'Manage Trip'
 
@@ -179,6 +193,13 @@ export function Layout() {
             )}
             <div className="flex items-center gap-2 flex-shrink-0">
               <ReportIssueButton onGradient={onGradient} />
+              <button
+                onClick={handleScanTap}
+                aria-label="Scan receipt"
+                className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
+              >
+                <ScanLine size={20} />
+              </button>
               <ModeToggle onGradient={onGradient} />
               {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
             </div>
@@ -197,6 +218,7 @@ export function Layout() {
                     <ShoppingProvider>
                       <ReceiptProvider>
                         <Outlet />
+                        <QuickScanCreateFlow open={scanCreateOpen} onOpenChange={setScanCreateOpen} />
                       </ReceiptProvider>
                     </ShoppingProvider>
                   </StayProvider>
@@ -361,6 +383,13 @@ export function Layout() {
           })}
         </nav>
       </aside>}
+
+      <QuickScanContextSheet
+        open={scanContextOpen}
+        onOpenChange={setScanContextOpen}
+        trips={trips}
+        onNewGroup={() => { setScanContextOpen(false); setScanCreateOpen(true) }}
+      />
 
       {/* Toast notifications */}
       <Toaster />

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, Link, useParams, useLocation } from 'react-router-dom'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, ScanLine } from 'lucide-react'
+import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { ParticipantProvider } from '@/contexts/ParticipantContext'
@@ -12,6 +13,9 @@ import { UserMenu } from '@/components/auth/UserMenu'
 import { SignInButton } from '@/components/auth/SignInButton'
 import { ModeToggle } from '@/components/quick/ModeToggle'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
+import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
+import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
+import { useTripContext } from '@/contexts/TripContext'
 import { Toaster } from '@/components/ui/toaster'
 import { getTripGradientPattern } from '@/services/tripGradientService'
 
@@ -20,6 +24,17 @@ export function QuickLayout() {
   const location = useLocation()
   const { currentTrip } = useCurrentTrip()
   const { user } = useAuth()
+  const { trips } = useTripContext()
+  const [scanContextOpen, setScanContextOpen] = useState(false)
+  const [scanCreateOpen, setScanCreateOpen] = useState(false)
+
+  const handleScanTap = () => {
+    if (trips.length === 0) {
+      setScanCreateOpen(true)
+    } else {
+      setScanContextOpen(true)
+    }
+  }
 
   const isInTrip = !!tripCode
   // On sub-pages (e.g. history), back goes to trip detail; on trip detail, back goes to /quick
@@ -87,6 +102,15 @@ export function QuickLayout() {
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
               <ReportIssueButton onGradient={onGradient} />
+              {isInTrip && (
+                <button
+                  onClick={handleScanTap}
+                  aria-label="Scan receipt"
+                  className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
+                >
+                  <ScanLine size={20} />
+                </button>
+              )}
               <ModeToggle onGradient={onGradient} />
               {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
             </div>
@@ -103,6 +127,7 @@ export function QuickLayout() {
                 <ShoppingProvider>
                   <ReceiptProvider>
                     <Outlet />
+                    <QuickScanCreateFlow open={scanCreateOpen} onOpenChange={setScanCreateOpen} />
                   </ReceiptProvider>
                 </ShoppingProvider>
               </MealProvider>
@@ -110,6 +135,13 @@ export function QuickLayout() {
           </ExpenseProvider>
         </ParticipantProvider>
       </main>
+
+      <QuickScanContextSheet
+        open={scanContextOpen}
+        onOpenChange={setScanContextOpen}
+        trips={trips}
+        onNewGroup={() => { setScanContextOpen(false); setScanCreateOpen(true) }}
+      />
 
       <Toaster />
     </div>

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -117,13 +117,7 @@ export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowP
   }
 
   const handleClose = () => {
-    if (createdTripCode) {
-      // If group was created, navigate to it before closing
-      onOpenChange(false)
-      navigate(`/t/${createdTripCode}/quick`)
-    } else {
-      onOpenChange(false)
-    }
+    onOpenChange(false)
     // Reset state after close animation
     setTimeout(() => {
       setStep('camera')

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -51,7 +51,8 @@ const CHIP_COLORS = [
 ]
 
 function getChipColor(index: number, assigned: boolean) {
-  return CHIP_COLORS[index % CHIP_COLORS.length][assigned ? 'on' : 'off']
+  if (!assigned) return 'bg-muted text-muted-foreground border border-border'
+  return CHIP_COLORS[index % CHIP_COLORS.length].on
 }
 
 
@@ -598,7 +599,7 @@ interface ItemRowProps {
 }
 
 function ItemRow({
-  index: _index,
+  index,
   item,
   participants,
   onNameChange,
@@ -610,7 +611,7 @@ function ItemRow({
   const allAssigned = participants.length > 0 && participants.every(p => item.assignedIds.has(p.id))
 
   return (
-    <div className="border border-border rounded-lg p-3 space-y-2">
+    <div className={`border border-border rounded-lg p-3 space-y-2 ${index % 2 !== 0 ? 'bg-muted/25' : ''}`}>
       {/* Name + Price */}
       <div className="flex gap-2 items-center">
         <Input

--- a/src/pages/QuickHomeScreen.tsx
+++ b/src/pages/QuickHomeScreen.tsx
@@ -59,12 +59,8 @@ export function QuickHomeScreen() {
     if (visibleTrips.length === 0) {
       // No groups — go straight to scan+create flow
       setScanCreateOpen(true)
-    } else if (visibleTrips.length === 1) {
-      // One group — navigate to it and open receipt capture there
-      const code = visibleTrips[0].trip.trip_code
-      navigate(`/t/${code}/quick`, { state: { openScan: true } })
     } else {
-      // Multiple groups — show picker
+      // 1+ groups — always show picker so user can choose or create new
       setScanContextOpen(true)
     }
   }


### PR DESCRIPTION
## Summary

- **#241 — ReceiptReviewSheet**: Unselected participant pills are now all the same neutral grey; only selected pills show a unique color. Item rows get alternating background (`bg-muted/25`) for visual separation.
- **#242 — QuickHomeScreen scan**: Always shows `QuickScanContextSheet` for 1+ groups (removed the single-group shortcut that bypassed the picker). The sheet already has a "New Group" button.
- **#244 — QuickScanCreateFlow cancel**: `handleClose` no longer navigates to the created group. Only "Done" / "Skip for now" navigate. Cancelling stays on the current page.
- **Global scan shortcut**: Added `ScanLine` icon button to `Layout` (always) and `QuickLayout` (only when inside a trip). Tapping opens the group picker or scan+create flow. `QuickScanCreateFlow` is rendered inside the existing `ReceiptProvider` tree so it has access to participant and receipt contexts.

## Test plan

- [ ] ReceiptReviewSheet: all unselected chips look neutral; selected show color
- [ ] ReceiptReviewSheet: alternating row backgrounds visible with 3+ items
- [ ] QuickHomeScreen with 1 group: tapping Scan opens group picker (not direct navigate)
- [ ] QuickScanCreateFlow: cancel at step 1, 2 or 3 stays on current page
- [ ] Full-mode any page: scan icon in header opens group picker
- [ ] Quick-mode group page: scan icon in header opens group picker
- [ ] Quick-mode home screen (`/quick`): no scan icon in header (home has its own CTA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)