### PR TITLE
fix: dashboard duplicate name + members chip position (#294, #283)

### DIFF
--- a/src/components/quick/QuickBalanceHero.tsx
+++ b/src/components/quick/QuickBalanceHero.tsx
@@ -19,7 +19,7 @@ export function QuickBalanceHero({ balance }: QuickBalanceHeroProps) {
 
   return (
     <motion.div
-      className="text-center py-8 mb-6"
+      className="text-center py-8 mb-2"
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.3 }}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -68,7 +68,6 @@ export function DashboardPage() {
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold text-foreground">Dashboard</h2>
-          <p className="text-sm text-muted-foreground mt-1">{currentTrip.name}</p>
         </div>
         <div className="flex gap-2">
           <ShareTripDialog

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -176,16 +176,18 @@ export function QuickGroupDetailPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="relative">
+        <div>
           <QuickBalanceHero balance={myBalance} />
           {balanceCalc.balances.length > 0 && (
-            <button
-              onClick={() => setMembersOpen(true)}
-              className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-background/80 backdrop-blur-sm border border-border text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <Users size={13} />
-              <span>{balanceCalc.balances.length}</span>
-            </button>
+            <div className="flex justify-center -mt-1 mb-5">
+              <button
+                onClick={() => setMembersOpen(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-muted/60 border border-border text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <Users size={13} />
+                <span>{balanceCalc.balances.length} members</span>
+              </button>
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

- **#294**: Dashboard was showing the trip name twice — once in the Layout header gradient and again as a subtitle under the "Dashboard" heading in the page body. Removed the redundant subtitle.
- **#283**: Members count chip was `absolute top-3 right-3` overlapping the balance hero. Moved to centered document flow directly below the balance amount with a "members" label. Reduced `QuickBalanceHero` bottom margin from `mb-6` to `mb-2` so it sits close to the balance text.

## Test plan
- [ ] Dashboard: trip name appears only in header, not duplicated in page body
- [ ] Quick mode group detail: members chip appears centered below the balance amount (not top-right corner)
- [ ] Tapping the chip still opens `QuickGroupMembersSheet`
- [ ] `npm run type-check` passes ✅

Closes #294
Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)