### PR TITLE
feat: payment reminder + manage group in quick mode

### DIFF
--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -22,7 +22,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useToast } from '@/hooks/use-toast'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
-  ExternalLink, ArrowLeftRight, Loader2, RefreshCw, AlertCircle, Users
+  ExternalLink, ArrowLeftRight, Loader2, RefreshCw, AlertCircle, Users, Settings
 } from 'lucide-react'
 
 
@@ -281,6 +281,12 @@ export function QuickGroupDetailPage() {
           label="View expenses & payments"
           description="See transaction history"
           onClick={() => navigate(`/t/${currentTrip.trip_code}/quick/history`)}
+        />
+        <QuickActionButton
+          icon={Settings}
+          label="Manage group"
+          description="Edit settings & participants"
+          onClick={() => navigate(`/t/${currentTrip.trip_code}/manage`)}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- **#256 / #260**: Add "Remind" button to settlement transaction cards in `QuickSettlementSheet` for transactions where someone owes the current user money and has an email on file. Uses same inline-confirm pattern as full-mode `SettlementPlan`. Includes receipt item data in the reminder when available.
- **#267**: Add "Manage group" action button (⚙) to `QuickGroupDetailPage` that navigates to `/t/:tripCode/manage` — users can now edit settings and participants without switching to full mode.

## Test plan
- [ ] Open a quick mode group with someone who owes you money and has an email — "Remind" button should appear on that transaction card
- [ ] Confirm and send reminder — should get success feedback "Reminder sent to [name]"
- [ ] Transaction where you owe someone: no Remind button shown
- [ ] "Manage group" action button appears in quick group detail page, navigates to manage page

🤖 Generated with [Claude Code](https://claude.com/claude-code)