### PR TITLE
fix: consistent desktop headers + edit dialog mobile alignment

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -11,6 +11,7 @@ import { ShoppingProvider } from '@/contexts/ShoppingContext'
 import { ReceiptProvider } from '@/contexts/ReceiptContext'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { SignInButton } from '@/components/auth/SignInButton'
+import { ModeToggle } from '@/components/quick/ModeToggle'
 import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
 import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
 import { useTripContext } from '@/contexts/TripContext'
@@ -76,7 +77,7 @@ export function QuickLayout() {
           </>
         )}
 
-        <div className="relative max-w-lg mx-auto px-4">
+        <div className="relative max-w-lg lg:max-w-7xl mx-auto px-4 lg:px-8">
           <div className="flex flex-col">
             {/* Row 1: back/logo + trip name (full width) + avatar */}
             <div className="flex items-center justify-between py-3">
@@ -108,13 +109,25 @@ export function QuickLayout() {
               </div>
               <div className="flex items-center gap-2 flex-shrink-0">
                 <ReportIssueButton onGradient={onGradient} />
+                {isInTrip && (
+                  <div className="hidden lg:flex items-center gap-2">
+                    <button
+                      onClick={handleScanTap}
+                      aria-label="Scan receipt"
+                      className={`p-2 rounded-md transition-colors ${onGradient ? 'text-white/80 hover:text-white hover:bg-white/10' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}`}
+                    >
+                      <ScanLine size={20} />
+                    </button>
+                    <ModeToggle onGradient={onGradient} />
+                  </div>
+                )}
                 {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
               </div>
             </div>
 
             {/* Row 2: full-width action strip — only on trip detail page, not sub-pages */}
             {isInTrip && !isSubPage && currentTrip && (
-              <div className={`grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
+              <div className={`lg:hidden grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
                 <button
                   onClick={handleScanTap}
                   className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors ${
@@ -155,7 +168,7 @@ export function QuickLayout() {
       </header>
 
       {/* Main content — extra top padding when two-row header is active */}
-      <main className={isInTrip && !isSubPage ? 'pt-[108px]' : 'pt-16'}>
+      <main className={isInTrip && !isSubPage ? 'pt-[108px] lg:pt-16' : 'pt-16'}>
         <ParticipantProvider>
           <ExpenseProvider>
             <SettlementProvider>

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -518,7 +518,7 @@ export function ManageTripPage() {
 
       {/* Edit Dialog */}
       <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
-        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto mx-4 sm:mx-auto">
           <DialogHeader>
             <DialogTitle>Edit {entityLabel} Details</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
## Summary
- **#356**: QuickLayout desktop header now matches Layout — Row 2 pills hidden on desktop (`lg:hidden`), scan + mode toggle shown inline in Row 1 (`hidden lg:flex`), header container widened (`max-w-lg lg:max-w-7xl`)
- **#352**: Edit Event dialog `max-w-2xl` → `max-w-lg` with `mx-4 sm:mx-auto` for proper mobile margins
- **#355**: Already fixed by PR #351 (closed)

Closes #356, closes #352

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 139 tests pass
- [x] `npm run test:e2e` — 26 tests pass
- [ ] Manual: Quick mode desktop header shows scan + toggle inline (no Row 2 pills)
- [ ] Manual: Full mode desktop header matches Quick mode pattern
- [ ] Manual: Edit Event dialog has proper margins on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)