### PR TITLE
fix: left-align marketing hero text on desktop (#374)

### DIFF
--- a/public/marketing.html
+++ b/public/marketing.html
@@ -187,11 +187,11 @@
       gap: 48px;
       align-items: center;
     }
+    .hero-text { position: relative; z-index: 1; text-align: center; }
     @media (min-width: 768px) {
       .hero-grid { grid-template-columns: 1fr auto; gap: 64px; }
       .hero-text { text-align: left; }
     }
-    .hero-text { position: relative; z-index: 1; text-align: center; }
     .hero-text h1 { margin-bottom: 20px; }
     .hero-headline-accent { position: relative; display: inline-block; }
     .hero-headline-accent svg { position: absolute; bottom: -8px; left: 0; width: 100%; height: 12px; }


### PR DESCRIPTION
## Summary
- Fix CSS source-order bug where `.hero-text { text-align: center }` (base) was defined after the `@media (min-width: 768px)` override, so center always won on desktop
- Hero heading, label, and paragraph are now left-aligned on desktop as intended

## Test plan
- [ ] Desktop (1280px): hero text left-aligned, buttons left-aligned
- [ ] Mobile (375px): hero text still centered

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)