### PR TITLE
fix: unify quick action button presentation across all 4 actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,26 @@ Always `dvh`. **Never** `vh`. **Never** `100vh`. **Never** `h-screen`.
 
 **Full spec and audit log:** `SHEET_AUDIT.md`
 
+### Quick Actions Standard (QuickGroupDetailPage)
+
+All 4 quick action buttons open **overlays** — never navigate away from `QuickGroupDetailPage`. The pattern:
+
+- **Mobile (< 768px)**: Bottom sheet (`Sheet` + `SheetContent side="bottom"`)
+- **Desktop (>= 768px)**: Centered dialog (`Dialog` + `DialogContent`)
+
+Breakpoint detection: `useMediaQuery('(max-width: 767px)')`.
+
+| Button | Mobile | Desktop | Height | Keyboard |
+|--------|--------|---------|--------|----------|
+| Scan a receipt | Sheet | Dialog `max-w-lg` | `92dvh` | N/A (no inputs) |
+| Add an expense | Sheet (MobileWizard) | Dialog `max-w-2xl` | `92dvh` + keyboard | `viewportOffset` ✅ |
+| Settle up | Sheet | Dialog `max-w-lg` | `92dvh` + keyboard | `viewportOffset` ✅ |
+| View history | Sheet | Dialog `max-w-lg` | `75dvh` | N/A (read-only) |
+
+Desktop dialogs use `hideClose` (custom header close button) + `max-h-[85vh] p-0 gap-0`. Content is shared between Sheet and Dialog via extracted JSX variables.
+
+**Full audit log:** `QUICK_ACTIONS_AUDIT.md`
+
 ### iOS Keyboard / Viewport
 
 On iOS Safari the **layout viewport does not shrink** when the soft keyboard opens. A `position: fixed; bottom: 0` Sheet stays at the physical screen bottom — behind the keyboard.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 # PLAN.md — Spl1t Feature Planning Document
 
 > **Living document.** Update at the start and end of every session.
-> Last updated: 2026-02-24 (Phases 1–7 ✅ all done; logo + favicon refresh)
+> Last updated: 2026-02-24 (Phases 1–7 ✅ all done; quick actions consistency audit)
 
 ---
 
@@ -739,6 +739,7 @@ Replace ad-hoc loading/error patterns with the shared components from 7a.
 | 2026-02-24 | Sheet/dialog audit | Full audit of all 11 bottom sheets + 20+ desktop dialogs. Defined single structural standard: `hideClose` + 3-slot header (back/spacer | title | close) + `flex flex-col` + `shrink-0` header + `flex-1 overflow-y-auto overscroll-contain` content + `dvh` heights. Created `AppSheet` reusable component (`src/components/ui/AppSheet.tsx`). Fixed all 11 sheets: 6 minor (close btn + hideClose + overscroll-contain), 3 moderate (header refactor), 2 full rebuilds (ReceiptCaptureSheet, DayDetailSheet). Added 3 sheet pitfalls to CLAUDE.md + new "Bottom Sheet Standard" section. Verified 5 sheets via Playwright MCP (localhost, 375×812). 140/140 tests pass, type-check clean. Full audit log in `SHEET_AUDIT.md`. |
 | 2026-02-24 | Logo + favicon refresh | Replaced old Trip-Splitter Pro circular clipart logo with new Spl1t split-S letter mark (coral + cream). Generated favicon at 32px + 16px (coral background for legibility) and apple-touch-icon at 180px. Updated index.html favicon tags, Layout.tsx + QuickLayout.tsx already had correct alt text. Updated marketing.html nav to show logo mark (32px) + wordmark side by side. Source assets archived in public/brand/. |
 | 2026-02-24 | Expense wizard numpad fix | PR #376: iOS Safari numpad keyboard (`inputMode="decimal"`) is taller than text keyboard — causes `visualViewport.offsetTop > 0`, pushing sheet header (✕ close button) above visible viewport on first open. Fix: added `viewportOffset` (`visualViewport.offsetTop`) to `useKeyboardHeight` hook; subtracted from sheet height in MobileWizard. When offset=0 (common case), behavior unchanged. Same vulnerability exists in 6 other sheets — logged in SHEET_AUDIT.md §8.1 for follow-up. |
+| 2026-02-24 | Quick actions consistency audit | Unified all 4 quick action buttons in QuickGroupDetailPage: mobile → bottom sheet, desktop → centered Dialog. (1) `dialog.tsx`: added `hideClose` prop to `DialogContent`. (2) `ReceiptCaptureSheet`: added Sheet/Dialog conditional (was always bottom sheet). (3) `QuickSettlementSheet`: added `viewportOffset` fix to keyboard style + Sheet/Dialog conditional. (4) Created `QuickHistorySheet` (was page navigation to `/quick/history`, now overlay). (5) `QuickGroupDetailPage`: history button switched from `navigate()` to `setHistoryOpen(true)`. Verified all 4 buttons via Playwright MCP on mobile (375×812) + desktop (1280×800). 140/140 tests, type-check clean. Full audit log in `QUICK_ACTIONS_AUDIT.md`. |
 
 ---
 

--- a/QUICK_ACTIONS_AUDIT.md
+++ b/QUICK_ACTIONS_AUDIT.md
@@ -1,0 +1,228 @@
+# Quick Actions Consistency Audit
+> Started: 2026-02-24
+> Status: COMPLETE
+> Scope: The 4 quick action buttons in QuickGroupDetailPage
+> Goal: Consistent bottom sheet (mobile) + centered modal
+>   (desktop) experience across all 4 actions.
+> Update this file continuously throughout the session.
+> If context is lost, read this file to resume.
+
+---
+
+## 1. Current Behaviour Inventory
+
+### Quick action buttons (QuickGroupDetailPage.tsx:178-204)
+
+| # | Button | Component opened | Mobile behaviour | Desktop behaviour | Height | Width | Navigates away? | Keyboard: width stable? | Header stable on keyboard? |
+|---|--------|-----------------|------------------|-------------------|--------|-------|-----------------|------------------------|---------------------------|
+| 1 | Scan a receipt | `ReceiptCaptureSheet` | Bottom sheet (`side="bottom"`) | **Same bottom sheet** — no desktop dialog | `92dvh` (static, no keyboard hook) | `w-full` (no explicit width) | No ✅ | N/A (no text inputs) | Yes ✅ (shrink-0 header) |
+| 2 | Add an expense | `QuickExpenseSheet` → `ExpenseWizard` → Mobile: `MobileWizard` (Sheet), Desktop: `ExpenseForm` (Dialog) | Bottom sheet, keyboard-aware height/bottom/paddingBottom with `viewportOffset` | Centered Dialog `max-w-2xl max-h-[90vh]` | Mobile: `92dvh` / `availableHeight` when keyboard open. Desktop: `max-h-[90vh]` | Mobile: `w-full`. Desktop: `max-w-2xl` (672px) | No ✅ | Yes ✅ | Yes ✅ (shrink-0 + viewportOffset fix) |
+| 3 | Settle up | `QuickSettlementSheet` | Bottom sheet, keyboard-aware height/bottom but **missing `viewportOffset`** | **Same bottom sheet** — no desktop dialog | `92dvh` / `availableHeight` when keyboard open | `w-full` (no explicit width) | No ✅ | Yes ✅ | **Partial** — no `viewportOffset` fix, numpad can push header off screen |
+| 4 | View expenses & payments | `QuickHistoryPage` (page navigation) | **Navigates away** to `/t/:tripCode/quick/history` — full page inside QuickLayout | **Navigates away** — same full page | Page height (not a sheet) | `max-w-lg mx-auto` page container | Yes ❌ | N/A | N/A |
+
+### Per-button details
+
+#### 1. Scan a receipt (`ReceiptCaptureSheet`)
+- Uses `Sheet` + `SheetContent side="bottom"` ✅
+- `hideClose` ✅
+- Standard 3-slot header: spacer | title | ✕ close ✅
+- `shrink-0` header with `border-b` ✅
+- `flex-1 overflow-y-auto overscroll-contain` scroll area ✅
+- `dvh` ✅ (not `vh`)
+- No `useKeyboardHeight` — no text inputs in this sheet (file picker buttons only)
+- **Desktop**: renders as bottom sheet, NOT a centered dialog ❌
+
+#### 2. Add an expense (`ExpenseWizard` → `MobileWizard` / `Dialog`)
+- Mobile: `MobileWizard` — full AppSheet standard ✅
+  - `hideClose` ✅, `shrink-0` header ✅, `dvh` ✅
+  - `useKeyboardHeight` with `viewportOffset` fix ✅ (best implementation)
+  - Sticky footer with navigation buttons ✅
+- Desktop: `Dialog` + `DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto"` ✅
+  - Centered modal ✅
+  - But `max-w-2xl` (672px), not `max-w-lg` (512px)
+  - Uses `vh` not `dvh` for `max-h` (desktop, acceptable)
+  - Radix default close button (absolute positioned) — no custom close
+- Breakpoint: `useMediaQuery('(max-width: 768px)')` — switches at 768px
+
+#### 3. Settle up (`QuickSettlementSheet`)
+- Uses `Sheet` + `SheetContent side="bottom"` ✅
+- `hideClose` ✅
+- Standard 3-slot header with back (form view) or spacer ✅
+- `shrink-0` header with `border-b` ✅
+- `flex-1 overflow-y-auto overscroll-contain` scroll area ✅
+- `dvh` ✅
+- `useKeyboardHeight` ✅ but keyboard style is:
+  ```
+  height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh'
+  bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined
+  ```
+  **Missing**: `viewportOffset` subtraction from bottom, `paddingBottom` for viewportOffset
+- **Desktop**: renders as bottom sheet, NOT a centered dialog ❌
+
+#### 4. View expenses & payments (`QuickHistoryPage`)
+- **Not a sheet at all** — navigates to `/t/:tripCode/quick/history`
+- Renders as full page inside `QuickLayout`
+- Has its own filter tabs (All / Expenses / Payments)
+- Read-only content (no keyboard interactions)
+- **Biggest deviation**: leaves `QuickGroupDetailPage` entirely ❌
+
+---
+
+## 2. The Standard (proposed)
+
+### Mobile standard (< 1024px)
+
+Every quick action opens as a **bottom sheet**. None navigate away from `QuickGroupDetailPage`. The user can always dismiss with ✕ and return to the trip detail.
+
+Sheet structure — identical to the AppSheet standard from `SHEET_AUDIT.md`:
+
+```
+SheetContent side="bottom" hideClose className="flex flex-col p-0 rounded-t-2xl"
+```
+
+- **Height**:
+  - Complex flows (Add Expense, Scan Receipt): `92dvh`, keyboard-aware via `useKeyboardHeight`
+  - Simple/read-only flows (Settle Up, View History): `92dvh` for Settle Up (has form view), `75dvh` for History (read-only)
+- **Width**: `w-full` always — determined by viewport width, never changes
+- **Header**: `shrink-0`, 3-slot flex row (back/spacer | title | ✕), `border-b`
+- **Content**: `flex-1 overflow-y-auto overscroll-contain`
+- **Footer/CTA**: `shrink-0` (if applicable)
+- **dvh not vh** — mandatory on all height values
+
+Width stability on keyboard open:
+- The sheet uses `side="bottom"` which spans the full viewport width
+- Width is determined by `inset-x-0` (from Radix), equivalent to `left: 0; right: 0`
+- When the keyboard opens, only height recalculates. Width is viewport-locked.
+- If width IS changing, it means something is setting an explicit width/max-width that reacts to viewport resize — find and remove it.
+
+### Desktop standard (>= 1024px)
+
+Every quick action opens as a **centered Dialog modal**. Not a bottom sheet. Not a full-screen page.
+
+Modal spec:
+- **Width**: `max-w-lg` (512px) — the Radix `DialogContent` default
+- **Position**: centered horizontally and vertically (`left-[50%] top-[50%] translate`)
+- **Background**: `bg-black/80` overlay (Radix default)
+- **Border-radius**: `sm:rounded-lg` (Radix default)
+- **Max-height**: `max-h-[85vh]` with internal `overflow-y-auto` if content overflows
+- **Content**: same as the mobile sheet content — just presented in a centered modal
+- **Dismiss**: Radix default ✕ (absolute top-right) is fine for dialogs
+
+Exception: `ExpenseWizard` desktop Dialog currently uses `max-w-2xl` (672px) because its `ExpenseForm` has multi-column fields. This is acceptable — the form is a mature component used in both Quick and Full mode. Changing it to `max-w-lg` would cram the layout. **Keep `max-w-2xl` for Add Expense desktop only.**
+
+### Breakpoint
+
+Use `useMediaQuery('(max-width: 767px)')` for mobile detection (consistent with existing `useMediaQuery` hook pattern in the codebase). This matches the `md:` Tailwind breakpoint (768px).
+
+Rationale: The `ExpenseWizard` already uses 768px as its breakpoint. The QuickLayout uses `lg:` (1024px) for header layout, but that's a different concern (header row vs content presentation). For sheet-vs-dialog switching, 768px is the right boundary — tablets in landscape should get the dialog experience.
+
+### Keyboard behaviour (mobile)
+
+When any input is focused and the keyboard opens:
+- **Width**: unchanged. Always full viewport width (`inset-x-0`).
+- **Height**: recalculates via `useKeyboardHeight`:
+  ```tsx
+  height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '<default>dvh'
+  bottom: keyboard.isVisible ? `${Math.max(0, keyboard.keyboardHeight - keyboard.viewportOffset)}px` : undefined
+  paddingBottom: keyboard.isVisible && keyboard.viewportOffset > 0 ? `${keyboard.viewportOffset}px` : undefined
+  ```
+- **Header**: stays fully visible — the `viewportOffset` adjustment prevents numpad from pushing it off screen.
+- **Active input**: scrolls into view within the `overflow-y-auto` content area.
+- **Footer/CTA**: stays accessible (sticky via `shrink-0`).
+
+Only sheets with text/number inputs need `useKeyboardHeight`. Read-only sheets (History) and file-picker sheets (Scan Receipt) do not.
+
+### Sheet-vs-Dialog switching pattern
+
+```tsx
+const isMobile = useMediaQuery('(max-width: 767px)')
+
+return isMobile ? (
+  <Sheet open={open} onOpenChange={onClose}>
+    <SheetContent side="bottom" hideClose className="flex flex-col p-0 rounded-t-2xl"
+      style={{ height: '92dvh' }}>
+      {/* header + content + footer */}
+    </SheetContent>
+  </Sheet>
+) : (
+  <Dialog open={open} onOpenChange={onClose}>
+    <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto p-0">
+      {/* same header + content + footer */}
+    </DialogContent>
+  </Dialog>
+)
+```
+
+---
+
+## 3. Gap Analysis
+
+| # | Button | Mobile: sheet? | Mobile: dvh? | Mobile: width stable? | Mobile: header stable? | Desktop: centered modal? | Desktop: fixed width? | Action needed |
+|---|--------|---------------|-------------|----------------------|----------------------|------------------------|---------------------|---------------|
+| 1 | Scan a receipt | ✅ Sheet | ✅ `92dvh` | ✅ `w-full` | ✅ `shrink-0` | ❌ Bottom sheet | ❌ No width constraint | 🔧 Add Dialog wrapper for desktop |
+| 2 | Add an expense | ✅ Sheet | ✅ `92dvh` + keyboard | ✅ `w-full` | ✅ Full viewportOffset | ✅ Centered Dialog | ✅ `max-w-2xl` (exception) | ✅ Correct (keep as-is) |
+| 3 | Settle up | ✅ Sheet | ✅ `92dvh` + keyboard | ✅ `w-full` | ⚠️ Missing viewportOffset | ❌ Bottom sheet | ❌ No width constraint | 🔧 Add viewportOffset fix + Dialog wrapper for desktop |
+| 4 | View history | ❌ Page navigation | N/A | N/A | N/A | ❌ Page navigation | N/A | 🔨 Full rebuild: convert page to sheet/dialog overlay |
+
+### Summary of changes needed
+
+1. **Scan a receipt** — 🔧 Minor: Wrap content in Sheet (mobile) / Dialog (desktop) conditional. Mobile sheet is already correct.
+
+2. **Add an expense** — ✅ No changes. Already has the best implementation (Sheet mobile + Dialog desktop).
+
+3. **Settle up** — 🔧 Moderate: Add `viewportOffset` to keyboard style (matching MobileWizard pattern). Add Dialog wrapper for desktop.
+
+4. **View history** — 🔨 Rebuild: Convert from page navigation (`navigate()`) to an overlay. Extract `QuickHistoryPage` content into a `QuickHistorySheet` component that renders as Sheet (mobile, `75dvh`, read-only) or Dialog (desktop, `max-w-lg max-h-[85vh]`). Update the button in `QuickGroupDetailPage` from `navigate()` to `setHistoryOpen(true)`.
+
+### Which buttons navigate away on mobile?
+- Only **View history** (#4) navigates away.
+
+### Which are sheets but wrong height/width?
+- None have wrong height/width. **Settle up** (#3) has correct height/width but incomplete keyboard handling.
+
+### Which already work on desktop?
+- Only **Add an expense** (#2) works correctly on desktop (Dialog).
+
+---
+
+## 4. Fix Log
+
+| # | Button | Problem | Fix applied | Files changed | Status |
+|---|--------|---------|-------------|---------------|--------|
+| 0 | (infrastructure) | `DialogContent` has no `hideClose` prop | Added optional `hideClose` prop to `DialogContent`, matching `SheetContent` pattern | `src/components/ui/dialog.tsx` | ✅ Done |
+| 1 | Scan a receipt | Desktop: bottom sheet instead of centered modal | Added `useMediaQuery` check — mobile renders Sheet, desktop renders Dialog with `hideClose max-h-[85vh] p-0 gap-0` | `src/components/receipts/ReceiptCaptureSheet.tsx` | ✅ Done |
+| 2 | Add an expense | Already correct | No changes needed | — | ✅ N/A |
+| 3 | Settle up | (a) Missing `viewportOffset` in keyboard style — numpad pushes header off screen. (b) Desktop: bottom sheet instead of centered modal | (a) Added `viewportOffset` subtraction from `bottom` + `paddingBottom` for offset, matching MobileWizard pattern. (b) Added `useMediaQuery` check — mobile renders Sheet, desktop renders Dialog with `hideClose max-h-[85vh] p-0 gap-0` | `src/components/quick/QuickSettlementSheet.tsx` | ✅ Done |
+| 4 | View history | Navigates away to separate page (`/t/:tripCode/quick/history`) | Created `QuickHistorySheet` component — Sheet on mobile (`75dvh`, read-only), Dialog on desktop (`max-w-lg max-h-[85vh]`). Changed button in `QuickGroupDetailPage` from `navigate()` to `setHistoryOpen(true)`. Route kept for backward compat. | `src/components/quick/QuickHistorySheet.tsx` (NEW), `src/pages/QuickGroupDetailPage.tsx` | ✅ Done |
+
+### Build verification
+- `npm run type-check`: ✅ clean
+- `npm test`: ✅ 140/140 tests pass
+
+---
+
+## 5. Playwright MCP Verification
+
+Tested against `localhost:5173` with Supabase fully mocked via `page.route()` + `page.addInitScript()`.
+
+### Mobile (375 × 812)
+
+| # | Button | Opens as | Height | Width | URL changed? | Result |
+|---|--------|----------|--------|-------|-------------|--------|
+| 1 | Scan a receipt | Bottom sheet | `92dvh` | Full viewport | No (`/quick`) | ✅ PASS |
+| 2 | Add an expense | Bottom sheet (MobileWizard) | `92dvh` | Full viewport | No (`/quick`) | ✅ PASS |
+| 3 | Settle up | Bottom sheet | `92dvh` | Full viewport | No (`/quick`) | ✅ PASS |
+| 4 | View history | Bottom sheet | `75dvh` | Full viewport | No (`/quick`) | ✅ PASS |
+
+### Desktop (1280 × 800)
+
+| # | Button | Opens as | Width | Centered? | URL changed? | Result |
+|---|--------|----------|-------|-----------|-------------|--------|
+| 1 | Scan a receipt | Centered Dialog | `max-w-lg` (512px) | ✅ | No (`/quick`) | ✅ PASS |
+| 2 | Add an expense | Centered Dialog | `max-w-2xl` (672px, exception) | ✅ | No (`/quick`) | ✅ PASS |
+| 3 | Settle up | Centered Dialog | `max-w-lg` (512px) | ✅ | No (`/quick`) | ✅ PASS |
+| 4 | View history | Centered Dialog | `max-w-lg` (512px) | ✅ | No (`/quick`) | ✅ PASS |
+
+### Console warnings (pre-existing, not in scope)
+- Radix `Missing Description or aria-describedby` — from Sheet/Dialog without explicit description (cosmetic)
+- `log-proxy` 401 — unauthenticated mock environment

--- a/src/components/quick/QuickHistorySheet.tsx
+++ b/src/components/quick/QuickHistorySheet.tsx
@@ -1,0 +1,167 @@
+import { useState, useMemo } from 'react'
+import { X, FileText } from 'lucide-react'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useExpenseContext } from '@/contexts/ExpenseContext'
+import { useSettlementContext } from '@/contexts/SettlementContext'
+import { buildTransactionHistory } from '@/services/transactionHistoryBuilder'
+import { TransactionItem } from '@/components/quick/TransactionItem'
+import { PageLoadingState } from '@/components/PageLoadingState'
+import { PageErrorState } from '@/components/PageErrorState'
+import { Card, CardContent } from '@/components/ui/card'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+
+type FilterType = 'all' | 'expenses' | 'payments'
+
+interface QuickHistorySheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function QuickHistorySheet({ open, onOpenChange }: QuickHistorySheetProps) {
+  const { currentTrip } = useCurrentTrip()
+  const { myParticipant } = useMyParticipant()
+  const { participants, families, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
+  const { expenses, loading: expensesLoading, error: expenseError, refreshExpenses } = useExpenseContext()
+  const { settlements, loading: settlementsLoading, error: settlementError, refreshSettlements } = useSettlementContext()
+  const [filter, setFilter] = useState<FilterType>('all')
+  const [retrying, setRetrying] = useState(false)
+  const isMobile = useMediaQuery('(max-width: 767px)')
+
+  const contextError = participantError || expenseError || settlementError
+
+  const handleRetry = async () => {
+    setRetrying(true)
+    try {
+      await Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()])
+    } finally {
+      setRetrying(false)
+    }
+  }
+
+  const loading = participantsLoading || expensesLoading || settlementsLoading
+
+  const transactions = useMemo(() => {
+    if (!currentTrip || !myParticipant) return []
+    return buildTransactionHistory(
+      expenses,
+      settlements,
+      participants,
+      families,
+      myParticipant,
+      currentTrip.tracking_mode
+    )
+  }, [expenses, settlements, participants, families, myParticipant, currentTrip])
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return transactions
+    if (filter === 'expenses') return transactions.filter(t => t.type === 'expense')
+    return transactions.filter(t => t.type === 'settlement')
+  }, [transactions, filter])
+
+  const filterButtons: { key: FilterType; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'expenses', label: 'Expenses' },
+    { key: 'payments', label: 'Payments' },
+  ]
+
+  const closeBtn = (
+    <button
+      onClick={() => onOpenChange(false)}
+      aria-label="Close"
+      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+    >
+      <X className="w-4 h-4 text-muted-foreground" />
+    </button>
+  )
+
+  const scrollContent = (
+    <div className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
+      {/* Filters */}
+      <div className="flex gap-2 mb-4">
+        {filterButtons.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setFilter(key)}
+            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              filter === key
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Transaction list */}
+      {loading ? (
+        <PageLoadingState />
+      ) : contextError ? (
+        <PageErrorState error={contextError} onRetry={handleRetry} retrying={retrying} />
+      ) : !myParticipant ? (
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-muted-foreground">
+              Link yourself to a participant to see transaction history.
+            </p>
+          </CardContent>
+        </Card>
+      ) : filtered.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-center py-8">
+            <FileText size={32} className="mx-auto text-muted-foreground/50 mb-3" />
+            <p className="text-muted-foreground">No transactions yet</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-1">
+          {filtered.map(tx => (
+            <TransactionItem
+              key={tx.id}
+              transaction={tx}
+              defaultCurrency={currentTrip?.default_currency}
+              exchangeRates={currentTrip?.exchange_rates}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="bottom"
+          hideClose
+          className="flex flex-col p-0 rounded-t-2xl"
+          style={{ height: '75dvh' }}
+        >
+          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="w-8" />
+            <SheetTitle className="text-base font-semibold">Expenses & Payments</SheetTitle>
+            {closeBtn}
+          </div>
+          {scrollContent}
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
+        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+          <div className="w-8" />
+          <DialogTitle className="text-base font-semibold">Expenses & Payments</DialogTitle>
+          {closeBtn}
+        </div>
+        {scrollContent}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -11,7 +11,9 @@ import { calculateOptimalSettlement, SettlementTransaction } from '@/services/se
 import { SettlementForm } from '@/components/SettlementForm'
 import { CreateSettlementInput } from '@/types/settlement'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Button } from '@/components/ui/button'
 import { useToast } from '@/hooks/use-toast'
 import { useAuth } from '@/contexts/AuthContext'
@@ -50,6 +52,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
   const [remindResults, setRemindResults] = useState<Record<number, 'sent' | 'error'>>({})
   const isSubmittingRef = useRef(false)
   const keyboard = useKeyboardHeight()
+  const isMobile = useMediaQuery('(max-width: 767px)')
 
   // Build email map: entity ID (participant.id or family_id) → email
   const fromEmailMap = useMemo(() => {
@@ -298,242 +301,271 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
     }).format(amount)
   }
 
-  return (
-    <Sheet open={open} onOpenChange={handleOpenChange}>
-      <SheetContent
-        side="bottom"
-        hideClose
-        className="flex flex-col p-0 rounded-t-2xl"
-        style={{
-          height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-          bottom: keyboard.isVisible ? `${keyboard.keyboardHeight}px` : undefined,
-        }}
-      >
-        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-          {view === 'form' ? (
-            <button
-              onClick={() => setView('suggestions')}
-              aria-label="Go back"
-              className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-            >
-              <ArrowLeft className="w-4 h-4 text-muted-foreground" />
-            </button>
+  const leftSlot = view === 'form' ? (
+    <button
+      onClick={() => setView('suggestions')}
+      aria-label="Go back"
+      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+    >
+      <ArrowLeft className="w-4 h-4 text-muted-foreground" />
+    </button>
+  ) : (
+    <div className="w-8" />
+  )
+
+  const closeBtn = (
+    <button
+      onClick={() => handleOpenChange(false)}
+      aria-label="Close"
+      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+    >
+      <X className="w-4 h-4 text-muted-foreground" />
+    </button>
+  )
+
+  const titleText = view === 'suggestions' ? 'Settle up' : 'Record payment'
+
+  const scrollContent = (
+    <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
+      {view === 'suggestions' ? (
+        <div className="space-y-4">
+          {allSettled ? (
+            <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
+              <PartyPopper size={48} className="mx-auto text-positive mb-2" />
+              <h3 className="text-lg font-semibold text-foreground mb-1">
+                All Settled!
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Everyone is squared up. No payments needed.
+              </p>
+            </div>
+          ) : !myParticipant ? (
+            <div className="text-center py-8">
+              <p className="text-muted-foreground text-sm">
+                Link yourself to a participant to see suggested payments.
+              </p>
+            </div>
+          ) : myTransactions.length === 0 ? (
+            <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
+              <PartyPopper size={48} className="mx-auto text-positive mb-2" />
+              <h3 className="text-lg font-semibold text-foreground mb-1">
+                You're all settled!
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                You have no pending payments.
+              </p>
+            </div>
           ) : (
-            <div className="w-8" />
-          )}
-          <SheetTitle className="text-base font-semibold">
-            {view === 'suggestions' ? 'Settle up' : 'Record payment'}
-          </SheetTitle>
-          <button
-            onClick={() => handleOpenChange(false)}
-            aria-label="Close"
-            className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-          >
-            <X className="w-4 h-4 text-muted-foreground" />
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
-        {view === 'suggestions' ? (
-          <div className="space-y-4">
-            {allSettled ? (
-              <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
-                <PartyPopper size={48} className="mx-auto text-positive mb-2" />
-                <h3 className="text-lg font-semibold text-foreground mb-1">
-                  All Settled!
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  Everyone is squared up. No payments needed.
-                </p>
-              </div>
-            ) : !myParticipant ? (
-              <div className="text-center py-8">
-                <p className="text-muted-foreground text-sm">
-                  Link yourself to a participant to see suggested payments.
-                </p>
-              </div>
-            ) : myTransactions.length === 0 ? (
-              <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
-                <PartyPopper size={48} className="mx-auto text-positive mb-2" />
-                <h3 className="text-lg font-semibold text-foreground mb-1">
-                  You're all settled!
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  You have no pending payments.
-                </p>
-              </div>
-            ) : (
-              <>
-                <p className="text-sm text-muted-foreground">
-                  Suggested payments to settle up:
-                </p>
-                {myTransactions.map((tx, i) => {
-                  const iOwe = tx.fromId === myEntityId
-                  const fromEmail = !iOwe ? fromEmailMap[tx.fromId] : undefined
-                  const canRemind = !iOwe && !!fromEmail
-                  const isConfirmingRemind = confirmingRemindIdx === i
-                  const remindResult = remindResults[i]
-                  return (
-                    <div
-                      key={i}
-                      className="border border-border rounded-lg p-4 flex items-start justify-between gap-3"
-                    >
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 text-sm">
-                          <span className="font-medium truncate">
-                            {iOwe ? 'You' : tx.fromName}
-                          </span>
-                          <ArrowRight size={16} className="text-muted-foreground flex-shrink-0" />
-                          <span className="font-medium truncate">
-                            {iOwe ? tx.toName : 'You'}
-                          </span>
-                        </div>
-                        <p className={`text-lg font-bold tabular-nums mt-0.5 ${iOwe ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
-                          {formatAmount(tx.amount)}
-                        </p>
-                        <p className="text-xs text-muted-foreground mt-0.5">
-                          {iOwe ? 'You owe' : 'Owed to you'}
-                        </p>
-                        {iOwe && (() => {
-                          const bankDetails = bankDetailsMap[tx.toId]
-                          const isLinked = linkedParticipantIds.has(tx.toId)
-                          if (bankDetails && (bankDetails.iban || bankDetails.holder)) {
-                            return (
-                              <div className="mt-2 text-xs text-muted-foreground space-y-0.5">
-                                {bankDetails.holder && <p>Account: {bankDetails.holder}</p>}
-                                {bankDetails.iban && <p className="font-mono">{bankDetails.iban}</p>}
-                              </div>
-                            )
-                          }
-                          if (isLinked) {
-                            return (
-                              <p className="mt-2 text-xs text-muted-foreground italic">
-                                Ask {tx.toName} to add their bank details
-                              </p>
-                            )
-                          }
-                          return (
-                            <p className="mt-2 text-xs text-muted-foreground italic">
-                              Ask {tx.toName} to join Spl1t to share payment details
-                            </p>
-                          )
-                        })()}
-                        {!iOwe && (() => {
-                          const myBank = userProfile?.bank_account_holder || userProfile?.bank_iban
-                          if (myBank) {
-                            return (
-                              <div className="mt-2 text-xs text-muted-foreground space-y-0.5">
-                                <p className="font-medium text-foreground/70">Your payment details:</p>
-                                {userProfile?.bank_account_holder && <p>Account: {userProfile.bank_account_holder}</p>}
-                                {userProfile?.bank_iban && <p className="font-mono">{userProfile.bank_iban}</p>}
-                              </div>
-                            )
-                          }
-                          return (
-                            <p className="mt-2 text-xs text-muted-foreground italic">
-                              Add your bank details in your profile so others can pay you
-                            </p>
-                          )
-                        })()}
-
-                        {/* Inline remind confirm */}
-                        {isConfirmingRemind && fromEmail && (
-                          <div className="mt-3 p-3 rounded-lg bg-accent/10 border border-accent/20 space-y-2">
-                            <p className="text-sm text-foreground">
-                              Send payment reminder to <strong>{tx.fromName}</strong>?
-                            </p>
-                            <p className="text-xs text-muted-foreground">{fromEmail}</p>
-                            <div className="flex gap-2">
-                              <Button
-                                size="sm"
-                                className="h-7 text-xs"
-                                onClick={() => handleRemind(tx, i)}
-                                disabled={sendingRemind}
-                              >
-                                {sendingRemind ? 'Sending…' : 'Send'}
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                className="h-7 text-xs"
-                                onClick={() => { setConfirmingRemindIdx(null) }}
-                                disabled={sendingRemind}
-                              >
-                                Cancel
-                              </Button>
-                            </div>
-                          </div>
-                        )}
-
-                        {remindResult === 'sent' && (
-                          <p className="mt-2 text-xs text-positive flex items-center gap-1">
-                            <Check size={12} />
-                            Reminder sent to {tx.fromName}
-                          </p>
-                        )}
-                        {remindResult === 'error' && (
-                          <p className="mt-2 text-xs text-destructive">
-                            Failed to send reminder. Please try again.
-                          </p>
-                        )}
+            <>
+              <p className="text-sm text-muted-foreground">
+                Suggested payments to settle up:
+              </p>
+              {myTransactions.map((tx, i) => {
+                const iOwe = tx.fromId === myEntityId
+                const fromEmail = !iOwe ? fromEmailMap[tx.fromId] : undefined
+                const canRemind = !iOwe && !!fromEmail
+                const isConfirmingRemind = confirmingRemindIdx === i
+                const remindResult = remindResults[i]
+                return (
+                  <div
+                    key={i}
+                    className="border border-border rounded-lg p-4 flex items-start justify-between gap-3"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 text-sm">
+                        <span className="font-medium truncate">
+                          {iOwe ? 'You' : tx.fromName}
+                        </span>
+                        <ArrowRight size={16} className="text-muted-foreground flex-shrink-0" />
+                        <span className="font-medium truncate">
+                          {iOwe ? tx.toName : 'You'}
+                        </span>
                       </div>
+                      <p className={`text-lg font-bold tabular-nums mt-0.5 ${iOwe ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
+                        {formatAmount(tx.amount)}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {iOwe ? 'You owe' : 'Owed to you'}
+                      </p>
+                      {iOwe && (() => {
+                        const bankDetails = bankDetailsMap[tx.toId]
+                        const isLinked = linkedParticipantIds.has(tx.toId)
+                        if (bankDetails && (bankDetails.iban || bankDetails.holder)) {
+                          return (
+                            <div className="mt-2 text-xs text-muted-foreground space-y-0.5">
+                              {bankDetails.holder && <p>Account: {bankDetails.holder}</p>}
+                              {bankDetails.iban && <p className="font-mono">{bankDetails.iban}</p>}
+                            </div>
+                          )
+                        }
+                        if (isLinked) {
+                          return (
+                            <p className="mt-2 text-xs text-muted-foreground italic">
+                              Ask {tx.toName} to add their bank details
+                            </p>
+                          )
+                        }
+                        return (
+                          <p className="mt-2 text-xs text-muted-foreground italic">
+                            Ask {tx.toName} to join Spl1t to share payment details
+                          </p>
+                        )
+                      })()}
+                      {!iOwe && (() => {
+                        const myBank = userProfile?.bank_account_holder || userProfile?.bank_iban
+                        if (myBank) {
+                          return (
+                            <div className="mt-2 text-xs text-muted-foreground space-y-0.5">
+                              <p className="font-medium text-foreground/70">Your payment details:</p>
+                              {userProfile?.bank_account_holder && <p>Account: {userProfile.bank_account_holder}</p>}
+                              {userProfile?.bank_iban && <p className="font-mono">{userProfile.bank_iban}</p>}
+                            </div>
+                          )
+                        }
+                        return (
+                          <p className="mt-2 text-xs text-muted-foreground italic">
+                            Add your bank details in your profile so others can pay you
+                          </p>
+                        )
+                      })()}
 
-                      <div className="flex flex-col gap-2 flex-shrink-0">
+                      {/* Inline remind confirm */}
+                      {isConfirmingRemind && fromEmail && (
+                        <div className="mt-3 p-3 rounded-lg bg-accent/10 border border-accent/20 space-y-2">
+                          <p className="text-sm text-foreground">
+                            Send payment reminder to <strong>{tx.fromName}</strong>?
+                          </p>
+                          <p className="text-xs text-muted-foreground">{fromEmail}</p>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              className="h-7 text-xs"
+                              onClick={() => handleRemind(tx, i)}
+                              disabled={sendingRemind}
+                            >
+                              {sendingRemind ? 'Sending…' : 'Send'}
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="h-7 text-xs"
+                              onClick={() => { setConfirmingRemindIdx(null) }}
+                              disabled={sendingRemind}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      )}
+
+                      {remindResult === 'sent' && (
+                        <p className="mt-2 text-xs text-positive flex items-center gap-1">
+                          <Check size={12} />
+                          Reminder sent to {tx.fromName}
+                        </p>
+                      )}
+                      {remindResult === 'error' && (
+                        <p className="mt-2 text-xs text-destructive">
+                          Failed to send reminder. Please try again.
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="flex flex-col gap-2 flex-shrink-0">
+                      <Button
+                        size="sm"
+                        onClick={() => handleRecord(tx)}
+                      >
+                        Settle
+                      </Button>
+                      {canRemind && !isConfirmingRemind && remindResult !== 'sent' && (
                         <Button
                           size="sm"
-                          onClick={() => handleRecord(tx)}
+                          variant="outline"
+                          onClick={() => { setConfirmingRemindIdx(i); setRemindResults(prev => { const n = { ...prev }; delete n[i]; return n }) }}
+                          title={`Send payment reminder to ${tx.fromName}`}
                         >
-                          Settle
+                          <Bell size={14} className="mr-1" />
+                          Remind
                         </Button>
-                        {canRemind && !isConfirmingRemind && remindResult !== 'sent' && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => { setConfirmingRemindIdx(i); setRemindResults(prev => { const n = { ...prev }; delete n[i]; return n }) }}
-                            title={`Send payment reminder to ${tx.fromName}`}
-                          >
-                            <Bell size={14} className="mr-1" />
-                            Remind
-                          </Button>
-                        )}
-                        {isConfirmingRemind && (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="text-muted-foreground"
-                            onClick={() => setConfirmingRemindIdx(null)}
-                          >
-                            <X size={14} />
-                          </Button>
-                        )}
-                      </div>
+                      )}
+                      {isConfirmingRemind && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="text-muted-foreground"
+                          onClick={() => setConfirmingRemindIdx(null)}
+                        >
+                          <X size={14} />
+                        </Button>
+                      )}
                     </div>
-                  )
-                })}
-              </>
-            )}
+                  </div>
+                )
+              })}
+            </>
+          )}
 
-            <div className="pt-2">
-              <Button
-                variant="outline"
-                className="w-full"
-                onClick={handleRecordDifferent}
-              >
-                Record a custom payment
-              </Button>
-            </div>
+          <div className="pt-2">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleRecordDifferent}
+            >
+              Record a custom payment
+            </Button>
           </div>
-        ) : (
-          <SettlementForm
-            onSubmit={handleSubmit}
-            onCancel={() => setView('suggestions')}
-            initialFromId={prefill?.fromId}
-            initialToId={prefill?.toId}
-            initialAmount={prefill?.amount}
-          />
-        )}
         </div>
-      </SheetContent>
-    </Sheet>
+      ) : (
+        <SettlementForm
+          onSubmit={handleSubmit}
+          onCancel={() => setView('suggestions')}
+          initialFromId={prefill?.fromId}
+          initialToId={prefill?.toId}
+          initialAmount={prefill?.amount}
+        />
+      )}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetContent
+          side="bottom"
+          hideClose
+          className="flex flex-col p-0 rounded-t-2xl"
+          style={{
+            height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
+            bottom: keyboard.isVisible
+              ? `${Math.max(0, keyboard.keyboardHeight - keyboard.viewportOffset)}px`
+              : undefined,
+            paddingBottom: keyboard.isVisible && keyboard.viewportOffset > 0
+              ? `${keyboard.viewportOffset}px`
+              : undefined,
+          }}
+        >
+          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+            {leftSlot}
+            <SheetTitle className="text-base font-semibold">{titleText}</SheetTitle>
+            {closeBtn}
+          </div>
+          {scrollContent}
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
+        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+          {leftSlot}
+          <DialogTitle className="text-base font-semibold">{titleText}</DialogTitle>
+          {closeBtn}
+        </div>
+        {scrollContent}
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/components/receipts/ReceiptCaptureSheet.tsx
+++ b/src/components/receipts/ReceiptCaptureSheet.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef } from 'react'
 import { Camera, Upload, Loader2, X, ScanLine } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { supabase } from '@/lib/supabase'
 import { useReceiptContext } from '@/contexts/ReceiptContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { logger } from '@/lib/logger'
 
 interface ReceiptCaptureSheetProps {
@@ -69,6 +71,7 @@ export function ReceiptCaptureSheet({ open, onOpenChange, onScanned }: ReceiptCa
   const { createReceiptTask, refreshPendingReceipts } = useReceiptContext()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
+  const isMobile = useMediaQuery('(max-width: 767px)')
 
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
@@ -200,137 +203,160 @@ export function ReceiptCaptureSheet({ open, onOpenChange, onScanned }: ReceiptCa
     onOpenChange(nextOpen)
   }
 
-  return (
-    <Sheet open={open} onOpenChange={handleOpenChange}>
-      <SheetContent
-        side="bottom"
-        hideClose
-        className="flex flex-col p-0 rounded-t-2xl"
-        style={{ height: '92dvh' }}
-      >
-        {/* Sticky header — never scrolls */}
-        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-          <div className="w-8" />
-          <SheetTitle className="text-base font-semibold flex items-center gap-2">
-            <ScanLine size={20} />
-            Scan Receipt
-          </SheetTitle>
-          <button
-            onClick={() => handleOpenChange(false)}
-            aria-label="Close"
-            className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-          >
-            <X className="w-4 h-4 text-muted-foreground" />
-          </button>
+  const closeBtn = (
+    <button
+      onClick={() => handleOpenChange(false)}
+      aria-label="Close"
+      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+    >
+      <X className="w-4 h-4 text-muted-foreground" />
+    </button>
+  )
+
+  const scrollContent = (
+    <div className="flex-1 overflow-y-auto overscroll-contain">
+      {!previewUrl ? (
+        /* File selection state */
+        <div className="flex-1 flex flex-col items-center justify-center gap-4 py-8 px-4">
+          <div className="w-24 h-24 rounded-full bg-muted flex items-center justify-center">
+            <Camera size={40} className="text-muted-foreground" />
+          </div>
+          <div className="text-center">
+            <p className="font-medium text-foreground">Add a receipt photo</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Take a photo or upload from your library
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 w-full max-w-xs">
+            <Button
+              variant="default"
+              className="gap-2"
+              onClick={() => cameraInputRef.current?.click()}
+            >
+              <Camera size={16} />
+              Take Photo
+            </Button>
+            <Button
+              variant="outline"
+              className="gap-2"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload size={16} />
+              Choose from Library
+            </Button>
+          </div>
+
+          <input
+            ref={cameraInputRef}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            className="hidden"
+            onChange={handleFileInputChange}
+          />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileInputChange}
+          />
         </div>
-
-        {/* Scrollable content — only this scrolls */}
-        <div className="flex-1 overflow-y-auto overscroll-contain">
-          {!previewUrl ? (
-            /* File selection state */
-            <div className="flex-1 flex flex-col items-center justify-center gap-4 py-8 px-4">
-              <div className="w-24 h-24 rounded-full bg-muted flex items-center justify-center">
-                <Camera size={40} className="text-muted-foreground" />
-              </div>
-              <div className="text-center">
-                <p className="font-medium text-foreground">Add a receipt photo</p>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Take a photo or upload from your library
-                </p>
-              </div>
-
-              <div className="flex flex-col gap-2 w-full max-w-xs">
-                <Button
-                  variant="default"
-                  className="gap-2"
-                  onClick={() => cameraInputRef.current?.click()}
-                >
-                  <Camera size={16} />
-                  Take Photo
-                </Button>
-                <Button
-                  variant="outline"
-                  className="gap-2"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <Upload size={16} />
-                  Choose from Library
-                </Button>
-              </div>
-
-              <input
-                ref={cameraInputRef}
-                type="file"
-                accept="image/*"
-                capture="environment"
-                className="hidden"
-                onChange={handleFileInputChange}
-              />
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={handleFileInputChange}
-              />
-            </div>
-          ) : (
-            /* Preview state */
-            <div className="flex flex-col gap-4 px-4 py-4">
-              <div className="relative rounded-lg overflow-hidden border border-border">
-                <img
-                  src={previewUrl}
-                  alt="Receipt preview"
-                  className="w-full max-h-64 object-contain bg-muted"
-                />
-                {!scanning && (
-                  <button
-                    onClick={handleReset}
-                    className="absolute top-2 right-2 rounded-full bg-background/80 p-1 border border-border"
-                    aria-label="Remove image"
-                  >
-                    <X size={16} />
-                  </button>
-                )}
-              </div>
-
-              {error && (
-                <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-3 py-2 space-y-1">
-                  <p className="font-medium">{error}</p>
-                  {errorDetail && (
-                    <pre className="text-xs whitespace-pre-wrap break-all opacity-80">{errorDetail}</pre>
-                  )}
-                </div>
-              )}
-
-              <Button
-                onClick={handleScan}
-                disabled={scanning}
-                size="lg"
-                className="gap-2"
+      ) : (
+        /* Preview state */
+        <div className="flex flex-col gap-4 px-4 py-4">
+          <div className="relative rounded-lg overflow-hidden border border-border">
+            <img
+              src={previewUrl}
+              alt="Receipt preview"
+              className="w-full max-h-64 object-contain bg-muted"
+            />
+            {!scanning && (
+              <button
+                onClick={handleReset}
+                className="absolute top-2 right-2 rounded-full bg-background/80 p-1 border border-border"
+                aria-label="Remove image"
               >
-                {scanning ? (
-                  <>
-                    <Loader2 size={16} className="animate-spin" />
-                    Analyzing receipt...
-                  </>
-                ) : (
-                  <>
-                    <ScanLine size={16} />
-                    Scan Receipt
-                  </>
-                )}
-              </Button>
+                <X size={16} />
+              </button>
+            )}
+          </div>
 
-              {scanning && (
-                <p className="text-xs text-muted-foreground text-center">
-                  This usually takes 5–10 seconds
-                </p>
+          {error && (
+            <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-3 py-2 space-y-1">
+              <p className="font-medium">{error}</p>
+              {errorDetail && (
+                <pre className="text-xs whitespace-pre-wrap break-all opacity-80">{errorDetail}</pre>
               )}
             </div>
           )}
+
+          <Button
+            onClick={handleScan}
+            disabled={scanning}
+            size="lg"
+            className="gap-2"
+          >
+            {scanning ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                Analyzing receipt...
+              </>
+            ) : (
+              <>
+                <ScanLine size={16} />
+                Scan Receipt
+              </>
+            )}
+          </Button>
+
+          {scanning && (
+            <p className="text-xs text-muted-foreground text-center">
+              This usually takes 5–10 seconds
+            </p>
+          )}
         </div>
-      </SheetContent>
-    </Sheet>
+      )}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetContent
+          side="bottom"
+          hideClose
+          className="flex flex-col p-0 rounded-t-2xl"
+          style={{ height: '92dvh' }}
+        >
+          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="w-8" />
+            <SheetTitle className="text-base font-semibold flex items-center gap-2">
+              <ScanLine size={20} />
+              Scan Receipt
+            </SheetTitle>
+            {closeBtn}
+          </div>
+          {scrollContent}
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
+        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+          <div className="w-8" />
+          <DialogTitle className="text-base font-semibold flex items-center gap-2">
+            <ScanLine size={20} />
+            Scan Receipt
+          </DialogTitle>
+          {closeBtn}
+        </div>
+        {scrollContent}
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -28,8 +28,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { hideClose?: boolean }
+>(({ className, children, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -41,10 +41,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <Cross2Icon className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideClose && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <Cross2Icon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -16,6 +16,7 @@ import { ReceiptCaptureSheet } from '@/components/receipts/ReceiptCaptureSheet'
 import { ReceiptReviewSheet } from '@/components/receipts/ReceiptReviewSheet'
 import { QuickParticipantSetupSheet } from '@/components/quick/QuickParticipantSetupSheet'
 import { QuickGroupMembersSheet } from '@/components/quick/QuickGroupMembersSheet'
+import { QuickHistorySheet } from '@/components/quick/QuickHistorySheet'
 import { PendingReceiptBanner, ReceiptReviewData } from '@/components/receipts/PendingReceiptBanner'
 import { PageLoadingState } from '@/components/PageLoadingState'
 import { PageErrorState } from '@/components/PageErrorState'
@@ -44,6 +45,7 @@ export function QuickGroupDetailPage() {
   const [receiptCaptureOpen, setReceiptCaptureOpen] = useState(false)
   const [participantSetupOpen, setParticipantSetupOpen] = useState(false)
   const [membersOpen, setMembersOpen] = useState(false)
+  const [historyOpen, setHistoryOpen] = useState(false)
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [retrying, setRetrying] = useState(false)
 
@@ -199,7 +201,7 @@ export function QuickGroupDetailPage() {
           icon={FileText}
           label="View expenses & payments"
           description="See transaction history"
-          onClick={() => navigate(`/t/${currentTrip.trip_code}/quick/history`)}
+          onClick={() => setHistoryOpen(true)}
         />
       </div>
 
@@ -255,6 +257,12 @@ export function QuickGroupDetailPage() {
         myParticipantId={myBalance?.id ?? null}
         currency={currentTrip.default_currency}
         participants={participants}
+      />
+
+      {/* History sheet */}
+      <QuickHistorySheet
+        open={historyOpen}
+        onOpenChange={setHistoryOpen}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- All 4 quick action buttons in `QuickGroupDetailPage` now open as **bottom sheets on mobile** and **centered Dialogs on desktop**
- Previously: Scan Receipt and Settle Up rendered as bottom sheets on desktop; View History navigated away to a separate page
- Added `hideClose` prop to `DialogContent` (matching `SheetContent` pattern)
- Added `viewportOffset` keyboard fix to `QuickSettlementSheet` (prevents iOS numpad from hiding header)
- Created `QuickHistorySheet` — converts page navigation into overlay (Sheet mobile / Dialog desktop)

## Files changed
| File | Change |
|------|--------|
| `src/components/ui/dialog.tsx` | Added `hideClose` prop to `DialogContent` |
| `src/components/receipts/ReceiptCaptureSheet.tsx` | Sheet (mobile) / Dialog (desktop) conditional |
| `src/components/quick/QuickSettlementSheet.tsx` | `viewportOffset` fix + Sheet/Dialog conditional |
| `src/components/quick/QuickHistorySheet.tsx` | **New** — replaces page navigation with overlay |
| `src/pages/QuickGroupDetailPage.tsx` | History button: `navigate()` → `setHistoryOpen(true)` |
| `CLAUDE.md` | Added "Quick Actions Standard" section |
| `PLAN.md` | Session log entry |
| `QUICK_ACTIONS_AUDIT.md` | **New** — full audit document |

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 140/140 pass
- [x] Playwright MCP: all 4 buttons on mobile (375×812) — bottom sheets ✅
- [x] Playwright MCP: all 4 buttons on desktop (1280×800) — centered Dialogs ✅
- [ ] Manual iOS Safari: Settle up numpad → header stays visible
- [ ] Manual iOS Safari: all 4 buttons dismiss with ✕ and return to trip detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)