### PR TITLE
feat: Phase 7e — admin page in Layout

### DIFF
--- a/src/pages/AdminAllTripsPage.tsx
+++ b/src/pages/AdminAllTripsPage.tsx
@@ -150,7 +150,7 @@ export function AdminAllTripsPage() {
   // Access denied
   if (!isAdmin) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="flex items-center justify-center py-24">
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -179,10 +179,9 @@ export function AdminAllTripsPage() {
 
   // Admin view
   return (
-    <div className="min-h-screen bg-background">
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
           <div>
             <h1 className="text-3xl font-bold text-foreground">All Trips (Admin)</h1>
             <p className="text-muted-foreground mt-1">
@@ -337,7 +336,6 @@ export function AdminAllTripsPage() {
           </p>
         </div>
         </>}
-      </div>
     </div>
   )
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -28,7 +28,6 @@ export function AppRoutes() {
   return (
     <Routes>
       {/* Special routes - outside Layout */}
-      <Route path="admin/all-trips" element={<ErrorBoundary><AdminAllTripsPage /></ErrorBoundary>} />
       <Route path="trip-not-found/:tripCode" element={<ErrorBoundary><TripNotFoundPage /></ErrorBoundary>} />
       <Route path="join/:token" element={<ErrorBoundary><JoinPage /></ErrorBoundary>} />
 
@@ -47,6 +46,7 @@ export function AppRoutes() {
       {/* Full Mode routes */}
       <Route path="/" element={<Layout />}>
         <Route index element={<ErrorBoundary><ConditionalHomePage /></ErrorBoundary>} />
+        <Route path="admin/all-trips" element={<ErrorBoundary><AdminAllTripsPage /></ErrorBoundary>} />
         <Route path="create-trip" element={<ErrorBoundary><TripsPage /></ErrorBoundary>} />
         <Route path="t/:tripCode/manage" element={<TripRouteGuard><ErrorBoundary><ManageTripPage /></ErrorBoundary></TripRouteGuard>} />
         <Route path="t/:tripCode/expenses" element={<TripRouteGuard><ErrorBoundary><ExpensesPage /></ErrorBoundary></TripRouteGuard>} />


### PR DESCRIPTION
## Summary
- Move `/admin/all-trips` route inside the `Layout` route group so it gets the standard header, side nav (desktop), and bottom nav (mobile)
- Remove standalone `min-h-screen bg-background` and `max-w-7xl mx-auto` wrappers from `AdminAllTripsPage` since Layout provides these
- Access-denied state adjusted to work within Layout's content area

## Files changed
- `src/routes.tsx` — moved admin route into Layout group
- `src/pages/AdminAllTripsPage.tsx` — removed redundant wrappers

## Test plan
- [x] `npm run type-check` passes clean
- [x] `npm test` — 139/139 tests pass
- [ ] Verify admin page shows standard header with Spl1t logo
- [ ] Verify desktop shows side nav (when no trip selected)
- [ ] Verify mobile shows bottom nav with "Trips" tab
- [ ] Verify access-denied state still renders correctly for non-admin users
- [ ] Verify back navigation works from admin page

🤖 Generated with [Claude Code](https://claude.com/claude-code)