### PR TITLE
fix: show creditor's bank details in quick settle up — closes #304

### DIFF
--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -397,6 +397,23 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                             </p>
                           )
                         })()}
+                        {!iOwe && (() => {
+                          const myBank = userProfile?.bank_account_holder || userProfile?.bank_iban
+                          if (myBank) {
+                            return (
+                              <div className="mt-2 text-xs text-muted-foreground space-y-0.5">
+                                <p className="font-medium text-foreground/70">Your payment details:</p>
+                                {userProfile?.bank_account_holder && <p>Account: {userProfile.bank_account_holder}</p>}
+                                {userProfile?.bank_iban && <p className="font-mono">{userProfile.bank_iban}</p>}
+                              </div>
+                            )
+                          }
+                          return (
+                            <p className="mt-2 text-xs text-muted-foreground italic">
+                              Add your bank details in your profile so others can pay you
+                            </p>
+                          )
+                        })()}
 
                         {/* Inline remind confirm */}
                         {isConfirmingRemind && fromEmail && (


### PR DESCRIPTION
## Summary
- When someone owes you money ("Owed to you" view), the settle up sheet now displays your own bank details from your profile
- If you haven't added bank details yet, shows a prompt: "Add your bank details in your profile so others can pay you"
- Previously only the debtor view ("You owe") showed bank info — the creditor view had no payment details at all

## Test plan
- [ ] Open Quick settle up sheet as a creditor (someone owes you)
- [ ] Verify your bank details appear under the "Owed to you" transaction
- [ ] If no bank details set, verify the prompt message appears
- [ ] Verify debtor view ("You owe") still shows the recipient's bank details as before
- [ ] Verify the full mode SettlementPlan is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)