### PR TITLE
fix: break mobile redirect loop + home link from trip header

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -180,14 +180,14 @@ export function Layout() {
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">
               {currentTrip ? (
-                <div className="flex-1 min-w-0">
+                <Link to="/" state={{ fromTrip: true }} className="flex-1 min-w-0">
                   <h1
                     className={`font-bold text-lg truncate ${onGradient ? 'text-white' : 'text-foreground'}`}
                     style={onGradient ? { textShadow: '0 1px 4px rgba(0,0,0,0.9)' } : undefined}
                   >
                     {currentTrip.name}
                   </h1>
-                </div>
+                </Link>
               ) : (
                 <motion.div
                   className="flex items-center gap-2"
@@ -364,6 +364,7 @@ export function Layout() {
                     <Link
                       key={item.path}
                       to={item.path}
+                      state={item.path === '/' ? { fromTrip: true } : undefined}
                       onClick={() => setMoreMenuOpen(false)}
                       className="block relative"
                     >

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -84,7 +84,11 @@ export function QuickLayout() {
               <div className="flex items-center gap-3 min-w-0">
                 {isInTrip ? (
                   <>
-                    <Link to={backTo} className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}>
+                    <Link
+                      to={backTo}
+                      state={backTo === '/' ? { fromTrip: true } : undefined}
+                      className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}
+                    >
                       {isSubPage ? <X size={20} /> : <ArrowLeft size={20} />}
                     </Link>
                     <div className="min-w-0">

--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -6,11 +6,13 @@ import { buildTrip } from '@/test/factories'
 
 // Track navigation
 const mockNavigate = vi.fn()
+let mockLocationState: any = {}
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
   return {
     ...actual,
     useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: '/', search: '', hash: '', state: mockLocationState, key: 'default' }),
   }
 })
 
@@ -64,6 +66,7 @@ import { getActiveTripId } from '@/lib/activeTripDetection'
 describe('ConditionalHomePage', () => {
   beforeEach(() => {
     mockNavigate.mockClear()
+    mockLocationState = {}
     mockAuth.loading = false
     mockTrips.loading = false
     mockTrips.trips = []
@@ -119,6 +122,28 @@ describe('ConditionalHomePage', () => {
         { replace: true }
       )
     })
+  })
+
+  it('skips auto-redirect when navigated with fromTrip state', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true })
+    const trip = buildTrip({
+      id: 'trip-1',
+      trip_code: 'summer-trip-Ab1234',
+    })
+    mockTrips.trips = [trip]
+    vi.mocked(getActiveTripId).mockReturnValue('trip-1')
+    mockLocationState = { fromTrip: true }
+
+    render(
+      <MemoryRouter>
+        <ConditionalHomePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('renders HomePage on mobile with no active trip', async () => {

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
 import { getActiveTripId } from '@/lib/activeTripDetection'
@@ -10,16 +10,27 @@ import { Loader2 } from 'lucide-react'
 /**
  * Renders at `/` — on mobile with an active trip, auto-redirects to Quick view.
  * Otherwise renders the unified HomePage.
+ *
+ * When navigated here with `state.fromTrip`, the auto-redirect is skipped once
+ * so the user can actually reach the home page from within a trip.
  */
 export function ConditionalHomePage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { user } = useAuth()
   const { trips, loading: tripsLoading } = useTripContext()
 
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
+  const fromTrip = !!(location.state as any)?.fromTrip
 
   useEffect(() => {
     if (!isMobile || tripsLoading) return
+
+    // User explicitly navigated here from a trip — let them stay
+    if (fromTrip) {
+      window.history.replaceState({}, '')
+      return
+    }
 
     const myTrips = user
       ? trips
@@ -32,7 +43,7 @@ export function ConditionalHomePage() {
         navigate(`/t/${activeTrip.trip_code}/quick`, { replace: true })
       }
     }
-  }, [isMobile, tripsLoading, user, trips, navigate])
+  }, [isMobile, tripsLoading, user, trips, navigate, fromTrip])
 
   if (isMobile && tripsLoading) {
     return (


### PR DESCRIPTION
## Summary
- Back arrow on `/t/:code/quick` and trip name in Full mode header now pass `state: { fromTrip: true }` when navigating to `/`
- `ConditionalHomePage` skips auto-redirect when `fromTrip` state is present, breaking the redirect loop on mobile
- Trip name in Layout header is now a `<Link>` to home, giving full-mode users single-tap access
- Overflow menu "Events & Trips" link also passes `fromTrip` state

Closes #361, closes #360

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — all pass (new `fromTrip` test added)
- [ ] Mobile viewport: back arrow on `/t/:code/quick` → lands on `/` and stays (no loop)
- [ ] Mobile viewport: refresh `/` → auto-redirects normally
- [ ] Full mode mobile: tap trip name in header → navigates to home
- [ ] Full mode: "Events & Trips" in overflow menu → navigates to home (no loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)