### PR TITLE
fix: prevent keyboard from hiding sheet header + unify back icon

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Link, useParams, useLocation, useNavigate } from 'react-router-dom'
-import { ArrowLeft, X, ScanLine, Settings, LayoutGrid } from 'lucide-react'
+import { ArrowLeft, ScanLine, Settings, LayoutGrid } from 'lucide-react'
 import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -89,7 +89,7 @@ export function QuickLayout() {
                       state={backTo === '/' ? { fromTrip: true } : undefined}
                       className={onGradient ? 'text-white/80 hover:text-white' : 'text-muted-foreground hover:text-foreground'}
                     >
-                      {isSubPage ? <X size={20} /> : <ArrowLeft size={20} />}
+                      <ArrowLeft size={20} />
                     </Link>
                     <div className="min-w-0">
                       <h1 className={`text-base font-semibold line-clamp-2 leading-tight ${onGradient ? 'text-white' : 'text-foreground'}`} style={onGradient ? { textShadow: '0 1px 4px rgba(0,0,0,0.9)' } : undefined}>

--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -4,8 +4,7 @@ import { ArrowRight } from 'lucide-react'
 import { CreateSettlementInput } from '@/types/settlement'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
-import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
-import { useScrollIntoView } from '@/hooks/useScrollIntoView'
+
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -48,15 +47,6 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
   useEffect(() => {
     return () => { isMounted.current = false }
   }, [])
-
-  // Keyboard detection for mobile
-  const formRef = useRef<HTMLFormElement>(null)
-  const keyboard = useKeyboardHeight()
-
-  useScrollIntoView(formRef, {
-    enabled: keyboard.isVisible,
-    offset: 20,
-  })
 
   // Update form when initial values change
   useEffect(() => {
@@ -175,7 +165,6 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
 
   return (
     <motion.form
-      ref={formRef}
       onSubmit={handleSubmit}
       className="space-y-4"
       variants={fadeInUp}

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -13,7 +13,7 @@ import { useAuth } from '@/contexts/AuthContext'
 import { calculateBalances } from '@/services/balanceCalculator'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
-import { useScrollIntoView } from '@/hooks/useScrollIntoView'
+
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { ExpenseForm } from './ExpenseForm'
@@ -81,13 +81,7 @@ function MobileWizard({
   const { user } = useAuth()
 
   // Keyboard detection for mobile
-  const contentRef = useRef<HTMLDivElement>(null)
   const keyboard = useKeyboardHeight()
-
-  useScrollIntoView(contentRef, {
-    enabled: keyboard.isVisible,
-    offset: 20,
-  })
 
   const [currentStep, setCurrentStep] = useState(1)
   const [showAdvanced, setShowAdvanced] = useState(false)
@@ -488,7 +482,7 @@ function MobileWizard({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
-        className="flex flex-col p-0 rounded-t-2xl"
+        className="flex flex-col p-0 rounded-t-2xl gap-0"
         style={{
           height: keyboard.isVisible
             ? `${keyboard.availableHeight}px`
@@ -512,8 +506,7 @@ function MobileWizard({
 
         {/* Scrollable content */}
         <div
-          ref={contentRef}
-          className="flex-1 overflow-y-auto px-6 py-4"
+          className="flex-1 overflow-y-auto min-h-0 px-6 py-4"
         >
           {error && (
             <div className="mb-4 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">


### PR DESCRIPTION
## Summary
- **Keyboard hiding sheet header on iPhone**: Added `gap-0` to ExpenseWizard SheetContent (overrides variant's `gap-4` adding 32px dead space), restored `min-h-0` on scrollable content div, and removed `useScrollIntoView` from both `ExpenseWizard` and `SettlementForm` — the hook is redundant with keyboard-aware sheet height and was causing the header to scroll away on iOS
- **Close icon inconsistency**: QuickLayout sub-pages (history) now use `ArrowLeft` instead of `X`, creating a clear visual distinction: back arrow (left) = page navigation, X (right) = sheet close

## Test plan
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — 139/140 pass (1 pre-existing flaky)
- [ ] Mobile (375×812): open "Add an expense" → tap amount field → header stays pinned
- [ ] Mobile: open "Settle up" → "Record a custom payment" → header stays visible
- [ ] Mobile: open "View expenses" → verify back arrow (not X) on left
- [ ] Real iPhone: expense wizard → tap amount → "Add Expense" header + progress bar stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)