### PR TITLE
fix: cache-bust logo and favicon in main app

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png?v=2" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Spl1t</title>
   </head>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -195,7 +195,7 @@ export function Layout() {
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <img src="/logo.png" alt="Spl1t" className="h-9 w-9 rounded-full" />
+                  <img src="/logo.png?v=2" alt="Spl1t" className="h-9 w-9 rounded-full" />
                   <h1 className="text-2xl font-bold text-foreground">
                     Spl<span className="text-[#E8714A]">1</span>t
                   </h1>

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -104,7 +104,7 @@ export function QuickLayout() {
                   </>
                 ) : (
                   <div className="flex items-center gap-2">
-                    <img src="/logo.png" alt="Spl1t" className="h-8 w-8 rounded-full" />
+                    <img src="/logo.png?v=2" alt="Spl1t" className="h-8 w-8 rounded-full" />
                     <h1 className="text-lg font-semibold text-foreground">
                       Spl<span className="text-[#E8714A]">1</span>t
                     </h1>


### PR DESCRIPTION
## Summary
- Add `?v=2` cache-busting query params to `/logo.png` in Layout and QuickLayout headers
- Add `?v=2` to favicon and apple-touch-icon refs in `index.html`
- Ensures browsers and Cloudflare CDN serve the new S-mark brand assets instead of the cached old globe logo

## Test plan
- [ ] Hard-refresh split.xtian.me — new S-mark logo appears in header
- [ ] Tab favicon shows new brand mark
- [ ] Check on mobile (iOS Safari) — apple-touch-icon updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)