### PR TITLE
fix: harden session health — drop 403 from auth-error, add expiry guard and cooldown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,7 @@ Vitest + Testing Library. Run with `npm test`. 139 tests covering contexts, hook
 | Amount input rejects comma on iOS | European locale decimal | `inputMode="decimal"` + `replace(',', '.')` |
 | Duplicate items in shopping list | Real-time subscription fires on own inserts | Existence check before adding to state |
 | All queries freeze after token refresh | Auth lock deadlock — `onAuthStateChange` callback `await`ed DB queries | **Never** `await` Supabase queries inside `onAuthStateChange`. Defer with `setTimeout(fn, 0)`. See below. |
+| 403 triggers token refresh | `sessionHealthBus` emitted `auth-error` on 403 | Only emit `auth-error` on 401; 403 is RLS/permissions |
 
 ---
 

--- a/DIAGNOSIS.md
+++ b/DIAGNOSIS.md
@@ -104,3 +104,10 @@ The Supabase auth client holds a lock during `_notifyAllSubscribers`, which `awa
 Remove `await`ed Supabase DB queries from the `onAuthStateChange` callback. Defer profile operations to `setTimeout(fn, 0)` so they execute in the next macrotask, after the auth lock is released.
 
 For `TOKEN_REFRESHED` events specifically, no profile fetch is needed at all — the user data hasn't changed, only the access token.
+
+## Secondary fixes (PR #288)
+
+- 403 responses no longer trigger `auth-error` bus event (permissions issue, not token expiry)
+- `auth-error` handler now checks token expiry before attempting refresh — a 401 with a valid token (e.g. RLS rejection, race condition) is logged and ignored
+- 30-second cooldown added between refresh attempts to prevent rapid sequential calls
+- `updateBankDetails` timeout reduced from 35s to 10s (consistent with other contexts)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 # PLAN.md — Spl1t Feature Planning Document
 
 > **Living document.** Update at the start and end of every session.
-> Last updated: 2026-02-23 (Phases 1–6 ✅ done; iOS user issue triage PRs #268–#278, 15 issues resolved; auth deadlock fix; quick header grid strip PR #285)
+> Last updated: 2026-02-23 (Phases 1–6 ✅ done; iOS user issue triage PRs #268–#278, 15 issues resolved; auth deadlock fix; auth-error hardening PR #288)
 
 ---
 
@@ -543,6 +543,7 @@ Extends payment reminder emails with receipt data. PR #213 attached JPEG images;
 | 2026-02-23 | Header declutter + back button | PR #280: QuickLayout switched to two-row header when isInTrip && !isSubPage — Row 1 gives trip name full horizontal width (only avatar on right), Row 2 is a compact action strip (Bug, Scan, Gear, ModeToggle, size=18 p-1.5). Sub-pages and home screen keep single-row. Main padding pt-[96px] for two-row, pt-16 otherwise. ManageTripPage 'Back to Quick View' replaced with coral-outlined Button (border-primary text-primary hover:bg-primary). |
 | 2026-02-23 | Auth deadlock fix | **Root cause**: `onAuthStateChange` callback in `AuthContext.tsx` `await`ed Supabase DB queries (`fetchProfile`/`upsertProfile`) while the Supabase auth lock was held. Every PostgREST request calls `getSession()` which re-acquires the same lock → circular deadlock. Triggered after any token refresh (manual or auto). **Fix**: made `onAuthStateChange` callback synchronous — profile upsert deferred to `setTimeout(0)`, `TOKEN_REFRESHED` profile fetch removed (user data unchanged). Added `debugLogger.ts` (`localStorage.setItem('spl1t_debug','true')`) for production diagnostics. Auth safety rule added to CLAUDE.md. Full analysis in `DIAGNOSIS.md`. Files: `src/contexts/AuthContext.tsx`, `src/hooks/useSessionHealth.ts`, `src/lib/debugLogger.ts`, `DIAGNOSIS.md`, `CLAUDE.md`. |
 | 2026-02-23 | Quick header grid strip | PR #285 (issue #282): replaced right-aligned bare icon row in QuickLayout two-row header with a structured `grid-cols-3` ghost-pill action bar — **Scan / Manage / Full view** — each with 14px icon + 11px label. Removed `ReportIssueButton` from header entirely. `Full view` pill calls `setMode('full')` + navigates to expenses. Hairline `border-t` divider between rows; `bg-white/10` pills on gradients, `bg-muted` on plain bg. Main padding `pt-[96px]` → `pt-[108px]`. Home screen (`!isInTrip`) row 1: `ModeToggle` + avatar only. |
+| 2026-02-23 | Auth-error hardening | PR #288: (1) 403 no longer emits `auth-error` — only 401 triggers session health check; (2) `auth-error` bus handler checks `isTokenExpired()` before attempting refresh — valid-token 401s (RLS, race conditions) are logged and skipped; (3) 30s cooldown between refresh attempts via `lastRefreshAttemptRef`; (4) `updateBankDetails` timeout 35s→10s for consistency. |
 
 ---
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -185,7 +185,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           bank_iban: iban || null,
         })
         .eq('id', user.id),
-      35000,
+      10000,
       'Saving bank details timed out. Please check your connection and try again.'
     )
 

--- a/src/hooks/useSessionHealth.ts
+++ b/src/hooks/useSessionHealth.ts
@@ -19,6 +19,7 @@ export function useSessionHealth(session: Session | null) {
   const [isExpired, setIsExpired] = useState(false)
   const lastHiddenAt = useRef<number>(0)
   const refreshingRef = useRef(false)
+  const lastRefreshAttemptRef = useRef<number>(0)
 
   // Attempt a silent token refresh before showing the overlay.
   // If the refresh succeeds, the user never sees the stale-session overlay.
@@ -32,6 +33,16 @@ export function useSessionHealth(session: Session | null) {
   const tryRefreshThenExpire = useCallback(async () => {
     if (!session) return
     if (!isTokenExpired(session)) return
+
+    // Cooldown: at most one refresh attempt per 30 seconds
+    const now = Date.now()
+    if (now - lastRefreshAttemptRef.current < 30_000) {
+      logger.info('Session health: refresh cooldown active — skipping', {
+        msUntilNextAllowed: 30_000 - (now - lastRefreshAttemptRef.current),
+      })
+      return
+    }
+    lastRefreshAttemptRef.current = now
 
     // Prevent concurrent refresh attempts
     if (refreshingRef.current) return
@@ -82,6 +93,14 @@ export function useSessionHealth(session: Session | null) {
 
     // --- Bus listeners ---
     const offAuthError = sessionHealthBus.on('auth-error', () => {
+      if (!session) return
+      if (!isTokenExpired(session)) {
+        logger.warn('Session health: 401 received but token not expired — skipping refresh', {
+          expires_at: session.expires_at,
+          now: Math.floor(Date.now() / 1000),
+        })
+        return
+      }
       logger.warn('Session health: auth error detected from API — attempting silent refresh')
       tryRefreshThenExpire()
     })

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -43,7 +43,8 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
           // Emit session health events for non-auth API calls
           const isAuthEndpoint = url.includes('/auth/')
           if (!isAuthEndpoint) {
-            if (response.status === 401 || response.status === 403) {
+            if (response.status === 401) {
+              // 403 intentionally excluded — it's an RLS/permissions issue, not token expiry
               sessionHealthBus.emit('auth-error')
             } else if (response.ok) {
               sessionHealthBus.emit('api-success')


### PR DESCRIPTION
## Summary

- **403 no longer triggers auth-error**: Only 401 responses emit the `auth-error` bus event. 403 is an RLS/permissions issue — refreshing the token won't fix it.
- **Expiry guard on auth-error handler**: When a 401 arrives but the token isn't expired, the refresh is skipped and the event is logged. Prevents unnecessary refresh churn from RLS rejections, race conditions, or network blips.
- **30-second cooldown**: `lastRefreshAttemptRef` prevents rapid sequential refresh attempts even when the token is genuinely expired.
- **`updateBankDetails` timeout 35s → 10s**: Consistent with the 10–15s standard used across all other contexts.

## Test plan

- [x] `npm run type-check` passes clean
- [x] `npm test` — 139/139 tests pass
- [ ] Fresh load → submit expense → works
- [ ] Simulate 401 with valid token (RLS rejection) → no refresh loop in logs
- [ ] Simulate expired token → refresh fires once, then cooldown prevents immediate retry
- [ ] Bank details save → completes within 10s or shows timeout error

🤖 Generated with [Claude Code](https://claude.com/claude-code)