### PR TITLE
fix: header consistency + UX polish — closes #299, #300, #302, #303, #305, #311

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -203,20 +203,8 @@ export function Layout() {
               )}
               <div className="flex items-center gap-2 flex-shrink-0">
                 <ReportIssueButton onGradient={onGradient} />
-                {tripCode ? (
-                  /* Desktop: scan + mode toggle stay in row 1; hidden on mobile (move to row 2) */
-                  <div className="hidden lg:flex items-center gap-2">
-                    <button
-                      onClick={handleScanTap}
-                      aria-label="Scan receipt"
-                      className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
-                    >
-                      <ScanLine size={20} />
-                    </button>
-                    <ModeToggle onGradient={onGradient} />
-                  </div>
-                ) : (
-                  /* No trip: always show scan + mode toggle */
+                {!tripCode && (
+                  /* No trip: show scan + mode toggle in row 1 */
                   <>
                     <button
                       onClick={handleScanTap}
@@ -232,13 +220,16 @@ export function Layout() {
               </div>
             </div>
 
-            {/* Row 2: mobile only, shown when in a trip */}
-            {tripCode && (() => {
+            {/* Row 2: action pills — shown when in a trip and loaded */}
+            {tripCode && currentTrip && (() => {
               const pillClass = `flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors ${
                 onGradient ? 'bg-white/10 hover:bg-white/20 text-white' : 'bg-muted hover:bg-muted/70 text-foreground'
               }`
+              const modePillClass = `flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors border ${
+                onGradient ? 'border-white/40 bg-white/15 hover:bg-white/25 text-white' : 'border-primary/40 bg-primary/10 hover:bg-primary/15 text-primary'
+              }`
               return (
-                <div className={`lg:hidden grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
+                <div className={`grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
                   <button onClick={handleScanTap} className={pillClass}>
                     <ScanLine size={14} />
                     Scan
@@ -247,7 +238,7 @@ export function Layout() {
                     <Settings size={14} />
                     Manage
                   </button>
-                  <button onClick={() => { void setMode('quick'); navigate(`/t/${tripCode}/quick`) }} className={pillClass}>
+                  <button onClick={() => { void setMode('quick'); navigate(`/t/${tripCode}/quick`) }} className={modePillClass}>
                     <Zap size={14} />
                     Quick view
                   </button>
@@ -259,7 +250,7 @@ export function Layout() {
       </header>
 
       {/* Main content */}
-      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 ${tripCode ? 'lg:ml-64' : ''} ${tripCode ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px]' : 'mt-20'}`}>
         <ParticipantProvider>
           <ExpenseProvider>
             <SettlementProvider>
@@ -397,7 +388,7 @@ export function Layout() {
       </nav>
 
       {/* Side navigation (desktop) */}
-      {tripCode && <aside className="hidden lg:block fixed left-0 top-20 bottom-0 w-64 bg-card border-r border-border soft-shadow">
+      {tripCode && <aside className="hidden lg:block fixed left-0 top-[108px] bottom-0 w-64 bg-card border-r border-border soft-shadow">
         <nav className="px-3 py-6 space-y-1">
           {desktopNavItems.map((item) => {
             const Icon = iconMap[item.label as keyof typeof iconMap]

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -108,14 +108,14 @@ export function QuickLayout() {
                 )}
               </div>
               <div className="flex items-center gap-2 flex-shrink-0">
-                {isInTrip && <ReportIssueButton onGradient={onGradient} />}
+                <ReportIssueButton onGradient={onGradient} />
                 {!isInTrip && <ModeToggle onGradient={onGradient} />}
                 {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
               </div>
             </div>
 
             {/* Row 2: full-width action strip — only on trip detail page, not sub-pages */}
-            {isInTrip && !isSubPage && (
+            {isInTrip && !isSubPage && currentTrip && (
               <div className={`grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
                 <button
                   onClick={handleScanTap}
@@ -141,10 +141,10 @@ export function QuickLayout() {
                 </button>
                 <button
                   onClick={() => { void setMode('full'); navigate(`/t/${tripCode}/expenses`) }}
-                  className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors ${
+                  className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors border ${
                     onGradient
-                      ? 'bg-white/10 hover:bg-white/20 text-white'
-                      : 'bg-muted hover:bg-muted/70 text-foreground'
+                      ? 'border-white/40 bg-white/15 hover:bg-white/25 text-white'
+                      : 'border-primary/40 bg-primary/10 hover:bg-primary/15 text-primary'
                   }`}
                 >
                   <LayoutGrid size={14} />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -74,16 +74,14 @@ export function DashboardPage() {
             tripCode={tripCode!}
             tripName={currentTrip.name}
             trigger={
-              <Button variant="outline" size="sm" className="gap-2">
-                <Share2 size={16} />
-                Share Trip
+              <Button variant="ghost" size="icon" title="Share Trip">
+                <Share2 size={18} />
               </Button>
             }
           />
           {expenses.length > 0 && (
-            <Button onClick={handleExportPDF} variant="outline" size="sm" className="gap-2">
-              <FileDown size={16} />
-              Export Summary
+            <Button onClick={handleExportPDF} variant="ghost" size="icon" title="Export Summary">
+              <FileDown size={18} />
             </Button>
           )}
         </div>

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -147,14 +147,6 @@ export function ExpensesPage() {
                 <FileDown size={18} />
               </Button>
             )}
-            <Button
-              onClick={() => setShowReceiptCapture(true)}
-              variant="ghost"
-              size="icon"
-              title="Scan a receipt"
-            >
-              <ScanLine size={18} />
-            </Button>
             <div className="relative">
               <Button
                 onClick={() => setFiltersVisible(v => !v)}


### PR DESCRIPTION
## Summary
- **#300**: Hide action pill strip during loading state (pills only appear once trip data is loaded)
- **#302**: Remove duplicate scan icon button from expenses page — header pill strip already provides scan
- **#303**: Dashboard "Share Trip" / "Export Summary" buttons changed from text+icon to icon-only, matching expenses page style
- **#299**: Mode-switching pills (Quick view / Full view) now visually distinct with primary-tinted border and background
- **#305**: ReportIssueButton added to Quick mode home header (was previously only shown in trip views)
- **#311**: Full mode pill strip now visible on desktop (was hidden with `lg:hidden`); standalone scan/mode-toggle icons removed from row 1 (now in pills); side nav top position adjusted to account for two-row header
- **#301**: Closed as duplicate of #300

## Test plan
- [ ] Navigate to a trip in both Quick and Full mode — verify pill strip appears
- [ ] Reload a trip page — verify pills don't flash before trip data loads
- [ ] Quick mode: verify "Full view" pill has accent color/border
- [ ] Full mode: verify "Quick view" pill has accent color/border
- [ ] Expenses page: verify no duplicate scan button (only header pill)
- [ ] Dashboard page: verify Share and Export are icon-only buttons
- [ ] Quick home (/quick): verify ReportIssueButton appears in header
- [ ] Desktop full mode: verify pill strip is visible (not hidden)
- [ ] Desktop full mode: verify side nav starts below the two-row header

🤖 Generated with [Claude Code](https://claude.com/claude-code)