### PR TITLE
fix: custom amount expense wizard broken on iOS — closes #306

### DIFF
--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -488,7 +488,7 @@ function MobileWizard({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
-        className="flex flex-col p-6 gap-0"
+        className="flex flex-col p-6 gap-0 overflow-hidden"
         style={{
           height: keyboard.isVisible
             ? `${keyboard.availableHeight}px`
@@ -527,7 +527,7 @@ function MobileWizard({
 
         <div
           ref={contentRef}
-          className="flex-1 overflow-y-auto -mx-6 px-6 pb-4"
+          className="flex-1 min-h-0 overflow-y-auto -mx-6 px-6 pb-4"
         >
           {currentStep === 1 && (
             <WizardStep1

--- a/src/components/expenses/wizard/WizardStep4.tsx
+++ b/src/components/expenses/wizard/WizardStep4.tsx
@@ -102,6 +102,34 @@ export function WizardStep4({
 
   const hasCustomSplitProps = participants !== undefined && onParticipantSplitChange !== undefined
 
+  const handleDistributeEvenly = () => {
+    const target = splitMode === 'percentage' ? 100 : parseFloat(amount || '0')
+    if (isNaN(target) || target <= 0) return
+
+    const allIds: { type: 'family' | 'participant'; id: string }[] = []
+    if (selectedFamilies) {
+      for (const id of selectedFamilies) allIds.push({ type: 'family', id })
+    }
+    if (selectedParticipants) {
+      for (const id of selectedParticipants) allIds.push({ type: 'participant', id })
+    }
+    if (allIds.length === 0) return
+
+    const base = Math.floor((target / allIds.length) * 100) / 100
+    const remainder = Math.round((target - base * allIds.length) * 100) / 100
+
+    for (let i = 0; i < allIds.length; i++) {
+      const { type, id } = allIds[i]
+      // Give remainder to the first entry so totals match exactly
+      const value = i === 0 ? (base + remainder).toFixed(2) : base.toFixed(2)
+      if (type === 'family') {
+        onFamilySplitChange?.(id, value)
+      } else {
+        onParticipantSplitChange?.(id, value)
+      }
+    }
+  }
+
   return (
     <motion.div
       className="space-y-6"
@@ -165,14 +193,24 @@ export function WizardStep4({
           <Label className="text-base font-medium">
             {splitMode === 'percentage' ? 'Percentages' : 'Amounts'}
           </Label>
-          <p className="text-sm text-muted-foreground">
-            {splitMode === 'percentage'
-              ? 'Enter percentages for each party (must sum to 100%)'
-              : `Enter amounts for each party (must sum to ${currency || 'EUR'} ${amount || '0.00'})`
-            }
-          </p>
+          <div className="flex items-baseline justify-between gap-2">
+            <p className="text-sm text-muted-foreground">
+              {splitMode === 'percentage'
+                ? 'Enter percentages for each party (must sum to 100%)'
+                : `Enter amounts for each party (must sum to ${currency || 'EUR'} ${amount || '0.00'})`
+              }
+            </p>
+            <button
+              type="button"
+              className="shrink-0 text-xs font-medium text-primary underline underline-offset-2"
+              onClick={handleDistributeEvenly}
+              disabled={disabled}
+            >
+              Split evenly
+            </button>
+          </div>
 
-          <div className="space-y-2 rounded-lg border border-input p-3">
+          <div className="space-y-1 rounded-lg border border-input p-3">
             {/* Families */}
             {!isIndividualsMode && selectedFamilies && selectedFamilies.length > 0 && families && (
               <>


### PR DESCRIPTION
## Summary
- **iOS scroll fix**: Added `min-h-0` to the wizard's scrollable content area and `overflow-hidden` to the Sheet container. The classic flex `min-height: auto` bug prevented `overflow-y-auto` from working — with 13+ entities in mixed tracking mode (3 families + 10 individuals), the bottom entries were hidden behind the footer navigation and unreachable.
- **"Split evenly" helper**: Added a quick-action link in the custom split section (both amount and percentage modes) that distributes the total equally across all selected entities, with rounding remainder on the first entry. Makes custom splits usable for large groups.
- **Tighter row spacing**: Reduced `space-y-2` to `space-y-1` in the split input container to fit more rows on screen.

## Test plan
- [ ] Open mobile expense wizard → Step 3 → Advanced Options → Step 4
- [ ] Select "By Amount" with mixed tracking (families + individuals)
- [ ] Verify all entity rows are scrollable and accessible
- [ ] Tap "Split evenly" and verify amounts are auto-filled correctly
- [ ] Verify "Add Expense" button enables when totals match
- [ ] Test "By Percentage" mode — "Split evenly" distributes 100% equally
- [ ] Test on iOS Safari specifically (the scroll bug is iOS-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)