### PR TITLE
fix: match currency select height to amount input — closes #322

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -507,7 +507,7 @@ export function ExpenseForm({
             onValueChange={setCurrency}
             disabled={loading}
           >
-            <SelectTrigger className="w-28">
+            <SelectTrigger className="w-28 h-14 text-base">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## Summary
- Currency `SelectTrigger` in `ExpenseForm` was missing `h-14`, defaulting to 40px while the amount `Input` is 56px
- Added `h-14 text-base` to match the amount field height and font size

## Test plan
- [ ] Open full-mode expense form (desktop or mobile)
- [ ] Verify amount input and currency dropdown are the same height

🤖 Generated with [Claude Code](https://claude.com/claude-code)