### PR TITLE
feat: Phase 7h — standardize loading/error states

### DIFF
--- a/src/pages/AdminAllTripsPage.tsx
+++ b/src/pages/AdminAllTripsPage.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
-import { Search, ExternalLink, Calendar, Users, UserCircle, ShieldAlert, Loader2 } from 'lucide-react'
+import { Search, ExternalLink, Calendar, Users, UserCircle, ShieldAlert } from 'lucide-react'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import { useAuth } from '@/contexts/AuthContext'
 import { supabase } from '@/lib/supabase'
 import type { Trip } from '@/types/trip'
@@ -31,6 +33,7 @@ export function AdminAllTripsPage() {
   const [allTrips, setAllTrips] = useState<Trip[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [retrying, setRetrying] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [sortBy, setSortBy] = useState<'recent' | 'name' | 'oldest'>('recent')
   const [ownerMap, setOwnerMap] = useState<Record<string, { name: string; email: string | null }>>({})
@@ -192,17 +195,35 @@ export function AdminAllTripsPage() {
 
         {/* Loading / Error */}
         {loading && (
-          <div className="flex items-center justify-center py-24">
-            <Loader2 className="animate-spin text-muted-foreground" size={32} />
-          </div>
+          <PageLoadingState />
         )}
 
         {error && !loading && (
-          <Card className="mb-6">
-            <CardContent className="pt-6">
-              <p className="text-destructive text-center">{error}</p>
-            </CardContent>
-          </Card>
+          <PageErrorState error={error} onRetry={async () => {
+            setRetrying(true)
+            setError(null)
+            setLoading(true)
+            try {
+              const signal = newSignal()
+              const { data, error: fetchError } = await withTimeout(
+                supabase
+                  .from('trips')
+                  .select('*')
+                  .order('created_at', { ascending: false })
+                  .abortSignal(signal),
+                15000,
+                'Loading all trips timed out.'
+              )
+              if (fetchError) {
+                setError(fetchError.message)
+              } else {
+                setAllTrips((data as unknown as Trip[]) ?? [])
+              }
+            } finally {
+              setLoading(false)
+              setRetrying(false)
+            }
+          }} retrying={retrying} />
         )}
 
         {!loading && !error && <>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -4,6 +4,8 @@ import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import { calculateBalances } from '@/services/balanceCalculator'
 import { exportTripSummaryToPDF } from '@/services/pdfExport'
 import { BalanceCard } from '@/components/BalanceCard'
@@ -21,10 +23,23 @@ const TopExpensesList = lazy(() => import('@/components/TopExpensesList').then(m
 
 export function DashboardPage() {
   const { currentTrip, tripCode } = useCurrentTrip()
-  const { participants, families } = useParticipantContext()
-  const { expenses } = useExpenseContext()
-  const { settlements } = useSettlementContext()
+  const { participants, families, loading: pLoading, error: pError, refreshParticipants } = useParticipantContext()
+  const { expenses, loading: eLoading, error: eError, refreshExpenses } = useExpenseContext()
+  const { settlements, loading: sLoading, error: sError, refreshSettlements } = useSettlementContext()
   const [selectedBalance, setSelectedBalance] = useState<ParticipantBalance | null>(null)
+  const [retrying, setRetrying] = useState(false)
+
+  const loading = pLoading || eLoading || sLoading
+  const contextError = pError || eError || sError
+
+  const handleRetry = async () => {
+    setRetrying(true)
+    try {
+      await Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()])
+    } finally {
+      setRetrying(false)
+    }
+  }
 
   if (!currentTrip) {
     return (
@@ -87,6 +102,11 @@ export function DashboardPage() {
         </div>
       </div>
 
+      {loading ? (
+        <PageLoadingState />
+      ) : contextError ? (
+        <PageErrorState error={contextError} onRetry={handleRetry} retrying={retrying} />
+      ) : <>
       {/* Trip Overview Stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
@@ -266,6 +286,8 @@ export function DashboardPage() {
           </div>
         </>
       )}
+
+      </>}
 
       {/* Cost Breakdown Dialog */}
       {selectedBalance && (

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { Plus, Search, Receipt, FileDown, SlidersHorizontal, ScanLine } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
@@ -38,7 +40,7 @@ import {
 
 export function ExpensesPage() {
   const { currentTrip } = useCurrentTrip()
-  const { expenses, loading, error, createExpense, updateExpense, deleteExpense } = useExpenseContext()
+  const { expenses, loading, error, createExpense, updateExpense, deleteExpense, refreshExpenses } = useExpenseContext()
   const { participants, families } = useParticipantContext()
   const { settlements } = useSettlementContext()
   const { pendingReceipts, receiptByExpenseId, dismissReceiptTask } = useReceiptContext()
@@ -53,6 +55,7 @@ export function ExpensesPage() {
   const [showReceiptCapture, setShowReceiptCapture] = useState(false)
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [viewingReceiptTask, setViewingReceiptTask] = useState<ReceiptTask | null>(null)
+  const [retrying, setRetrying] = useState(false)
 
   const handleCreateExpense = async (input: CreateExpenseInput) => {
     await createExpense(input)
@@ -163,9 +166,10 @@ export function ExpensesPage() {
 
         {/* Error Message */}
         {error && (
-          <div className="bg-destructive/10 border border-destructive/30 text-destructive px-4 py-3 rounded-lg">
-            {error}
-          </div>
+          <PageErrorState error={error} onRetry={async () => {
+            setRetrying(true)
+            try { await refreshExpenses() } finally { setRetrying(false) }
+          }} retrying={retrying} />
         )}
 
         {/* Pending receipts banner */}
@@ -245,7 +249,7 @@ export function ExpensesPage() {
         <Card>
           <CardContent className="pt-6">
             {loading ? (
-              <p className="text-muted-foreground text-center py-8">Loading expenses...</p>
+              <PageLoadingState />
             ) : filteredExpenses.length === 0 ? (
               <div className="text-center py-8">
                 <Receipt size={48} className="mx-auto text-muted-foreground/50 mb-4" />

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Edit, Trash2, Info, X, Plus, ArrowLeft } from 'lucide-react'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import { format } from 'date-fns'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useTripContext } from '@/contexts/TripContext'
@@ -43,7 +45,7 @@ export function ManageTripPage() {
   const { updateTrip, deleteTrip } = useTripContext()
   const location = useLocation()
   const fromQuick = !!(location.state as any)?.fromQuick
-  const { participants, error: participantError, clearError: clearParticipantError } = useParticipantContext()
+  const { participants, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
   const { meals } = useMealContext()
   const { toast } = useToast()
   const navigate = useNavigate()
@@ -51,14 +53,7 @@ export function ManageTripPage() {
   const [showEditDialog, setShowEditDialog] = useState(false)
   const [isUpdating, setIsUpdating] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
-
-  // Surface participant errors as toasts
-  useEffect(() => {
-    if (participantError) {
-      toast({ title: 'Error', description: participantError, variant: 'destructive' })
-      clearParticipantError()
-    }
-  }, [participantError])
+  const [retrying, setRetrying] = useState(false)
 
   // Currency settings state
   const [currencyDefault, setCurrencyDefault] = useState(currentTrip?.default_currency || 'EUR')
@@ -260,23 +255,32 @@ export function ManageTripPage() {
         <h3 className="text-lg font-semibold text-foreground">
           Participants & Families
         </h3>
-        {participants.length === 0 && (
-          <Card className="border-dashed border-primary/40 bg-primary/5">
-            <CardContent className="pt-4 pb-4">
-              <p className="text-sm text-primary font-medium">
-                Add participants to get started
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Participants are required before you can add expenses.
-              </p>
-            </CardContent>
-          </Card>
-        )}
-        {currentTrip.tracking_mode === 'individuals' ? (
-          <IndividualsSetup />
-        ) : (
-          <FamiliesSetup />
-        )}
+        {participantsLoading ? (
+          <PageLoadingState />
+        ) : participantError ? (
+          <PageErrorState error={participantError} onRetry={async () => {
+            setRetrying(true)
+            try { await refreshParticipants() } finally { setRetrying(false) }
+          }} retrying={retrying} />
+        ) : <>
+          {participants.length === 0 && (
+            <Card className="border-dashed border-primary/40 bg-primary/5">
+              <CardContent className="pt-4 pb-4">
+                <p className="text-sm text-primary font-medium">
+                  Add participants to get started
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Participants are required before you can add expenses.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+          {currentTrip.tracking_mode === 'individuals' ? (
+            <IndividualsSetup />
+          ) : (
+            <FamiliesSetup />
+          )}
+        </>}
       </div>
 
       {/* Details Card */}

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -4,7 +4,8 @@ import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMealContext } from '@/contexts/MealContext'
 import { useActivityContext } from '@/contexts/ActivityContext'
 import { useStayContext } from '@/contexts/StayContext'
-import { useToast } from '@/hooks/use-toast'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import type { MealWithIngredients } from '@/types/meal'
 import type { Activity } from '@/types/activity'
 import { PlannerGrid } from '@/components/PlannerGrid'
@@ -17,36 +18,25 @@ const StayMap = lazy(() => import('@/components/StayMap'))
 
 export function PlannerPage() {
   const { currentTrip } = useCurrentTrip()
-  const { meals, loading: mealsLoading, error: mealError, clearError: clearMealError, getMealsWithIngredients } = useMealContext()
-  const { loading: activitiesLoading, error: activityError, clearError: clearActivityError, getActivitiesForDate } = useActivityContext()
-  const { stays, loading: staysLoading, error: stayError, clearError: clearStayError, getStayForDate, getStaysForDate } = useStayContext()
-  const { toast } = useToast()
+  const { meals, loading: mealsLoading, error: mealError, getMealsWithIngredients, refreshMeals } = useMealContext()
+  const { loading: activitiesLoading, error: activityError, getActivitiesForDate, refreshActivities } = useActivityContext()
+  const { stays, loading: staysLoading, error: stayError, getStayForDate, getStaysForDate, refreshStays } = useStayContext()
   const [mealsWithIngredients, setMealsWithIngredients] = useState<MealWithIngredients[]>([])
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [showMap, setShowMap] = useState(true)
-
-  useEffect(() => {
-    if (mealError) {
-      toast({ title: 'Error', description: mealError, variant: 'destructive' })
-      clearMealError()
-    }
-  }, [mealError])
-
-  useEffect(() => {
-    if (activityError) {
-      toast({ title: 'Error', description: activityError, variant: 'destructive' })
-      clearActivityError()
-    }
-  }, [activityError])
-
-  useEffect(() => {
-    if (stayError) {
-      toast({ title: 'Error', description: stayError, variant: 'destructive' })
-      clearStayError()
-    }
-  }, [stayError])
+  const [retrying, setRetrying] = useState(false)
 
   const loading = mealsLoading || activitiesLoading || staysLoading
+  const contextError = mealError || activityError || stayError
+
+  const handleRetry = async () => {
+    setRetrying(true)
+    try {
+      await Promise.all([refreshMeals(), refreshActivities(), refreshStays()])
+    } finally {
+      setRetrying(false)
+    }
+  }
 
   const enableMeals = currentTrip?.enable_meals ?? false
   const enableActivities = currentTrip?.enable_activities ?? false
@@ -112,17 +102,15 @@ export function PlannerPage() {
         </p>
       </div>
 
-      {/* Loading State */}
-      {loading && (
-        <Card>
-          <CardContent className="pt-6">
-            <p className="text-muted-foreground text-center py-8">Loading planner...</p>
-          </CardContent>
-        </Card>
-      )}
+      {/* Loading / Error State */}
+      {loading ? (
+        <PageLoadingState />
+      ) : contextError ? (
+        <PageErrorState error={contextError} onRetry={handleRetry} retrying={retrying} />
+      ) : <>
 
       {/* Grid Overview */}
-      {!loading && tripDates.length > 0 && (
+      {tripDates.length > 0 && (
         <PlannerGrid
           tripDates={tripDates}
           getMealsForDate={getMealsForDate}
@@ -134,7 +122,7 @@ export function PlannerPage() {
       )}
 
       {/* Stay Map */}
-      {!loading && hasStaysWithCoords && (
+      {hasStaysWithCoords && (
         <div className="space-y-2">
           <Button
             variant="outline"
@@ -174,7 +162,7 @@ export function PlannerPage() {
       />
 
       {/* Empty State */}
-      {!loading && tripDates.length === 0 && (
+      {tripDates.length === 0 && (
         <Card>
           <CardContent className="pt-6">
             <div className="text-center py-8">
@@ -189,6 +177,7 @@ export function PlannerPage() {
           </CardContent>
         </Card>
       )}
+      </>}
     </div>
   )
 }

--- a/src/pages/QuickHistoryPage.tsx
+++ b/src/pages/QuickHistoryPage.tsx
@@ -6,18 +6,32 @@ import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
 import { buildTransactionHistory } from '@/services/transactionHistoryBuilder'
 import { TransactionItem } from '@/components/quick/TransactionItem'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, FileText } from 'lucide-react'
+import { FileText } from 'lucide-react'
 
 type FilterType = 'all' | 'expenses' | 'payments'
 
 export function QuickHistoryPage() {
   const { currentTrip } = useCurrentTrip()
   const { myParticipant } = useMyParticipant()
-  const { participants, families, loading: participantsLoading } = useParticipantContext()
-  const { expenses, loading: expensesLoading } = useExpenseContext()
-  const { settlements, loading: settlementsLoading } = useSettlementContext()
+  const { participants, families, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
+  const { expenses, loading: expensesLoading, error: expenseError, refreshExpenses } = useExpenseContext()
+  const { settlements, loading: settlementsLoading, error: settlementError, refreshSettlements } = useSettlementContext()
   const [filter, setFilter] = useState<FilterType>('all')
+  const [retrying, setRetrying] = useState(false)
+
+  const contextError = participantError || expenseError || settlementError
+
+  const handleRetry = async () => {
+    setRetrying(true)
+    try {
+      await Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()])
+    } finally {
+      setRetrying(false)
+    }
+  }
 
   const loading = participantsLoading || expensesLoading || settlementsLoading
 
@@ -68,9 +82,9 @@ export function QuickHistoryPage() {
 
       {/* Transaction list */}
       {loading ? (
-        <div className="flex items-center justify-center py-12">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-        </div>
+        <PageLoadingState />
+      ) : contextError ? (
+        <PageErrorState error={contextError} onRetry={handleRetry} retrying={retrying} />
       ) : !myParticipant ? (
         <Card>
           <CardContent className="pt-6 text-center">

--- a/src/pages/QuickHomeScreen.tsx
+++ b/src/pages/QuickHomeScreen.tsx
@@ -10,8 +10,9 @@ import { QuickCreateSheet } from '@/components/quick/QuickCreateSheet'
 import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
 import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
 import { TripCard } from '@/components/TripCard'
+import { PageLoadingState } from '@/components/PageLoadingState'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, ChevronRight, Plus, Eye, ChevronDown, ExternalLink, ScanLine } from 'lucide-react'
+import { ChevronRight, Plus, Eye, ChevronDown, ExternalLink, ScanLine } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { motion } from 'framer-motion'
 
@@ -112,9 +113,7 @@ export function QuickHomeScreen() {
 
         {/* Groups list */}
         {loading ? (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-          </div>
+          <PageLoadingState />
         ) : visibleTrips.length === 0 ? (
           <Card>
             <CardContent className="pt-6">

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -5,6 +5,8 @@ import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import { useReceiptContext } from '@/contexts/ReceiptContext'
 import { calculateBalances } from '@/services/balanceCalculator'
 import { calculateOptimalSettlement } from '@/services/settlementOptimizer'
@@ -21,9 +23,9 @@ import { logger } from '@/lib/logger'
 export function SettlementsPage() {
   const { currentTrip } = useCurrentTrip()
   const { user, userProfile } = useAuth()
-  const { participants, families } = useParticipantContext()
-  const { expenses } = useExpenseContext()
-  const { createSettlement, settlements } = useSettlementContext()
+  const { participants, families, loading: pLoading, error: pError, refreshParticipants } = useParticipantContext()
+  const { expenses, loading: eLoading, error: eError, refreshExpenses } = useExpenseContext()
+  const { createSettlement, settlements, loading: sLoading, error: sError, refreshSettlements } = useSettlementContext()
   const { receiptByExpenseId } = useReceiptContext()
   const [showCustomSettlement, setShowCustomSettlement] = useState(false)
   const [prefilledAmount, setPrefilledAmount] = useState<number | undefined>(undefined)
@@ -31,6 +33,19 @@ export function SettlementsPage() {
   const customSettlementRef = useRef<HTMLDivElement>(null)
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
   const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
+  const [retrying, setRetrying] = useState(false)
+
+  const loading = pLoading || eLoading || sLoading
+  const contextError = pError || eError || sError
+
+  const handleRetry = async () => {
+    setRetrying(true)
+    try {
+      await Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()])
+    } finally {
+      setRetrying(false)
+    }
+  }
 
   // Build a map of entity ID (participant ID or family_id) → email for the "from" side of transactions
   const fromEmailMap = useMemo(() => {
@@ -246,6 +261,11 @@ export function SettlementsPage() {
           )}
         </div>
 
+        {loading ? (
+          <PageLoadingState />
+        ) : contextError ? (
+          <PageErrorState error={contextError} onRetry={handleRetry} retrying={retrying} />
+        ) : <>
         {/* Settlement Summary Stats */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card>
@@ -416,6 +436,7 @@ export function SettlementsPage() {
             </CardContent>
           </Card>
         )}
+        </>}
       </div>
     </>
   )

--- a/src/pages/ShoppingPage.tsx
+++ b/src/pages/ShoppingPage.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react'
 import { Plus, ShoppingCart, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useShoppingContext } from '@/contexts/ShoppingContext'
-import { useToast } from '@/hooks/use-toast'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
 import type { ShoppingItemWithMeals } from '@/types/shopping'
 import { CATEGORY_ORDER } from '@/types/shopping'
 import { ShoppingItemRow } from '@/components/ShoppingItemRow'
@@ -21,19 +22,12 @@ type SortDirection = 'asc' | 'desc'
 
 export function ShoppingPage() {
   const { currentTrip } = useCurrentTrip()
-  const { shoppingItems, loading, error: shoppingError, clearError: clearShoppingError, getShoppingItemsWithMeals } = useShoppingContext()
-  const { toast } = useToast()
+  const { shoppingItems, loading, error: shoppingError, getShoppingItemsWithMeals, refreshShoppingItems } = useShoppingContext()
   const [itemsWithMeals, setItemsWithMeals] = useState<ShoppingItemWithMeals[]>([])
   const [showAddForm, setShowAddForm] = useState(false)
   const [sortColumn, setSortColumn] = useState<SortColumn>('status')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-
-  useEffect(() => {
-    if (shoppingError) {
-      toast({ title: 'Error', description: shoppingError, variant: 'destructive' })
-      clearShoppingError()
-    }
-  }, [shoppingError])
+  const [retrying, setRetrying] = useState(false)
 
   useEffect(() => {
     const loadItemsWithMeals = async () => {
@@ -140,17 +134,15 @@ export function ShoppingPage() {
           </Card>
         </div>
 
-        {/* Loading State */}
-        {loading && (
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-muted-foreground text-center py-8">Loading shopping list...</p>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Shopping List Content */}
-        {!loading && (
+        {/* Loading / Error State */}
+        {loading ? (
+          <PageLoadingState />
+        ) : shoppingError ? (
+          <PageErrorState error={shoppingError} onRetry={async () => {
+            setRetrying(true)
+            try { await refreshShoppingItems() } finally { setRetrying(false) }
+          }} retrying={retrying} />
+        ) : (
           <>
             {shoppingItems.length === 0 ? (
               <Card>


### PR DESCRIPTION
## Summary
- Replace inconsistent loading text ("Loading expenses...", "Loading planner...", etc.) and ad-hoc error banners/toasts with the shared `<PageLoadingState />` and `<PageErrorState />` components from Phase 7a
- Add retry functionality (with `retrying` state) to every page that fetches context data
- Remove toast-based error surfacing from PlannerPage, ShoppingPage, and ManageTripPage in favor of inline error cards
- 9 pages updated: ExpensesPage, SettlementsPage, DashboardPage, PlannerPage, ShoppingPage, ManageTripPage, QuickHistoryPage, QuickHomeScreen, AdminAllTripsPage

## Test plan
- [x] `npm run type-check` — passes clean
- [x] `npm test` — 139/139 pass
- [ ] Visual: every page shows centered Loader2 spinner while loading (not text)
- [ ] Visual: every page shows error Card with Retry button when fetch fails
- [ ] Retry button re-fetches data on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)