### PR TITLE
fix: expense wizard iOS sheet pattern + broken card layout (#367, #359)

### DIFF
--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -14,7 +14,7 @@ import { calculateBalances } from '@/services/balanceCalculator'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { useScrollIntoView } from '@/hooks/useScrollIntoView'
-import { Sheet, SheetContent } from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { ExpenseForm } from './ExpenseForm'
 import { WizardProgress } from './wizard/WizardProgress'
@@ -488,11 +488,11 @@ function MobileWizard({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
-        className="flex flex-col p-6 gap-0 overflow-hidden"
+        className="flex flex-col p-0 rounded-t-2xl"
         style={{
           height: keyboard.isVisible
             ? `${keyboard.availableHeight}px`
-            : '90vh',
+            : '92dvh',
           bottom: keyboard.isVisible
             ? `${keyboard.keyboardHeight}px`
             : undefined,
@@ -504,31 +504,36 @@ function MobileWizard({
           }
         }}
       >
-        <WizardProgress currentStep={currentStep} totalSteps={totalSteps} />
+        {/* Sticky header */}
+        <div className="px-6 py-4 border-b border-border shrink-0">
+          <SheetTitle>Add Expense</SheetTitle>
+          <WizardProgress currentStep={currentStep} totalSteps={totalSteps} />
+        </div>
 
-        {error && (
-          <div className="mb-4 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
-            <div className="flex items-start justify-between gap-2">
-              <span>{error}</span>
-              <button
-                type="button"
-                onClick={handleSubmit}
-                disabled={isSubmitting}
-                className="shrink-0 text-xs underline underline-offset-2 opacity-80 hover:opacity-100 disabled:opacity-40"
-              >
-                Try again
-              </button>
-            </div>
-            {errorDetail && (
-              <pre className="mt-2 text-xs whitespace-pre-wrap break-all opacity-80">{errorDetail}</pre>
-            )}
-          </div>
-        )}
-
+        {/* Scrollable content */}
         <div
           ref={contentRef}
-          className="flex-1 min-h-0 overflow-y-auto -mx-6 px-6 pb-4"
+          className="flex-1 overflow-y-auto px-6 py-4"
         >
+          {error && (
+            <div className="mb-4 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
+              <div className="flex items-start justify-between gap-2">
+                <span>{error}</span>
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={isSubmitting}
+                  className="shrink-0 text-xs underline underline-offset-2 opacity-80 hover:opacity-100 disabled:opacity-40"
+                >
+                  Try again
+                </button>
+              </div>
+              {errorDetail && (
+                <pre className="mt-2 text-xs whitespace-pre-wrap break-all opacity-80">{errorDetail}</pre>
+              )}
+            </div>
+          )}
+
           {currentStep === 1 && (
             <WizardStep1
               description={description}
@@ -605,7 +610,8 @@ function MobileWizard({
           )}
         </div>
 
-        <div className="pt-4 border-t border-border" style={{ flexShrink: 0 }}>
+        {/* Sticky footer */}
+        <div className="px-6 py-4 border-t border-border shrink-0">
           <WizardNavigation
             currentStep={currentStep}
             totalSteps={totalSteps}

--- a/src/components/expenses/wizard/WizardProgress.tsx
+++ b/src/components/expenses/wizard/WizardProgress.tsx
@@ -9,9 +9,9 @@ export function WizardProgress({ currentStep, totalSteps }: WizardProgressProps)
   const percentage = (currentStep / totalSteps) * 100
 
   return (
-    <div className="mb-6">
+    <div className="mt-2">
       {/* Progress Bar */}
-      <div className="w-full h-2 bg-muted/30 rounded-full overflow-hidden mb-2">
+      <div className="w-full h-1.5 bg-muted/30 rounded-full overflow-hidden mb-1">
         <motion.div
           className="h-full bg-primary"
           initial={{ width: 0 }}
@@ -26,10 +26,10 @@ export function WizardProgress({ currentStep, totalSteps }: WizardProgressProps)
 
       {/* Step Indicator */}
       <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           Step {currentStep} of {totalSteps}
         </p>
-        <p className="text-sm font-medium text-primary">
+        <p className="text-xs font-medium text-primary">
           {percentage.toFixed(0)}%
         </p>
       </div>

--- a/src/components/quick/TransactionItem.tsx
+++ b/src/components/quick/TransactionItem.tsx
@@ -17,11 +17,17 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
   }
 
-  const formatDualCurrency = (amount: number, currency: string) => {
-    const base = formatAmount(amount, currency)
-    if (!defaultCurrency || !exchangeRates || currency === defaultCurrency) return base
-    const converted = convertToBaseCurrency(amount, currency, defaultCurrency, exchangeRates)
-    return `${formatAmount(converted, defaultCurrency)} (${base})`
+  const isForeignCurrency = !!defaultCurrency && !!exchangeRates && tx.currency !== defaultCurrency
+
+  const formatBaseAmount = (amount: number, currency: string) => {
+    if (!isForeignCurrency) return formatAmount(amount, currency)
+    const converted = convertToBaseCurrency(amount, currency, defaultCurrency!, exchangeRates!)
+    return formatAmount(converted, defaultCurrency!)
+  }
+
+  const formatOriginalAmount = (amount: number, currency: string) => {
+    if (!isForeignCurrency) return null
+    return formatAmount(amount, currency)
   }
 
   const getRoleDisplay = () => {
@@ -30,8 +36,12 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
         return {
           label: 'You paid',
           icon: <DollarSign size={16} className="text-primary" />,
-          amountText: `Total: ${formatDualCurrency(tx.roleAmount, tx.currency)}`,
-          subText: tx.myShare !== undefined ? `Your share: ${formatDualCurrency(tx.myShare, tx.currency)}` : null,
+          prefix: 'Total:',
+          mainAmount: formatBaseAmount(tx.roleAmount, tx.currency),
+          originalAmount: formatOriginalAmount(tx.roleAmount, tx.currency),
+          subPrefix: tx.myShare !== undefined ? 'Your share:' : null,
+          subAmount: tx.myShare !== undefined ? formatBaseAmount(tx.myShare, tx.currency) : null,
+          subOriginal: tx.myShare !== undefined ? formatOriginalAmount(tx.myShare, tx.currency) : null,
           amountClass: 'text-foreground font-semibold',
           bgClass: 'bg-primary/5',
         }
@@ -39,8 +49,12 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
         return {
           label: `${tx.payerName} paid`,
           icon: <DollarSign size={16} className="text-muted-foreground" />,
-          amountText: `Your share: ${formatDualCurrency(tx.roleAmount, tx.currency)}`,
-          subText: `Total: ${formatDualCurrency(tx.amount, tx.currency)}`,
+          prefix: 'Your share:',
+          mainAmount: formatBaseAmount(tx.roleAmount, tx.currency),
+          originalAmount: formatOriginalAmount(tx.roleAmount, tx.currency),
+          subPrefix: 'Total:',
+          subAmount: formatBaseAmount(tx.amount, tx.currency),
+          subOriginal: formatOriginalAmount(tx.amount, tx.currency),
           amountClass: 'text-muted-foreground',
           bgClass: 'bg-muted/30',
         }
@@ -48,8 +62,12 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
         return {
           label: `You paid ${tx.recipientName}`,
           icon: <ArrowUpRight size={16} className="text-red-500" />,
-          amountText: formatDualCurrency(tx.roleAmount, tx.currency),
-          subText: null,
+          prefix: null,
+          mainAmount: formatBaseAmount(tx.roleAmount, tx.currency),
+          originalAmount: formatOriginalAmount(tx.roleAmount, tx.currency),
+          subPrefix: null,
+          subAmount: null,
+          subOriginal: null,
           amountClass: 'text-red-600 dark:text-red-400 font-semibold',
           bgClass: 'bg-red-50 dark:bg-red-950/20',
         }
@@ -57,8 +75,12 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
         return {
           label: `${tx.payerName} paid you`,
           icon: <ArrowDownLeft size={16} className="text-green-500" />,
-          amountText: formatDualCurrency(tx.roleAmount, tx.currency),
-          subText: null,
+          prefix: null,
+          mainAmount: formatBaseAmount(tx.roleAmount, tx.currency),
+          originalAmount: formatOriginalAmount(tx.roleAmount, tx.currency),
+          subPrefix: null,
+          subAmount: null,
+          subOriginal: null,
           amountClass: 'text-green-600 dark:text-green-400 font-semibold',
           bgClass: 'bg-green-50 dark:bg-green-950/20',
         }
@@ -68,29 +90,41 @@ export function TransactionItem({ transaction: tx, defaultCurrency, exchangeRate
   const display = getRoleDisplay()
 
   return (
-    <div className={`flex items-center justify-between px-4 py-3 rounded-lg ${display.bgClass}`}>
-      <div className="flex items-center gap-3 min-w-0">
-        <div className="flex-shrink-0">{display.icon}</div>
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-foreground break-words">
-            {tx.type === 'expense' ? tx.description : display.label}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {tx.type === 'expense' ? display.label : tx.description}
-            {' \u00B7 '}
-            {formatDate(tx.date)}
-          </p>
+    <div className={`flex items-start gap-3 px-4 py-3 rounded-lg ${display.bgClass}`}>
+      <div className="flex-shrink-0 mt-0.5">{display.icon}</div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-foreground truncate">
+              {tx.type === 'expense' ? tx.description : display.label}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {tx.type === 'expense' ? display.label : tx.description}
+              {' \u00B7 '}
+              {formatDate(tx.date)}
+            </p>
+          </div>
+          <div className="flex-shrink-0 text-right">
+            <p className={`text-sm tabular-nums ${display.amountClass}`}>
+              {display.prefix && <span className="text-xs font-normal text-muted-foreground">{display.prefix} </span>}
+              {display.mainAmount}
+            </p>
+            {display.originalAmount && (
+              <p className="text-[11px] text-muted-foreground/70 tabular-nums">{display.originalAmount}</p>
+            )}
+            {display.subAmount && (
+              <>
+                <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
+                  {display.subPrefix && <span>{display.subPrefix} </span>}
+                  {display.subAmount}
+                </p>
+                {display.subOriginal && (
+                  <p className="text-[11px] text-muted-foreground/70 tabular-nums">{display.subOriginal}</p>
+                )}
+              </>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="flex-shrink-0 ml-3 text-right">
-        <p className={`text-sm tabular-nums ${display.amountClass}`}>
-          {display.amountText}
-        </p>
-        {display.subText && (
-          <p className="text-xs text-muted-foreground tabular-nums">
-            {display.subText}
-          </p>
-        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- **Expense wizard header disappearing on iOS** (#367): Refactored `MobileWizard` to the canonical iOS sheet pattern (`p-0`, `92dvh`, `rounded-t-2xl`, `shrink-0` sticky header with `SheetTitle`). The old `p-6` + `90vh` layout let the progress bar/header shrink away when the iOS keyboard opened.
- **Inconsistent close experience** (#359): PR #364 only fixed `QuickSettlementSheet` but left the expense wizard untouched. Now both sheets follow the identical iOS sheet pattern with proper header + close X.
- **Broken transaction cards** (history page): Dual-currency amounts like `Total: €24.31 (THB 875.00)` squeezed description to ~5 characters wide due to `flex-shrink-0` on the amount column. Split base/foreign amounts onto separate lines so both description and amounts have room.

## Changes
| File | What changed |
|------|-------------|
| `ExpenseWizard.tsx` | MobileWizard → iOS sheet pattern: `p-0`, `92dvh`, `rounded-t-2xl`, sticky `shrink-0` header with `SheetTitle "Add Expense"`, `flex-1 overflow-y-auto` content, `shrink-0` footer |
| `WizardProgress.tsx` | Compact layout (`mt-2`, smaller bar `h-1.5`, `text-xs`) to fit inside sticky header alongside title |
| `TransactionItem.tsx` | Split dual-currency into base amount + foreign amount on separate line; description truncates cleanly instead of wrapping to 5+ lines |

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — 140 tests pass
- [x] `npm run build` succeeds
- [ ] Mobile: open "Add an expense" wizard → verify "Add Expense" title + progress bar visible in sticky header
- [ ] Mobile: tap into an amount field → iOS keyboard opens → header stays pinned, content scrolls
- [ ] Mobile: open "Settle up" sheet → verify same header/X pattern as expense wizard
- [ ] Mobile: "View expenses & payments" → verify card text not squished, amounts on separate lines for foreign currency
- [ ] Desktop: expense wizard renders as Dialog (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)