### PR TITLE
fix: iOS contact autofill in QuickParticipantPicker

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -286,6 +286,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
               value={name}
               onChange={e => setName(e.target.value)}
               className="flex-1"
+              autoComplete="section-participant name"
             />
             <Button type="submit" size="sm" disabled={adding || !name.trim()}>
               {adding ? '…' : 'Add'}
@@ -300,6 +301,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
               placeholder="Email (optional)"
               value={email}
               onChange={e => setEmail(e.target.value)}
+              autoComplete="section-participant email"
             />
           </div>
           {error && (


### PR DESCRIPTION
## Summary
- Adds `autoComplete="section-participant name"` to the Name input
- Adds `autoComplete="section-participant email"` to the Email input
- The shared `section-participant` prefix groups both fields as a logical contact unit — iOS fills both when a name suggestion is tapped

## Why
The Contact Picker API (`navigator.contacts`) is Android-only; iOS Safari never shipped it, so the "Add from Contacts" button is correctly hidden on iPhone. However, iOS's native contact autofill (keyboard suggestions from Address Book) can still be triggered via `autoComplete` — this was missing from the manual form, forcing users to type contacts by hand.

## Test plan
- [ ] `npm run type-check` passes clean ✅
- [ ] iOS Safari: focus the Name field → contact name suggestions appear above keyboard → tap a contact → Name and Email both fill
- [ ] Android: "Add from Contacts" button still works (untouched code path)
- [ ] Desktop: harmless browser autofill suggestions or ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)