### PR TITLE
fix: mobile UI polish (cancel button, name wrap, settle labels, row colors)

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -83,7 +83,7 @@ export function QuickLayout() {
                     <ArrowLeft size={20} />
                   </Link>
                   <div className="min-w-0">
-                    <h1 className={`text-lg font-semibold truncate leading-tight ${onGradient ? 'text-white drop-shadow-md' : 'text-foreground'}`}>
+                    <h1 className={`text-base font-semibold line-clamp-2 leading-tight ${onGradient ? 'text-white drop-shadow-md' : 'text-foreground'}`}>
                       {currentTrip?.name}
                     </h1>
                     {currentTrip && (

--- a/src/components/TopExpensesList.tsx
+++ b/src/components/TopExpensesList.tsx
@@ -60,7 +60,7 @@ export function TopExpensesList({ expenses, participants, limit = 5, currency = 
           {topExpenses.map((expense, index) => (
             <div
               key={expense.id}
-              className="flex items-start justify-between p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+              className={`flex items-start justify-between p-3 rounded-lg hover:bg-muted/50 transition-colors ${index % 2 === 0 ? 'bg-muted/30' : 'bg-transparent'}`}
             >
               <div className="flex items-start gap-3 flex-1 min-w-0">
                 <div className="flex-shrink-0 w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center">

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -247,14 +247,26 @@ export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowP
       >
         {/* Sticky header */}
         <div className="px-6 py-4 border-b border-border shrink-0 flex items-center justify-between">
-          <SheetTitle className="flex items-center gap-2">
-            <ScanLine size={20} />
-            {step === 'camera' && 'Scan a Receipt'}
-            {step === 'scanning' && 'Reading receipt…'}
-            {step === 'participants' && (createdTripName ?? 'Add People')}
-          </SheetTitle>
+          <div className="flex items-center gap-2 min-w-0">
+            {/* X close button — always visible on all steps */}
+            <button
+              onClick={handleClose}
+              aria-label="Close"
+              className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors flex-shrink-0"
+            >
+              <X size={18} />
+            </button>
+            <SheetTitle className="flex items-center gap-2 truncate">
+              <ScanLine size={20} className="flex-shrink-0" />
+              <span className="truncate">
+                {step === 'camera' && 'Scan a Receipt'}
+                {step === 'scanning' && 'Reading receipt…'}
+                {step === 'participants' && (createdTripName ?? 'Add People')}
+              </span>
+            </SheetTitle>
+          </div>
           {step === 'participants' && (
-            <Button size="sm" onClick={handleDone} className="gap-1">
+            <Button size="sm" onClick={handleDone} className="gap-1 flex-shrink-0">
               Done
               <ChevronRight size={14} />
             </Button>

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -296,7 +296,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
       <SheetContent side="bottom" className="h-[85vh] overflow-y-auto">
         <SheetHeader className="mb-4">
           <SheetTitle>
-            {view === 'suggestions' ? 'Log a payment' : (
+            {view === 'suggestions' ? 'Settle up' : (
               <button
                 onClick={() => setView('suggestions')}
                 className="flex items-center gap-1.5 text-base font-semibold hover:text-primary transition-colors"
@@ -440,7 +440,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                           size="sm"
                           onClick={() => handleRecord(tx)}
                         >
-                          Record
+                          Settle
                         </Button>
                         {canRemind && !isConfirmingRemind && remindResult !== 'sent' && (
                           <Button
@@ -476,7 +476,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                 className="w-full"
                 onClick={handleRecordDifferent}
               >
-                Record a different payment
+                Record a custom payment
               </Button>
             </div>
           </div>

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -272,8 +272,8 @@ export function QuickGroupDetailPage() {
         />
         <QuickActionButton
           icon={CreditCard}
-          label="Log your payment"
-          description="Record a payment you made"
+          label="Settle up"
+          description="Record a payment between people"
           onClick={() => setSettlementOpen(true)}
         />
         <QuickActionButton


### PR DESCRIPTION
## Summary
- **#258**: Add X close button to `QuickScanCreateFlow` header on **all steps** (camera, scanning, participants) — previously only swipe-down could dismiss the sheet on steps 1–2
- **#259**: Replace `truncate` with `line-clamp-2` on event name in `QuickLayout` header so long event/trip names wrap to 2 lines instead of being cut off with ellipsis
- **#261**: Rename ambiguous labels throughout quick mode: "Log your payment" → "Settle up", "Log a payment" → "Settle up", "Record" → "Settle", "Record a different payment" → "Record a custom payment"
- **#262**: Alternate row background in `TopExpensesList` (even rows `bg-muted/30`, odd rows transparent) for visual separation between expense items

## Test plan
- [ ] Open scan flow → X button visible on camera step, scanning step, and participants step
- [ ] Tapping X on camera/participants step closes sheet without navigating
- [ ] Tapping X during scanning step closes sheet (trip already created — user can find it in groups list)
- [ ] Long event name in quick header wraps to 2 lines instead of truncating
- [ ] Quick group detail shows "Settle up" action button
- [ ] Opening settlement sheet shows "Settle up" as title, "Settle" on transaction buttons
- [ ] Dashboard top expenses list has alternating row colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)