### PR TITLE
fix: use Spl1t brand name in marketing hero headline (#383)

### DIFF
--- a/public/marketing.html
+++ b/public/marketing.html
@@ -25,7 +25,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Spl1t — Split costs, not friendships</title>
+  <title>Spl1t — Spl1t costs, not friendships</title>
   <meta name="description" content="The fastest way to split trip and event costs. AI receipt scanning, shared link access — no sign-up required.">
   <meta name="theme-color" content="#E8714A">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png?v=2">
@@ -769,7 +769,7 @@
           <span class="section-label">No sign-up required</span>
 
           <h1>
-            Split costs,<br>
+            Spl<span style="color:var(--primary);">1</span>t costs,<br>
             not <span class="hero-headline-accent">friendships
               <svg viewBox="0 0 200 12" preserveAspectRatio="none" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M2 8 C40 2, 60 12, 100 6 S160 2, 198 8" stroke="#E8714A" stroke-width="3" stroke-linecap="round"/>
@@ -1424,7 +1424,7 @@
   <footer class="footer">
     <div class="container">
       <div class="wordmark">Spl<span>1</span>t</div>
-      <p class="footer-tagline">Split costs, not friendships.</p>
+      <p class="footer-tagline">Spl1t costs, not friendships.</p>
       <p class="footer-noauth">No account required &mdash; just share the link.</p>
       <a href="https://split.xtian.me" class="footer-link">
         Open Spl1t


### PR DESCRIPTION
## Summary
- Hero headline changed from "Split costs" to "Spl**1**t costs" with the "1" in primary color (`var(--primary)`)
- Page `<title>` and footer tagline updated to match
- Brand name is now prominent across all key touchpoints on the marketing page

## Test plan
- [ ] Visit marketing page — hero headline shows "Spl1t costs, not friendships" with colored "1"
- [ ] Browser tab shows "Spl1t — Spl1t costs, not friendships"
- [ ] Footer tagline reads "Spl1t costs, not friendships."

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)