### PR TITLE
fix: AI receipt parser infers expense category — closes #332

### DIFF
--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -35,6 +35,7 @@ interface ReceiptReviewSheetProps {
   extractedTotal: number | null
   currency: string
   imagePath?: string | null
+  extractedCategory?: string | null
   onDone: () => void
 }
 
@@ -135,6 +136,7 @@ export function ReceiptReviewSheet({
   extractedTotal,
   currency,
   imagePath,
+  extractedCategory,
   onDone,
 }: ReceiptReviewSheetProps) {
   const keyboard = useKeyboardHeight()
@@ -168,7 +170,10 @@ export function ReceiptReviewSheet({
   const [confirmedTotal, setConfirmedTotal] = useState('')
   const [tipAmount, setTipAmount] = useState('0')
   const [paidBy, setPaidBy] = useState('')
-  const [category, setCategory] = useState<ExpenseCategory>('Food')
+  const validCategories: ExpenseCategory[] = ['Food', 'Accommodation', 'Transport', 'Activities', 'Training', 'Other']
+  const [category, setCategory] = useState<ExpenseCategory>(
+    validCategories.includes(extractedCategory as ExpenseCategory) ? extractedCategory as ExpenseCategory : 'Food'
+  )
   const [merchantName, setMerchantName] = useState('')
   const [activeCurrency, setActiveCurrency] = useState(currency)
   const [exchangeRate, setExchangeRate] = useState('')
@@ -208,7 +213,7 @@ export function ReceiptReviewSheet({
     setTipAmount('0')
     setPaidBy(defaultPayerId)
     setMerchantName(merchant ?? '')
-    setCategory('Food')
+    setCategory(validCategories.includes(extractedCategory as ExpenseCategory) ? extractedCategory as ExpenseCategory : 'Food')
     setActiveCurrency(currency)
     setExchangeRate('')
     setShowAllItems(true)

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -324,6 +324,7 @@ export type Database = {
           extracted_total: number | null
           extracted_currency: string | null
           extracted_date: string | null
+          extracted_category: string | null
           confirmed_total: number | null
           tip_amount: number
           mapped_items: Json | null
@@ -343,6 +344,7 @@ export type Database = {
           extracted_total?: number | null
           extracted_currency?: string | null
           extracted_date?: string | null
+          extracted_category?: string | null
           confirmed_total?: number | null
           tip_amount?: number
           mapped_items?: Json | null
@@ -362,6 +364,7 @@ export type Database = {
           extracted_total?: number | null
           extracted_currency?: string | null
           extracted_date?: string | null
+          extracted_category?: string | null
           confirmed_total?: number | null
           tip_amount?: number
           mapped_items?: Json | null

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -43,6 +43,7 @@ interface ReceiptReviewData {
   total: number | null
   currency: string
   imagePath: string | null
+  category: string | null
 }
 
 export function ExpensesPage() {
@@ -207,6 +208,7 @@ export function ExpensesPage() {
                           total: task.extracted_total,
                           currency: task.extracted_currency ?? currentTrip?.default_currency ?? 'USD',
                           imagePath: task.receipt_image_path ?? null,
+                          category: task.extracted_category ?? null,
                         })
                       }
                     >
@@ -364,6 +366,7 @@ export function ExpensesPage() {
           extractedTotal={receiptReviewData.total}
           currency={receiptReviewData.currency}
           imagePath={receiptReviewData.imagePath}
+          extractedCategory={receiptReviewData.category}
           onDone={() => setReceiptReviewData(null)}
         />
       )}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -33,6 +33,7 @@ interface ReceiptReviewData {
   total: number | null
   currency: string
   imagePath: string | null
+  category: string | null
 }
 
 export function QuickGroupDetailPage() {
@@ -225,6 +226,7 @@ export function QuickGroupDetailPage() {
                         total: task.extracted_total,
                         currency: task.extracted_currency ?? currentTrip.default_currency,
                         imagePath: task.receipt_image_path ?? null,
+                        category: task.extracted_category ?? null,
                       })
                     }
                   >
@@ -339,6 +341,7 @@ export function QuickGroupDetailPage() {
           extractedTotal={receiptReviewData.total}
           currency={receiptReviewData.currency}
           imagePath={receiptReviewData.imagePath}
+          extractedCategory={receiptReviewData.category}
           onDone={() => setReceiptReviewData(null)}
         />
       )}

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -22,6 +22,7 @@ export interface ReceiptTask {
   extracted_total: number | null;
   extracted_currency: string | null;
   extracted_date: string | null;
+  extracted_category: string | null;
   confirmed_total: number | null;
   tip_amount: number;
   mapped_items: MappedItem[] | null;

--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -21,7 +21,8 @@ Return ONLY valid JSON with this exact structure:
   "items": [{"name": "item name", "price": 12.50, "qty": 1}],
   "subtotal": 25.00,
   "total": 27.50,
-  "currency": "USD"
+  "currency": "USD",
+  "category": "Food"
 }
 Rules:
 - merchant: Scan the entire receipt, especially the header area at the top, for the business name, restaurant name, store name, or brand. It may appear as large text, a logo caption, a subtitle, or small print. If you see a name in both Latin and non-Latin script (e.g. Thai, Arabic, Chinese), return the Latin version. If the name is only in a non-Latin script, return a romanised/transliterated version of it. If truly no business name is readable anywhere, invent a short creative name (2–4 words) that evokes the vibe of the items ordered — e.g. "The Wandering Wok" for Thai food, "Mystery Grill" for a barbecue spot, "Island Bites" for tropical drinks. Never return null.
@@ -32,6 +33,7 @@ Rules:
 - If a value cannot be read, use null
 - Do NOT include tax lines as items — include them in total but not subtotal
 - DO include service charges, tips, and gratuities as separate line items (name them "Service Charge", "Tip", etc.)
+- category: one of "Food", "Accommodation", "Transport", "Activities", "Training", or "Other". Infer from the merchant name and items. Examples: restaurants/cafes/groceries → "Food", hotels/hostels/Airbnb → "Accommodation", Grab/Uber/taxi/bus/train/flights → "Transport", tours/parks/museums → "Activities". Default to "Other" if unclear.
 - Return ONLY the JSON object, no other text`
 
 Deno.serve(async (req) => {
@@ -167,6 +169,7 @@ Deno.serve(async (req) => {
       subtotal?: number | null
       total?: number | null
       currency?: string | null
+      category?: string | null
     } = {}
 
     try {
@@ -204,6 +207,8 @@ Deno.serve(async (req) => {
     const extractedDate = typeof extracted.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(extracted.date)
       ? extracted.date
       : null
+    const validCategories = ['Food', 'Accommodation', 'Transport', 'Activities', 'Training', 'Other']
+    const extractedCategory = validCategories.includes(extracted.category ?? '') ? extracted.category! : null
 
     // Save results and mark as ready for review
     await supabase
@@ -215,6 +220,7 @@ Deno.serve(async (req) => {
         extracted_total: extractedTotal,
         extracted_currency: extractedCurrency,
         extracted_date: extractedDate,
+        extracted_category: extractedCategory,
         updated_at: new Date().toISOString(),
       })
       .eq('id', receipt_task_id)
@@ -234,6 +240,7 @@ Deno.serve(async (req) => {
         total: extractedTotal,
         currency: extractedCurrency,
         date: extractedDate,
+        category: extractedCategory,
       }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     )

--- a/supabase/migrations/028_receipt_category.sql
+++ b/supabase/migrations/028_receipt_category.sql
@@ -1,0 +1,2 @@
+-- Add extracted_category to receipt_tasks for AI-inferred expense category
+ALTER TABLE receipt_tasks ADD COLUMN extracted_category TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary
- Added `category` field to the AI receipt extraction prompt — Claude now infers the expense category from merchant name and line items
- Categories: Food, Accommodation, Transport, Activities, Training, Other (with examples in prompt)
- `ReceiptReviewSheet` now defaults to the AI-inferred category instead of always "Food"
- New migration 028 adds `extracted_category` column to `receipt_tasks`

## Test plan
- [ ] Scan a restaurant receipt → category defaults to "Food"
- [ ] Scan a Grab/taxi receipt → category defaults to "Transport"
- [ ] Scan a hotel receipt → category defaults to "Accommodation"
- [ ] Verify category can still be manually changed in review sheet
- [ ] Verify old receipts (no extracted_category) still default to "Food"

**Note:** Requires migration 028 + `supabase functions deploy process-receipt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)