### PR TITLE
feat: Phase 7b+7c — icon unification + remove redundant buttons

### DIFF
--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
-import { Zap, Settings2 } from 'lucide-react'
+import { Zap, LayoutGrid } from 'lucide-react'
 
 interface ModeToggleProps {
   onGradient?: boolean
@@ -68,7 +68,7 @@ export function ModeToggle({ onGradient = false }: ModeToggleProps) {
           effectiveMode === 'full' ? activeClass : inactiveClass
         }`}
       >
-        <Settings2 size={14} />
+        <LayoutGrid size={14} />
         Full
       </button>
     </div>

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -24,7 +24,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useToast } from '@/hooks/use-toast'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
-  ExternalLink, ArrowLeftRight, Loader2, Users
+  Loader2, Users
 } from 'lucide-react'
 
 export function QuickGroupDetailPage() {
@@ -200,26 +200,6 @@ export function QuickGroupDetailPage() {
           description="See transaction history"
           onClick={() => navigate(`/t/${currentTrip.trip_code}/quick/history`)}
         />
-      </div>
-
-      {/* Bottom actions */}
-      <div className="space-y-3">
-        <Button
-          variant="outline"
-          className="w-full gap-2"
-          onClick={() => navigate('/quick')}
-        >
-          <ArrowLeftRight size={16} />
-          My Groups
-        </Button>
-        <Button
-          variant="outline"
-          className="w-full gap-2"
-          onClick={() => navigate(`/t/${currentTrip.trip_code}/dashboard`)}
-        >
-          <ExternalLink size={16} />
-          See in Full Mode
-        </Button>
       </div>
 
       {/* Expense sheet */}


### PR DESCRIPTION
## Summary
- **Phase 7b**: Replace `Settings2` icon with `LayoutGrid` in `ModeToggle` — now consistent with Row 2 pills in both layouts (`Zap` = Quick, `LayoutGrid` = Full)
- **Phase 7c**: Remove "My Groups" and "See in Full Mode" buttons from bottom of `QuickGroupDetailPage` — header back arrow (`←`) and Row 2 "Full view" pill already provide both navigation paths

## Test plan
- [ ] ModeToggle shows `LayoutGrid` icon for Full mode (not gear/Settings2)
- [ ] Row 2 pills in QuickLayout and Layout still show correct icons (no change expected)
- [ ] Quick trip detail page ends after action buttons — no "My Groups" or "See in Full Mode" at bottom
- [ ] Back arrow in Quick header still navigates to groups list
- [ ] "Full view" pill in Row 2 still switches to Full mode
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — 139/139 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)