### PR TITLE
fix: authenticated users can see trips via shared URL

### DIFF
--- a/src/contexts/TripContext.test.tsx
+++ b/src/contexts/TripContext.test.tsx
@@ -33,7 +33,7 @@ vi.mock('@/lib/tripCodeGenerator', () => ({
 }))
 
 function TestConsumer() {
-  const { trips, loading, error, getTripById, getTripByCode } = useTripContext()
+  const { trips, loading, error, getTripById, getTripByCode, ensureTripLoaded } = useTripContext()
   const trip1 = getTripById('trip-1')
   const tripByCode = getTripByCode('summer-trip-Ab1234')
   return (
@@ -43,6 +43,7 @@ function TestConsumer() {
       <span data-testid="count">{trips.length}</span>
       <span data-testid="trip1">{trip1?.name ?? 'null'}</span>
       <span data-testid="tripByCode">{tripByCode?.name ?? 'null'}</span>
+      <span data-testid="ensureTripLoaded">{typeof ensureTripLoaded}</span>
     </div>
   )
 }

--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -13,6 +13,7 @@ interface TripContextType {
   error: string | null
   getTripById: (id: string) => Event | undefined
   getTripByCode: (tripCode: string) => Event | undefined
+  ensureTripLoaded: (tripCode: string) => Promise<Event | null>
   createTrip: (input: CreateEventInput) => Promise<Event | null>
   updateTrip: (id: string, input: UpdateEventInput) => Promise<boolean>
   deleteTrip: (id: string) => Promise<boolean>
@@ -90,6 +91,34 @@ export function TripProvider({ children }: { children: ReactNode }) {
   // Get trip by code
   const getTripByCode = (tripCode: string) => {
     return trips.find(trip => trip.trip_code === tripCode)
+  }
+
+  // Fetch a single trip by code and add it to the local array.
+  // Used when an authenticated user navigates to a trip they didn't create
+  // and aren't a participant of — URL is the access token.
+  const ensureTripLoaded = async (tripCode: string): Promise<Event | null> => {
+    const existing = trips.find(t => t.trip_code === tripCode)
+    if (existing) return existing
+
+    try {
+      const { data, error: fetchError } = await withTimeout<any>(
+        (supabase as any).from('trips').select('*').eq('trip_code', tripCode).maybeSingle().abortSignal(newSignal()),
+        15000,
+        'Loading trip timed out.'
+      )
+      if (fetchError) throw fetchError
+      if (!data) return null
+
+      const trip = data as unknown as Event
+      setTrips(prev => {
+        if (prev.some(t => t.id === trip.id)) return prev
+        return [...prev, trip]
+      })
+      return trip
+    } catch (err) {
+      logger.error('Failed to fetch trip by code', { tripCode, error: err instanceof Error ? err.message : String(err) })
+      return null
+    }
   }
 
   // Create new trip
@@ -248,6 +277,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
     error,
     getTripById,
     getTripByCode,
+    ensureTripLoaded,
     createTrip,
     updateTrip,
     deleteTrip,

--- a/src/hooks/useCurrentTrip.test.tsx
+++ b/src/hooks/useCurrentTrip.test.tsx
@@ -14,6 +14,7 @@ vi.mock('@/contexts/TripContext', () => ({
     trips,
     loading: false,
     getTripByCode: (code: string) => trips.find(t => t.trip_code === code),
+    ensureTripLoaded: vi.fn().mockResolvedValue(null),
   }),
 }))
 

--- a/src/hooks/useCurrentTrip.ts
+++ b/src/hooks/useCurrentTrip.ts
@@ -1,13 +1,23 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTripContext } from '@/contexts/TripContext'
 import { addToMyTrips } from '@/lib/myTripsStorage'
 
 export function useCurrentTrip() {
   const { tripCode } = useParams<{ tripCode: string }>()
-  const { getTripByCode, loading } = useTripContext()
+  const { getTripByCode, loading, ensureTripLoaded } = useTripContext()
+  const [fallbackLoading, setFallbackLoading] = useState(false)
 
   const currentTrip = tripCode ? getTripByCode(tripCode) : null
+
+  // Fallback: if trip not in local array (authenticated user viewing someone else's trip),
+  // fetch it directly by trip_code — URL is the access token
+  useEffect(() => {
+    if (tripCode && !currentTrip && !loading) {
+      setFallbackLoading(true)
+      ensureTripLoaded(tripCode).finally(() => setFallbackLoading(false))
+    }
+  }, [tripCode, !currentTrip, loading])
 
   // Automatically add trip to "My Trips" when accessed
   useEffect(() => {
@@ -19,6 +29,6 @@ export function useCurrentTrip() {
   return {
     currentTrip,
     tripCode,
-    loading,
+    loading: loading || fallbackLoading,
   }
 }


### PR DESCRIPTION
## Summary
- Authenticated users navigating to a shared trip URL (where they're not the creator or a participant) were being redirected to trip-not-found
- Root cause: `fetchTrips()` client-side filter for authenticated users only fetches trips they created or are linked to as a participant — trips accessed purely via URL were excluded
- Adds `ensureTripLoaded(tripCode)` fallback in TripContext that fetches a single trip by `trip_code` when not found in the local array
- `useCurrentTrip` calls this fallback and exposes a combined loading state so `TripRouteGuard` doesn't redirect prematurely

## Test plan
- [x] `npm run type-check` passes clean
- [x] All 139 unit tests pass
- [ ] Manual: sign in as user A, navigate to trip created by user B → must load
- [ ] Manual: sign out, navigate to same trip → must load (no regression)
- [ ] Manual: navigate to own trip → must load (no regression)
- [ ] Manual: navigate to non-existent trip code → must show trip-not-found

🤖 Generated with [Claude Code](https://claude.com/claude-code)