### PR TITLE
fix: match currency select height to amount input in SettlementForm (#380)

### DIFF
--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -280,7 +280,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
             onValueChange={setCurrency}
             disabled={loading}
           >
-            <SelectTrigger className="w-24">
+            <SelectTrigger className="w-24 h-14 text-base">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## Summary
- Currency `SelectTrigger` in `SettlementForm` defaulted to `h-9` (36px) while the adjacent amount `Input` was `h-14` (56px) — a 20px height mismatch on the same row
- Added `h-14 text-base` to the currency SelectTrigger to match

## Test plan
- [ ] Open settle up sheet on mobile (quick view)
- [ ] Verify amount input and currency select are the same height
- [ ] Verify desktop settlement dialog also looks correct

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)