### PR TITLE
fix: contrast "1" in Spl1t brand + bust marketing logo cache

### DIFF
--- a/public/marketing.html
+++ b/public/marketing.html
@@ -28,9 +28,9 @@
   <title>Spl1t — Split costs, not friendships</title>
   <meta name="description" content="The fastest way to split trip and event costs. AI receipt scanning, shared link access — no sign-up required.">
   <meta name="theme-color" content="#E8714A">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png?v=2">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -751,7 +751,7 @@
   <nav class="nav" id="nav">
     <div class="container nav-inner">
       <a href="#" style="display:flex;align-items:center;gap:10px;text-decoration:none;">
-        <img src="/logo.png" alt="Spl1t" width="32" height="32" style="border-radius:6px;" />
+        <img src="/logo.png?v=2" alt="Spl1t" width="32" height="32" style="border-radius:6px;" />
         <span style="font-size:1.375rem;font-weight:800;letter-spacing:-0.02em;color:var(--text);">Spl<span style="color:var(--primary);">1</span>t</span>
       </a>
       <a href="https://split.xtian.me" class="btn btn-primary btn-sm">Open App</a>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -197,7 +197,7 @@ export function Layout() {
                 >
                   <img src="/logo.png" alt="Spl1t" className="h-9 w-9 rounded-full" />
                   <h1 className="text-2xl font-bold text-foreground">
-                    Spl1t
+                    Spl<span className="text-[#E8714A]">1</span>t
                   </h1>
                 </motion.div>
               )}

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -106,7 +106,7 @@ export function QuickLayout() {
                   <div className="flex items-center gap-2">
                     <img src="/logo.png" alt="Spl1t" className="h-8 w-8 rounded-full" />
                     <h1 className="text-lg font-semibold text-foreground">
-                      Spl1t
+                      Spl<span className="text-[#E8714A]">1</span>t
                     </h1>
                   </div>
                 )}

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -225,7 +225,7 @@ export function JoinPage() {
             className="text-3xl font-bold tracking-tight mb-1"
             style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}
           >
-            Spl1t
+            Spl<span style={{ color: '#E8714A', WebkitTextFillColor: '#E8714A' }}>1</span>t
           </h1>
           <p className="text-xs text-muted-foreground">Fair cost splitting for groups</p>
         </div>


### PR DESCRIPTION
## Summary
- Style the "1" in **Spl1t** with coral `#E8714A` across Layout, QuickLayout, and JoinPage headers — matching the marketing page convention
- Add `?v=2` cache-busting to marketing.html logo and favicon references so the new S-mark brand logo loads instead of the cached old one

## Test plan
- [ ] Verify "1" is coral in the app header (both Full and Quick mode)
- [ ] Verify JoinPage shows coral "1" over the purple gradient
- [ ] Verify marketing page at /marketing.html loads the new S-mark logo (not the old globe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)