### PR TITLE
fix: include service charges/tips as receipt line items — closes #323

### DIFF
--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -31,6 +31,7 @@ Rules:
 - currency is the 3-letter ISO code (default "USD" if unclear)
 - If a value cannot be read, use null
 - Do NOT include tax lines as items — include them in total but not subtotal
+- DO include service charges, tips, and gratuities as separate line items (name them "Service Charge", "Tip", etc.)
 - Return ONLY the JSON object, no other text`
 
 Deno.serve(async (req) => {


### PR DESCRIPTION
## Summary
- Updated the `process-receipt` edge function's Claude prompt to explicitly include service charges, tips, and gratuities as separate line items
- Previously, the rule "Do NOT include tax lines as items" was also excluding service charges — causing extracted items to sum to only the subtotal while the total included these charges
- Tax lines remain excluded from items (included in total only)

## Test plan
- [ ] Scan a receipt with a service charge line → verify it appears as a "Service Charge" item
- [ ] Scan a receipt with a tip/gratuity → verify it appears as a line item
- [ ] Scan a receipt with tax only → verify tax is NOT included as a line item
- [ ] Verify extracted items + service charge sum matches the total

**Note:** This is a Supabase Edge Function change — requires `supabase functions deploy process-receipt` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)