### PR TITLE
fix: shared link fallback timing race

### DIFF
--- a/src/hooks/useCurrentTrip.ts
+++ b/src/hooks/useCurrentTrip.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTripContext } from '@/contexts/TripContext'
 import { addToMyTrips } from '@/lib/myTripsStorage'
@@ -7,17 +7,25 @@ export function useCurrentTrip() {
   const { tripCode } = useParams<{ tripCode: string }>()
   const { getTripByCode, loading, ensureTripLoaded } = useTripContext()
   const [fallbackLoading, setFallbackLoading] = useState(false)
+  const fallbackAttempted = useRef<string | null>(null)
 
   const currentTrip = tripCode ? getTripByCode(tripCode) : null
+
+  // Synchronously determine if a fallback fetch is needed — must be computed
+  // during render (not in an effect) so TripRouteGuard sees loading=true
+  // immediately and doesn't redirect to trip-not-found in the same cycle.
+  const shouldFallback = !loading && !!tripCode && !currentTrip
+    && fallbackAttempted.current !== tripCode
 
   // Fallback: if trip not in local array (authenticated user viewing someone else's trip),
   // fetch it directly by trip_code — URL is the access token
   useEffect(() => {
-    if (tripCode && !currentTrip && !loading) {
+    if (shouldFallback && tripCode) {
+      fallbackAttempted.current = tripCode
       setFallbackLoading(true)
       ensureTripLoaded(tripCode).finally(() => setFallbackLoading(false))
     }
-  }, [tripCode, !currentTrip, loading])
+  }, [shouldFallback, tripCode])
 
   // Automatically add trip to "My Trips" when accessed
   useEffect(() => {
@@ -29,6 +37,6 @@ export function useCurrentTrip() {
   return {
     currentTrip,
     tripCode,
-    loading: loading || fallbackLoading,
+    loading: loading || fallbackLoading || shouldFallback,
   }
 }


### PR DESCRIPTION
## Summary
- Fixes the timing race in #316 where `TripRouteGuard` redirected to trip-not-found before the fallback fetch could start
- Root cause: `setFallbackLoading(true)` is a React state update (takes effect next render), but TripRouteGuard's redirect effect fires in the same render cycle — it sees `loading: false` and redirects immediately
- Fix: compute `shouldFallback` synchronously during render and include it in the returned `loading` value, so TripRouteGuard sees `loading: true` on the very first render where the trip isn't found locally
- Uses a ref to track attempted trip codes so the fallback doesn't loop for genuinely non-existent trips

## Test plan
- [x] `npm run type-check` passes clean
- [x] All 139 unit tests pass
- [ ] Manual: sign in as user A, navigate to trip created by user B → must load
- [ ] Manual: navigate to non-existent trip code → must show trip-not-found (not infinite spinner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)