### PR TITLE
fix: consistent desktop layout — closes #329, #330

### DIFF
--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -137,7 +137,7 @@ export function ExpensesPage() {
 
   return (
     <>
-      <div className="max-w-4xl mx-auto space-y-4">
+      <div className="space-y-4">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-y-2">
           <h2 className="text-xl font-bold text-foreground">Expenses</h2>

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -240,9 +240,8 @@ export function SettlementsPage() {
             </p>
           </div>
           {expenses.length > 0 && (
-            <Button onClick={handleExportPDF} variant="outline" size="sm" className="gap-2">
-              <FileDown size={16} />
-              Export PDF
+            <Button onClick={handleExportPDF} variant="ghost" size="icon" title="Export PDF">
+              <FileDown size={18} />
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- **#329 (inconsistent spacing):** Removed `max-w-4xl mx-auto` from expenses page — it now fills the same width as settlements and dashboard on desktop
- **#330 (Export PDF button):** Changed from text+icon `outline` button to icon-only `ghost` button, matching the expenses page's export button style

## Test plan
- [ ] Desktop: expenses page content fills same width as settlements and dashboard
- [ ] Desktop: settlements "Export PDF" is now an icon-only button with tooltip
- [ ] Mobile: expenses page layout unchanged (was already full-width)
- [ ] Verify PDF export still works from the icon button

🤖 Generated with [Claude Code](https://claude.com/claude-code)