### PR TITLE
fix: two-row QuickLayout header — full trip name + coral back button

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -75,63 +75,74 @@ export function QuickLayout() {
           </>
         )}
 
-        <div className="relative max-w-lg mx-auto px-4 py-3">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3 min-w-0">
-              {isInTrip ? (
-                <>
-                  <Link to={backTo} className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}>
-                    <ArrowLeft size={20} />
-                  </Link>
-                  <div className="min-w-0">
-                    <h1 className={`text-base font-semibold line-clamp-2 leading-tight ${onGradient ? 'text-white' : 'text-foreground'}`} style={onGradient ? { textShadow: '0 1px 4px rgba(0,0,0,0.9)' } : undefined}>
-                      {currentTrip?.name}
+        <div className="relative max-w-lg mx-auto px-4">
+          <div className="flex flex-col">
+            {/* Row 1: back/logo + trip name (full width) + avatar */}
+            <div className="flex items-center justify-between py-3">
+              <div className="flex items-center gap-3 min-w-0">
+                {isInTrip ? (
+                  <>
+                    <Link to={backTo} className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}>
+                      <ArrowLeft size={20} />
+                    </Link>
+                    <div className="min-w-0">
+                      <h1 className={`text-base font-semibold line-clamp-2 leading-tight ${onGradient ? 'text-white' : 'text-foreground'}`} style={onGradient ? { textShadow: '0 1px 4px rgba(0,0,0,0.9)' } : undefined}>
+                        {currentTrip?.name}
+                      </h1>
+                      {currentTrip && (
+                        <p className={`text-xs leading-tight ${onGradient ? 'text-white/60' : 'text-muted-foreground'}`}>
+                          {currentTrip.event_type === 'event' ? 'Event' : 'Trip'}
+                        </p>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <img src="/logo.png" alt="Spl1t" className="h-8 w-8 rounded-full" />
+                    <h1 className="text-lg font-semibold text-foreground">
+                      Spl1t
                     </h1>
-                    {currentTrip && (
-                      <p className={`text-xs leading-tight ${onGradient ? 'text-white/60' : 'text-muted-foreground'}`}>
-                        {currentTrip.event_type === 'event' ? 'Event' : 'Trip'}
-                      </p>
-                    )}
                   </div>
-                </>
-              ) : (
-                <div className="flex items-center gap-2">
-                  <img src="/logo.png" alt="Spl1t" className="h-8 w-8 rounded-full" />
-                  <h1 className="text-lg font-semibold text-foreground">
-                    Spl1t
-                  </h1>
-                </div>
-              )}
+                )}
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                {!isInTrip && (
+                  <>
+                    <ReportIssueButton onGradient={onGradient} />
+                    <ModeToggle onGradient={onGradient} />
+                  </>
+                )}
+                {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
+              </div>
             </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <ReportIssueButton onGradient={onGradient} />
-              {isInTrip && (
+
+            {/* Row 2: action icons — only on trip detail page, not sub-pages */}
+            {isInTrip && !isSubPage && (
+              <div className="flex items-center justify-end gap-1 pb-1.5">
+                <ReportIssueButton onGradient={onGradient} />
                 <button
                   onClick={handleScanTap}
                   aria-label="Scan receipt"
-                  className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
+                  className={`p-1.5 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
                 >
-                  <ScanLine size={20} />
+                  <ScanLine size={18} />
                 </button>
-              )}
-              {isInTrip && (
                 <button
                   onClick={() => navigate(`/t/${tripCode}/manage`, { state: { fromQuick: true } })}
                   aria-label="Manage group"
-                  className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
+                  className={`p-1.5 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
                 >
-                  <Settings size={20} />
+                  <Settings size={18} />
                 </button>
-              )}
-              <ModeToggle onGradient={onGradient} />
-              {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
-            </div>
+                <ModeToggle onGradient={onGradient} />
+              </div>
+            )}
           </div>
         </div>
       </header>
 
-      {/* Main content */}
-      <main className="pt-16">
+      {/* Main content — extra top padding when two-row header is active */}
+      <main className={isInTrip && !isSubPage ? 'pt-[96px]' : 'pt-16'}>
         <ParticipantProvider>
           <ExpenseProvider>
             <SettlementProvider>

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -231,13 +231,15 @@ export function ManageTripPage() {
     <div className="space-y-6">
       {/* Back to Quick View */}
       {fromQuick && (
-        <button
+        <Button
+          variant="outline"
+          size="sm"
           onClick={() => navigate(`/t/${tripCode}/quick`)}
-          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors -mb-2"
+          className="gap-1.5 border-primary text-primary hover:bg-primary hover:text-primary-foreground"
         >
-          <ArrowLeft size={16} />
+          <ArrowLeft size={14} />
           Back to Quick View
-        </button>
+        </Button>
       )}
 
       {/* Header */}


### PR DESCRIPTION
## Problem

PR #278 added a gear icon to `QuickLayout`'s header, pushing the right-side icons to 5 total (Bug, Scan, Gear, ModeToggle, Avatar). On mobile this severely truncated the trip name ("The I..." instead of the full name). The "← Back to Quick View" link on `ManageTripPage` was also low-contrast muted text, easy to miss.

## Fix 1 — Two-row header when inside a trip

**`src/components/QuickLayout.tsx`**

Switches to a two-row header when `isInTrip && !isSubPage`:

```
Row 1: [←]  Trip Name (full width)                    [Avatar]
Row 2 (trip detail only):         [Bug][Scan][⚙][⚡/🔀]
```

- Row 1: trip name gets the full available width — no truncation
- Row 2: compact action strip (`size={18}`, `p-1.5`) right-aligned
- Sub-pages (e.g. history): single-row, no action icons
- Home screen (`/quick`): unchanged single-row (Bug, ModeToggle, Avatar)
- `<main>` padding: `pt-[96px]` for two-row header, `pt-16` otherwise

## Fix 2 — Prominent coral "Back to Quick View" button

**`src/pages/ManageTripPage.tsx`**

Replaces the plain muted `<button>` with a shadcn `<Button variant="outline">` styled with the primary coral colour — visually distinct and clearly tappable.

## Verification
- [ ] Trip name gets full width on Row 1 — no truncation on long names
- [ ] Row 2 shows Bug, Scan, Gear, ModeToggle — all tappable
- [ ] Sub-pages (history): single-row, no Row 2
- [ ] Home screen (`/quick`): single-row unchanged
- [ ] ManageTripPage: coral outline "Back to Quick View" button visible
- [ ] `npm run type-check` passes clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)