### PR TITLE
fix: restore trips SELECT policy — URL is the access token

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -66,12 +66,12 @@
 
 ### FINDING-4: Trips table RLS policy allows all reads — admin page is security theater
 
-- **Status: PARTIALLY RESOLVED** — Migration 026 replaces the single `FOR ALL USING (true)` policy with per-operation policies: INSERT restricted to authenticated users, UPDATE/DELETE restricted to trip creator. SELECT remains `USING (true)` because the shared link flow requires anonymous read access (TripContext fetches all trips for anon users). Full read restriction requires refactoring the anonymous query to filter by `trip_code` at the DB level.
+- **Status: CORRECTED** — The security session migration incorrectly restricted SELECT in addition to INSERT/UPDATE/DELETE. A follow-up migration 027 (PR #314) drops the SELECT restrictions and restores `USING (true)`. INSERT/UPDATE/DELETE restrictions to trip creator are retained. The app's access model (URL = access token) is now documented in CLAUDE.md under "Access Model — Core Design Rule" to prevent this class of regression.
 - **Area:** 10 (adminAuth)
 - **File(s):** `supabase/migrations/001_initial_schema.sql` (RLS policy: `USING (true)`)
 - **Description:** The trips table RLS policy allows **all** operations to **all** users. Every regular user already has full read access to all trips via `supabase.from('trips').select('*')`. The admin page protects a UI view, not the underlying data.
 - **Risk:** Any authenticated user (or anyone with the public anon key) can query all trips in the database. Trip codes, names, and owner information are exposed.
-- **Recommended fix:** Tighten trips RLS so users can only see trips they created or participate in. If a global admin view is needed, use a service role key from a server-side edge function.
+- **Recommended fix:** ~~Tighten trips RLS so users can only see trips they created or participate in.~~ **CONFLICTS WITH ACCESS MODEL** — this recommendation was incorrect. The app uses trip_code URLs as access tokens; restricting SELECT breaks shared link access for every trip. The correct approach is SELECT USING (true) on trips, with admin views powered by a service role key from a server-side edge function. See CLAUDE.md "Access Model — Core Design Rule".
 
 ### FINDING-5: All 4 edge functions lack JWT verification — callable by anyone with the public anon key
 
@@ -491,7 +491,7 @@
 1. **FINDING-5:** ✅ JWT verification on all 4 edge functions + shared `_shared/auth.ts`
 2. **FINDING-6:** ✅ HTML-escape user strings in email templates (`escapeHtml()`)
 3. **FINDING-2/3/43:** ✅ Admin auth replaced with Supabase user ID allowlist
-4. **FINDING-4:** ✅ (partial) Trips RLS: writes restricted to creator; reads still open for shared links
+4. **FINDING-4:** ✅ Trips RLS: writes restricted to creator; SELECT restored to USING (true) — URL is the access token
 5. **FINDING-16:** ✅ Client-side 5MB + server-side 10MB image size limits
 6. **FINDING-20/42:** ✅ Ownership check + idempotency guard in process-receipt
 7. **FINDING-41:** ✅ CORS restricted to `https://split.xtian.me` on all edge functions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,47 @@ git branch -d fix/description
 
 ---
 
+## Access Model — Core Design Rule
+
+**Trip URL = access token. Never restrict SELECT on the trips table.**
+
+The app's security model is based on trip_code obscurity, not auth.
+Anyone with the URL (/t/:tripCode) can read and participate in a trip —
+authenticated or not. Authentication unlocks personal features only.
+
+Capability tiers:
+
+Unauthenticated (has URL):
+- Full read access to all trip data
+- Add/edit expenses, settlements, shopping items, meals, activities, stays
+
+Authenticated:
+- Everything above
+- "This is me" participant linking → personal balance summary
+- View bank account details (for settling up)
+- Submit feedback / bug reports
+
+RLS rules that must be maintained on the trips table:
+- SELECT: USING (true) — open to all, authenticated and anonymous
+- INSERT: restricted to authenticated users (auth.uid() IS NOT NULL)
+- UPDATE: restricted to trip creator (auth.uid() = created_by)
+- DELETE: restricted to trip creator (auth.uid() = created_by)
+
+Never add participant-based or owner-based SELECT restrictions to trips.
+If you believe a SELECT restriction is needed for security, stop and
+discuss it first — it will break shared link access for every trip
+in the system.
+
+Features that are auth-gated (bank details, personal balance, feedback)
+are gated in the UI and edge functions, not at the RLS level.
+
+Common pitfall: adding SELECT RLS that looks correct in isolation
+(e.g. "users can only see their own trips") but breaks the shared
+link flow entirely. The trip_code in the URL is the only access
+control needed for reads.
+
+---
+
 ## Architecture
 
 ### App Modes (Quick vs Full)

--- a/supabase/migrations/027_restore_trips_select.sql
+++ b/supabase/migrations/027_restore_trips_select.sql
@@ -1,0 +1,24 @@
+-- Migration 027: Restore open SELECT on trips table
+--
+-- Context: The security migration (026) was intended to keep SELECT open
+-- (USING (true)) while restricting INSERT/UPDATE/DELETE. However, the
+-- production database ended up with restrictive SELECT policies that broke
+-- the app's core access model: the URL is the access token.
+--
+-- This migration drops ALL SELECT policies on trips and restores a single
+-- open SELECT policy. INSERT/UPDATE/DELETE policies from migration 026 are
+-- left untouched — those correctly restrict writes to authenticated/creator.
+--
+-- See CLAUDE.md "Access Model — Core Design Rule" for the full rationale.
+
+-- Drop any SELECT policies that may exist (cover all possible names)
+DROP POLICY IF EXISTS "trips_select" ON trips;
+DROP POLICY IF EXISTS "trips_select_own" ON trips;
+DROP POLICY IF EXISTS "trips_select_participant" ON trips;
+DROP POLICY IF EXISTS "trips_select_by_code" ON trips;
+DROP POLICY IF EXISTS "trips_select_all" ON trips;
+
+-- Restore open SELECT — anyone (authenticated or anonymous) can read trips
+CREATE POLICY "trips_select_all" ON trips
+  FOR SELECT
+  USING (true);


### PR DESCRIPTION
## Summary

- **Migration 027**: Drops all SELECT policies on the `trips` table and restores `USING (true)`. The security session migration (026) was intended to keep SELECT open while restricting INSERT/UPDATE/DELETE, but production ended up with a restrictive SELECT that broke shared link access — trips created by other users returned "trip not found"
- **CLAUDE.md**: New "Access Model — Core Design Rule" section documenting the URL-based access model, capability tiers (unauthenticated vs authenticated), and the RLS rules that must be maintained on trips
- **AUDIT.md**: FINDING-4 status updated from PARTIALLY RESOLVED to CORRECTED; original recommendation to restrict SELECT flagged as conflicting with the access model

### Related tables checked
All related tables (expenses, settlements, participants, families, meals, shopping_items, activities, stays, meal_shopping_items) retain their original `FOR ALL USING (true) WITH CHECK (true)` policies — unauthenticated users can INSERT into all of them, which is correct per the access model.

### Migration applied
Migration 027 has been pushed to the production Supabase project. The `DROP POLICY IF EXISTS` confirmed that only `trips_select` existed (the others — `trips_select_own`, `trips_select_participant`, `trips_select_by_code`, `trips_select_all` — did not exist).

## Test plan
- [ ] Open a trip URL created by another user while signed in → must load
- [ ] Open a trip URL while signed out → must load
- [ ] Add an expense while signed out → must succeed
- [ ] Try to delete someone else's trip while signed out → must fail
- [ ] Try to delete someone else's trip while signed in → must fail
- [ ] Confirm bank details not visible to unauthenticated users (UI gate)
- [x] `npm run type-check` — passes clean
- [x] `npm test` — all 139 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)