### PR TITLE
fix: quick mode UX polish — gear icon, trip name contrast, settle label (#274 #275 #277)

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,5 +1,5 @@
-import { Outlet, Link, useParams, useLocation } from 'react-router-dom'
-import { ArrowLeft, ScanLine } from 'lucide-react'
+import { Outlet, Link, useParams, useLocation, useNavigate } from 'react-router-dom'
+import { ArrowLeft, ScanLine, Settings } from 'lucide-react'
 import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -23,6 +23,7 @@ import { getTripGradientPattern } from '@/services/tripGradientService'
 export function QuickLayout() {
   const { tripCode } = useParams<{ tripCode: string }>()
   const location = useLocation()
+  const navigate = useNavigate()
   const { currentTrip } = useCurrentTrip()
   const { user } = useAuth()
   const { trips } = useTripContext()
@@ -70,7 +71,7 @@ export function QuickLayout() {
                 />
               )
             })}
-            <div className="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent" />
+            <div className="absolute inset-0 bg-gradient-to-r from-black/50 to-transparent" />
           </>
         )}
 
@@ -83,7 +84,7 @@ export function QuickLayout() {
                     <ArrowLeft size={20} />
                   </Link>
                   <div className="min-w-0">
-                    <h1 className={`text-base font-semibold line-clamp-2 leading-tight ${onGradient ? 'text-white drop-shadow-md' : 'text-foreground'}`}>
+                    <h1 className={`text-base font-semibold line-clamp-2 leading-tight ${onGradient ? 'text-white' : 'text-foreground'}`} style={onGradient ? { textShadow: '0 1px 4px rgba(0,0,0,0.9)' } : undefined}>
                       {currentTrip?.name}
                     </h1>
                     {currentTrip && (
@@ -111,6 +112,15 @@ export function QuickLayout() {
                   className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
                 >
                   <ScanLine size={20} />
+                </button>
+              )}
+              {isInTrip && (
+                <button
+                  onClick={() => navigate(`/t/${tripCode}/manage`, { state: { fromQuick: true } })}
+                  aria-label="Manage group"
+                  className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
+                >
+                  <Settings size={20} />
                 </button>
               )}
               <ModeToggle onGradient={onGradient} />

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -302,7 +302,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                 className="flex items-center gap-1.5 text-base font-semibold hover:text-primary transition-colors"
               >
                 <ArrowLeft size={18} />
-                Back
+                Settlement plan
               </button>
             )}
           </SheetTitle>

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { Edit, Trash2, Info, X, Plus } from 'lucide-react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { Edit, Trash2, Info, X, Plus, ArrowLeft } from 'lucide-react'
 import { format } from 'date-fns'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useTripContext } from '@/contexts/TripContext'
@@ -40,6 +40,8 @@ import { StaySection } from '@/components/StaySection'
 export function ManageTripPage() {
   const { currentTrip, tripCode } = useCurrentTrip()
   const { updateTrip, deleteTrip } = useTripContext()
+  const location = useLocation()
+  const fromQuick = !!(location.state as any)?.fromQuick
   const { participants } = useParticipantContext()
   const { meals } = useMealContext()
   const { toast } = useToast()
@@ -227,6 +229,17 @@ export function ManageTripPage() {
 
   return (
     <div className="space-y-6">
+      {/* Back to Quick View */}
+      {fromQuick && (
+        <button
+          onClick={() => navigate(`/t/${tripCode}/quick`)}
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors -mb-2"
+        >
+          <ArrowLeft size={16} />
+          Back to Quick View
+        </button>
+      )}
+
       {/* Header */}
       <div>
         <h2 className="text-2xl font-bold text-foreground">Manage {entityLabel}</h2>

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -22,7 +22,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useToast } from '@/hooks/use-toast'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
-  ExternalLink, ArrowLeftRight, Loader2, RefreshCw, AlertCircle, Users, Settings
+  ExternalLink, ArrowLeftRight, Loader2, RefreshCw, AlertCircle, Users
 } from 'lucide-react'
 
 
@@ -281,12 +281,6 @@ export function QuickGroupDetailPage() {
           label="View expenses & payments"
           description="See transaction history"
           onClick={() => navigate(`/t/${currentTrip.trip_code}/quick/history`)}
-        />
-        <QuickActionButton
-          icon={Settings}
-          label="Manage group"
-          description="Edit settings & participants"
-          onClick={() => navigate(`/t/${currentTrip.trip_code}/manage`)}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- **#277**: Remove "Manage group" action card from quick detail page; replace with gear icon (⚙) in the QuickLayout header (visible only when inside a trip). Tapping navigates to `/manage` with `fromQuick` state. ManageTripPage now shows a "← Back to Quick View" link at the top when reached from quick mode, keeping users oriented.
- **#275**: Trip name contrast — increase left gradient overlay from 30% to 50% opacity; replace `drop-shadow-md` filter with inline `textShadow` for precise contrast on all gradient colors on all browsers.
- **#274**: Settlement form back button renamed from "Back" → "Settlement plan" so users understand what they're returning to.

## Test plan
- [ ] Quick detail page: "Manage group" action card is gone
- [ ] Quick detail page: gear icon appears in header (next to scan); tap navigates to `/manage`
- [ ] ManageTripPage: "← Back to Quick View" link visible when reached via gear icon, not visible when reached via normal full-mode navigation
- [ ] Trip with gradient header: name is legible on mobile Chrome/Safari with various gradient colors
- [ ] Settle up sheet: form-view back button reads "Settlement plan" not "Back"

🤖 Generated with [Claude Code](https://claude.com/claude-code)