### PR TITLE
fix: X icon on quick mode sub-pages for consistent dismiss UX (#289)

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Link, useParams, useLocation, useNavigate } from 'react-router-dom'
-import { ArrowLeft, ScanLine, Settings, LayoutGrid } from 'lucide-react'
+import { ArrowLeft, X, ScanLine, Settings, LayoutGrid } from 'lucide-react'
 import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -85,7 +85,7 @@ export function QuickLayout() {
                 {isInTrip ? (
                   <>
                     <Link to={backTo} className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}>
-                      <ArrowLeft size={20} />
+                      {isSubPage ? <X size={20} /> : <ArrowLeft size={20} />}
                     </Link>
                     <div className="min-w-0">
                       <h1 className={`text-base font-semibold line-clamp-2 leading-tight ${onGradient ? 'text-white' : 'text-foreground'}`} style={onGradient ? { textShadow: '0 1px 4px rgba(0,0,0,0.9)' } : undefined}>


### PR DESCRIPTION
## Summary

Quick mode had two different back/close affordances:
- Sub-pages (Expenses & Payments history) showed a `←` back arrow in the layout header
- Expense/settlement sheets showed a `✕` close button (from shadcn `SheetContent`)

Users found this inconsistent. Fix: sub-pages (`isSubPage = true`) now show `✕` instead of `←`. The trip detail page still uses `←` (it's navigating home, not dismissing an overlay).

All "exit" actions in quick mode now use the same `✕` icon.

## Test plan
- [ ] Quick history page (`/t/:code/quick/history`): header shows `✕` (was `←`)
- [ ] Quick trip detail page (`/t/:code/quick`): header still shows `←` back to My Groups
- [ ] Tapping `✕` on history page navigates back to trip detail (correct)
- [ ] Expense wizard sheet: still shows shadcn `✕` close (unchanged)
- [ ] `npm run type-check` passes ✅

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)