### PR TITLE
fix: filter hidden groups from global scan context sheet (#250)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -25,6 +25,7 @@ import { ModeToggle } from '@/components/quick/ModeToggle'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
 import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
 import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
+import { getHiddenTripCodes } from '@/lib/mutedTripsStorage'
 import {
   Sheet,
   SheetContent,
@@ -54,12 +55,13 @@ export function Layout() {
   const { currentTrip, tripCode } = useCurrentTrip()
   const { user } = useAuth()
   const { trips } = useTripContext()
+  const visibleTrips = trips.filter(t => !getHiddenTripCodes().includes(t.trip_code))
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
   const [scanContextOpen, setScanContextOpen] = useState(false)
   const [scanCreateOpen, setScanCreateOpen] = useState(false)
 
   const handleScanTap = () => {
-    if (trips.length === 0) {
+    if (visibleTrips.length === 0) {
       setScanCreateOpen(true)
     } else {
       setScanContextOpen(true)
@@ -387,7 +389,7 @@ export function Layout() {
       <QuickScanContextSheet
         open={scanContextOpen}
         onOpenChange={setScanContextOpen}
-        trips={trips}
+        trips={visibleTrips}
         onNewGroup={() => { setScanContextOpen(false); setScanCreateOpen(true) }}
       />
 

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -16,6 +16,7 @@ import { ReportIssueButton } from '@/components/ReportIssueButton'
 import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
 import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
 import { useTripContext } from '@/contexts/TripContext'
+import { getHiddenTripCodes } from '@/lib/mutedTripsStorage'
 import { Toaster } from '@/components/ui/toaster'
 import { getTripGradientPattern } from '@/services/tripGradientService'
 
@@ -25,11 +26,12 @@ export function QuickLayout() {
   const { currentTrip } = useCurrentTrip()
   const { user } = useAuth()
   const { trips } = useTripContext()
+  const visibleTrips = trips.filter(t => !getHiddenTripCodes().includes(t.trip_code))
   const [scanContextOpen, setScanContextOpen] = useState(false)
   const [scanCreateOpen, setScanCreateOpen] = useState(false)
 
   const handleScanTap = () => {
-    if (trips.length === 0) {
+    if (visibleTrips.length === 0) {
       setScanCreateOpen(true)
     } else {
       setScanContextOpen(true)
@@ -139,7 +141,7 @@ export function QuickLayout() {
       <QuickScanContextSheet
         open={scanContextOpen}
         onOpenChange={setScanContextOpen}
-        trips={trips}
+        trips={visibleTrips}
         onNewGroup={() => { setScanContextOpen(false); setScanCreateOpen(true) }}
       />
 


### PR DESCRIPTION
## Summary

- `Layout.tsx` and `QuickLayout.tsx` were passing `trips` (all groups) to `QuickScanContextSheet`, so hidden groups showed up in the scan picker on non-home pages
- Now both layouts call `getHiddenTripCodes()` and filter before passing `visibleTrips`, matching `QuickHomeScreen`'s existing behaviour

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)