### PR TITLE
fix: expense wizard sheet gap when iOS numpad opens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,9 @@ On mobile (< 768 px), renders `MobileWizard` (bottom Sheet, 3–4 step wizard). 
 - `paidBy` is pre-filled with the auth user's linked adult participant (`participant.user_id === user.id && is_adult`) via a `useEffect` that fires when the form opens and the field is still empty
 - `suggestedPayer` banner still shows the balance-based suggestion; tapping it overrides `paidBy`
 - `useMediaQuery('(max-width: 768px)')` initialises as `false` on first render, then updates — this is expected behaviour
-- Sheet height: `keyboard.isVisible ? availableHeight - viewportOffset : 92dvh` — `viewportOffset` accounts for iOS visual viewport scroll when numpad opens
-- Sheet bottom: `keyboard.isVisible ? keyboardHeight : undefined` — **critical for iOS** (see iOS section)
+- Sheet height: `keyboard.isVisible ? availableHeight : 92dvh`
+- Sheet bottom: `keyboard.isVisible ? Math.max(0, keyboardHeight - viewportOffset) : undefined` — **critical for iOS** (see iOS section)
+- Sheet paddingBottom: `viewportOffset > 0 ? viewportOffset : undefined` — keeps content above keyboard overlap zone when iOS scrolls the visual viewport
 
 ### Bottom Sheet Standard (`AppSheet` — `src/components/ui/AppSheet.tsx`)
 
@@ -262,13 +263,18 @@ Fix pattern (in `MobileWizard`):
 ```tsx
 style={{
   height: keyboard.isVisible
-    ? `${keyboard.availableHeight - keyboard.viewportOffset}px`
+    ? `${keyboard.availableHeight}px`
     : '92dvh',
-  bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
+  bottom: keyboard.isVisible
+    ? `${Math.max(0, keyboard.keyboardHeight - keyboard.viewportOffset)}px`
+    : undefined,
+  paddingBottom: keyboard.isVisible && keyboard.viewportOffset > 0
+    ? `${keyboard.viewportOffset}px`
+    : undefined,
 }}
 ```
 
-`useKeyboardHeight` (`src/hooks/useKeyboardHeight.ts`) uses `window.visualViewport` to detect keyboard visibility. Keyboard is considered open when `window.innerHeight - visualViewport.height > 150px`. Also tracks `viewportOffset` (`visualViewport.offsetTop`) — on iOS, the browser scrolls the visual viewport when a taller keyboard (numpad) opens, which can push the sheet header above the visible area. Subtracting `viewportOffset` from the height keeps the header in view.
+`useKeyboardHeight` (`src/hooks/useKeyboardHeight.ts`) uses `window.visualViewport` to detect keyboard visibility. Keyboard is considered open when `window.innerHeight - visualViewport.height > 150px`. Also tracks `viewportOffset` (`visualViewport.offsetTop`) — on iOS, the browser scrolls the visual viewport when a taller keyboard (numpad) opens, which can push the sheet header above the visible area. The fix adjusts `bottom` downward by `viewportOffset` (closing the gap with the keyboard) and adds `paddingBottom` to keep flex content above the keyboard overlap zone.
 
 **Do not** use `autoFocus` or `ref.focus()` on inputs inside sheets/modals — it triggers the keyboard immediately on open, before the user has tapped anything.
 
@@ -393,7 +399,7 @@ Run interactively via Claude Code with Playwright MCP. Scenarios requiring Googl
 | Sheet header scrolls away | `overflow-y-auto` on SheetContent or missing `shrink-0` on header | Use flex structure: `shrink-0` header + `flex-1 overflow-y-auto` content. See Bottom Sheet Standard. |
 | Two X buttons on sheet | Radix default absolute X + custom close button | Pass `hideClose` to `SheetContent` to suppress Radix default |
 | Sheet height wrong on iOS | Using `vh` instead of `dvh` | Always use `dvh`. `vh` does not recalculate when iOS keyboard opens. |
-| Sheet header hidden when numpad opens | iOS numpad is taller → `visualViewport.offsetTop > 0` → header above visible area | Subtract `keyboard.viewportOffset` from sheet height: `availableHeight - viewportOffset` |
+| Sheet header hidden when numpad opens | iOS numpad is taller → `visualViewport.offsetTop > 0` → header above visible area | Reduce `bottom` by `viewportOffset` + add `paddingBottom: viewportOffset` (see iOS Keyboard section) |
 
 ---
 

--- a/SHEET_AUDIT.md
+++ b/SHEET_AUDIT.md
@@ -116,7 +116,12 @@ No variations. No plain X without circle. No oversized X. No Radix default absol
     className="flex flex-col p-0 rounded-t-2xl"
     style={{
       height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-      bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
+      bottom: keyboard.isVisible
+        ? `${Math.max(0, keyboard.keyboardHeight - keyboard.viewportOffset)}px`
+        : undefined,
+      paddingBottom: keyboard.isVisible && keyboard.viewportOffset > 0
+        ? `${keyboard.viewportOffset}px`
+        : undefined,
     }}
   >
     {/* STICKY HEADER — never scrolls */}
@@ -288,7 +293,7 @@ interface AppSheetProps {
 
 | # | Component | Issue | Fix applied | Status |
 |---|-----------|-------|-------------|--------|
-| 12 | MobileWizard (ExpenseWizard.tsx) | iOS Safari: numpad keyboard causes `visualViewport.offsetTop > 0`, pushing sheet header above visible viewport — ✕ close button disappears on first numpad open | Added `viewportOffset` to `useKeyboardHeight` hook (tracks `visualViewport.offsetTop`); subtracted offset from sheet height so top aligns with visible viewport. When offset=0 (common case), behavior unchanged. | ✅ Done (PR #373) |
+| 12 | MobileWizard (ExpenseWizard.tsx) | iOS Safari: numpad keyboard causes `visualViewport.offsetTop > 0`, pushing sheet header above visible viewport — ✕ close button disappears on first numpad open | Added `viewportOffset` to `useKeyboardHeight` hook (tracks `visualViewport.offsetTop`). **v1 (PR #376):** subtracted offset from height — fixed header but left gap between sheet and keyboard. **v2 (PR #380):** keep `height: availableHeight` (no subtraction), reduce `bottom` by `viewportOffset` (closes gap), add `paddingBottom: viewportOffset` (keeps content above keyboard overlap). When offset=0, identical to pre-#376 behavior. | ✅ Done (PR #380) |
 
 ### Test results
 
@@ -374,5 +379,5 @@ The same `visualViewport.offsetTop` issue fixed in MobileWizard (PR #373) exists
 - `QuickParticipantSetupSheet` (`src/components/quick/QuickParticipantSetupSheet.tsx`)
 - `QuickScanCreateFlow` (`src/components/quick/QuickScanCreateFlow.tsx`)
 
-**Fix:** In each, change `keyboard.availableHeight` to `keyboard.availableHeight - keyboard.viewportOffset`.
+**Fix:** In each, apply the same pattern as MobileWizard: keep `height: availableHeight`, reduce `bottom` by `viewportOffset`, add `paddingBottom: viewportOffset`.
 Alternatively, fix `AppSheet` and migrate sheets that don't use it yet.

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -487,10 +487,13 @@ function MobileWizard({
         className="flex flex-col p-0 rounded-t-2xl"
         style={{
           height: keyboard.isVisible
-            ? `${keyboard.availableHeight - keyboard.viewportOffset}px`
+            ? `${keyboard.availableHeight}px`
             : '92dvh',
           bottom: keyboard.isVisible
-            ? `${keyboard.keyboardHeight}px`
+            ? `${Math.max(0, keyboard.keyboardHeight - keyboard.viewportOffset)}px`
+            : undefined,
+          paddingBottom: keyboard.isVisible && keyboard.viewportOffset > 0
+            ? `${keyboard.viewportOffset}px`
             : undefined,
         }}
         onInteractOutside={(e) => {


### PR DESCRIPTION
## Summary
- PR #376 fixed the X close button disappearing when the iOS numpad opens by subtracting `viewportOffset` from sheet height — but this left a visible gap between the sheet bottom and the keyboard
- **Root cause:** height was reduced by `viewportOffset` but `bottom: keyboardHeight` was unchanged, so the sheet sits `viewportOffset` px above the keyboard
- **Fix:** keep `height: availableHeight` (full visual viewport), reduce `bottom` by `viewportOffset` (closes the gap), add `paddingBottom: viewportOffset` (keeps flex content above the keyboard overlap zone)
- When `viewportOffset = 0` (common case / non-numpad), behavior is identical to pre-#376

## Changes
| Property | Before (broken) | After (fix) |
|----------|-----------------|-------------|
| `height` | `availableHeight - viewportOffset` | `availableHeight` |
| `bottom` | `keyboardHeight` | `Math.max(0, keyboardHeight - viewportOffset)` |
| `paddingBottom` | (none) | `viewportOffset` (when > 0) |

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 140/140 pass
- [ ] Real iOS test: open expense wizard → focus Amount field → confirm no gap between sheet and keyboard, X button visible, Next button visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)