### PR TITLE
refactor: family entity Phase 1 — data migration

### DIFF
--- a/FAMILY_ENTITY.md
+++ b/FAMILY_ENTITY.md
@@ -1,0 +1,129 @@
+# Family Entity Audit
+
+_Audited 2026-02-24_
+
+## What "family" means
+
+A family = a group of people who **share one wallet** for the trip. They settle as a unit, not individually. Use cases: couples, parents + kids, friends sharing all costs.
+
+This mental model is **never explained in the UI**. Current labels: "Individuals + Families" / "Track at family level with individual breakdowns" — meaningless to a first-time user.
+
+---
+
+## Complexity footprint
+
+| Metric | Value |
+|--------|-------|
+| Files touching family logic | **44** |
+| Total family-related references in `src/` | **536** |
+| `FamiliesSetup.tsx` | **906 lines** (vs 349 for IndividualsSetup — 2.6x) |
+| Distribution types in expense JSONB | **3** (individuals, families, mixed) |
+| "CRITICAL: avoid double-counting" comments | **5** |
+| Per-expense decisions families mode adds | **2** (which families + account for size toggle) |
+
+### Heaviest files
+
+| File | Family refs | Lines | Family % |
+|------|-----------|-------|----------|
+| `balanceCalculator.ts` | 92 | 503 | 18% |
+| `ExpenseSplitPreview.tsx` | 58 | 374 | 16% |
+| `ExpenseForm.tsx` | 52 | ~1000 | 5% |
+| `balanceCalculator.test.ts` | 57 | ~420 | 14% |
+| `ExpenseWizard.tsx` | 23 | ~600 | 4% |
+| `QuickSettlementSheet.tsx` | 23 | ~200 | 12% |
+
+---
+
+## UX issues
+
+### 1. No explanation of when to use families
+
+The tracking mode selector (`TripForm.tsx:188-231`) shows two radio options with no guidance. A user doesn't know what "Track at family level" means until they've used it. The "same wallet" concept is intuitive — it just needs to be surfaced.
+
+### 2. Tracking mode is permanently locked
+
+`disableTrackingMode` (`TripForm.tsx:190`) prevents changing the mode after adding participants. If someone picks wrong, they must delete all participants and start over. No escape hatch.
+
+### 3. Three checkbox lists when splitting an expense
+
+In families mode, the expense form (`ExpenseForm.tsx:706-823`) and mobile wizard (`WizardStep3.tsx`) show:
+1. **Families** — checkboxes for family units
+2. **Standalone Individuals** — people not in any family
+3. **All Individuals** — everyone, including people already covered by family checkboxes
+
+The same person appears in two lists. The code needs 5 deduplication guards to prevent double-counting. If the system needs that many guardrails, the UI model is wrong.
+
+### 4. "Account for family size" is per-expense
+
+The `accountForFamilySize` toggle (`WizardStep3.tsx:122-146`) appears on **every** expense. In practice, a trip group either wants proportional splitting or equal splitting — they don't toggle this per dinner bill. This should be a trip-level setting, not a per-expense decision.
+
+### 5. Five concepts users must understand
+
+To use families mode, a user needs to grasp:
+1. "Family" = shared wallet (not explained)
+2. The tracking mode choice is permanent (warned but not explained why)
+3. Family entities vs individual people are different selection targets
+4. Selecting a family implicitly covers its members (double-counting risk)
+5. "Account for family size" changes how costs are split
+
+---
+
+## Architecture issue: parallel entity model
+
+The root cause of code complexity: families are a **separate entity type**, not a grouping tag on participants.
+
+### Current model (parallel entities)
+
+```
+families table
+  id UUID ← used in expense distribution JSONB
+  family_name, adults, children
+
+participants table
+  id UUID
+  family_id UUID ← FK to families (nullable)
+```
+
+- Expense `distribution` JSONB stores `families: string[]` (family IDs)
+- Balance calculator maps between participant IDs and family entity IDs
+- 3 distribution types: `individuals`, `families`, `mixed`
+- "Mixed" exists ONLY because families mode can have standalone participants
+- Every component that touches money branches on `if (trackingMode === 'families')`
+
+### Alternative model (grouping tag)
+
+```
+participants table
+  id UUID
+  wallet_group TEXT ← nullable label, e.g. "The Smiths"
+```
+
+- Expenses only reference participant IDs (one distribution type)
+- Balance calculation groups by `wallet_group` at display time
+- No "mixed" type needed, no double-counting logic
+- ~1,350 fewer lines, 44 files → ~35
+
+### Why the refactor is non-trivial
+
+- Existing expense data with `distribution.type === 'families'` or `'mixed'` needs migration
+- Settlement optimizer currently works with family entity IDs
+- `adults`/`children` counts on families would need to be derived from participant metadata
+- Requires data migration strategy for production trips
+
+---
+
+## Potential improvements (if/when we act)
+
+### Quick wins (UX only)
+- Add explanation text: _"Use when some people share money and don't need to settle between themselves — e.g., a couple or parents with kids"_
+- Rename "Individuals + Families" → "Shared wallets" or "Some people share money"
+- Move `accountForFamilySize` to trip settings (removes 33 refs across 7 files)
+
+### Medium effort
+- Unify the 3-list expense split UI into one grouped list
+- Allow converting between tracking modes after participants exist
+
+### Major refactor
+- Migrate from parallel entity model to grouping-tag model
+- Eliminate `mixed` distribution type
+- Merge `FamiliesSetup.tsx` + `IndividualsSetup.tsx` into one component

--- a/FAMILY_REFACTOR.md
+++ b/FAMILY_REFACTOR.md
@@ -1,0 +1,160 @@
+# Family Entity Refactor
+> Started: 2026-02-24
+> Status: PLANNING COMPLETE — READY FOR PHASE 1
+> Executor: read this file at the start of every phase session to understand where things stand.
+
+## Architecture Summary
+
+### Current Model (parallel entities)
+
+The app uses a **parallel entity model** for shared-wallet groups. A `families` table stores group metadata (name, adults count, children count). Each `participant` optionally references a `family_id`. Expense distribution JSONB stores **family UUIDs** as first-class split targets via three distribution types: `individuals`, `families`, and `mixed`. The balance calculator, settlement optimizer, split preview, and Excel export all branch on these three types. The `mixed` type exists solely because families-mode trips can have standalone participants who aren't in any family.
+
+This produces 536 family-related references across 44 files, 5+ deduplication guards to prevent double-counting (same person appearing in both a family selection and individual selection), and a 906-line `FamiliesSetup.tsx` (2.6x the equivalent `IndividualsSetup.tsx`).
+
+### Target Model (grouping tag)
+
+Replace the `families` table and `family_id` FK with a `wallet_group TEXT` column on `participants`. Expenses reference **only participant IDs** (one distribution type: `individuals`). The balance calculator groups by `wallet_group` at display time. The `families` and `mixed` distribution types are eliminated. `accountForFamilySize` moves from per-expense to trip-level. ~1,350 fewer lines, 44 → ~35 files.
+
+## Key Files
+
+### Phase 1 — Data Migration
+| File | Why |
+|------|-----|
+| `supabase/migrations/029_add_wallet_group.sql` | Add `wallet_group TEXT` to participants |
+| `src/services/balanceCalculator.ts` | Read for snapshot script (function signature) |
+| `src/services/balanceCalculator.test.ts` | Reference for parity tests |
+
+### Phase 2 — Engine Swap
+| File | Why |
+|------|-----|
+| `src/services/balanceCalculator.ts` | Write V2 alongside V1, then swap |
+| `src/services/balanceCalculator.test.ts` | Parity tests for V2 |
+| `src/services/settlementOptimizer.ts` | Update `isFamily` → `isGroup` or remove |
+| `src/services/transactionHistoryBuilder.ts` | Uses `myEntityId` (family_id in families mode) |
+| `src/services/excelExport.ts` | Distribution type branching (lines 26-42) |
+| `src/types/expense.ts` | Simplify `ExpenseDistribution` union |
+
+### Phase 3 — UI Simplification
+| File | Why |
+|------|-----|
+| `src/components/expenses/ExpenseForm.tsx` | Remove 3-list split UI (lines 326-399) |
+| `src/components/expenses/wizard/WizardStep3.tsx` | Remove accountForFamilySize toggle, simplify |
+| `src/components/expenses/ExpenseSplitPreview.tsx` | Remove families/mixed preview branches (lines 80-298) |
+| `src/components/setup/FamiliesSetup.tsx` | Delete entirely |
+| `src/components/setup/IndividualsSetup.tsx` | Rename/evolve into ParticipantsSetup.tsx |
+| `src/components/quick/QuickSettlementSheet.tsx` | Simplify entity ID resolution |
+| `src/pages/ManageTripPage.tsx` | References FamiliesSetup |
+| `src/components/quick/QuickParticipantSetupSheet.tsx` | References FamiliesSetup |
+| `src/types/participant.ts` | Remove Family interface, remove family_id from Participant |
+| `supabase/migrations/030_drop_family_id.sql` | Drop FK |
+| `supabase/migrations/031_drop_families_table.sql` | Drop table |
+
+### Phase 4 — Family Balance View
+| File | Why |
+|------|-----|
+| `src/components/quick/QuickGroupDetailPage.tsx` | Add within-group toggle |
+| `src/components/quick/QuickBalanceHero.tsx` | Display within-group balances |
+| `src/services/balanceCalculator.ts` | Add within-group calculation helper |
+
+## Schema: Current State
+
+### `families` table
+```sql
+id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+family_name TEXT NOT NULL,
+adults INTEGER NOT NULL CHECK (adults > 0),
+children INTEGER NOT NULL DEFAULT 0
+```
+
+### `participants` table
+```sql
+id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+family_id UUID REFERENCES families(id) ON DELETE CASCADE,  -- nullable
+name TEXT NOT NULL,
+is_adult BOOLEAN NOT NULL DEFAULT true,
+user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,  -- nullable
+email TEXT  -- nullable
+```
+
+### Distribution JSONB (on `expenses.distribution`)
+```ts
+// Union of three types:
+IndividualsDistribution { type: 'individuals', participants: string[], splitMode?, participantSplits? }
+FamiliesDistribution { type: 'families', families: string[], splitMode?, familySplits?, accountForFamilySize? }
+MixedDistribution { type: 'mixed', families: string[], participants: string[], splitMode?, familySplits?, participantSplits?, accountForFamilySize? }
+```
+
+### Settlement optimizer output
+```ts
+SettlementTransaction { fromId, fromName, toId, toName, amount, isFromFamily, isToFamily }
+```
+In families mode, `fromId`/`toId` are family UUIDs, not participant IDs.
+
+## Schema: Target State
+
+### `families` table — **DROPPED**
+
+### `participants` table
+```sql
+id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+-- family_id DROPPED
+wallet_group TEXT,  -- nullable; e.g. "The Smiths"
+name TEXT NOT NULL,
+is_adult BOOLEAN NOT NULL DEFAULT true,
+user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+email TEXT
+```
+
+### Distribution JSONB — **unified**
+```ts
+// Single type only:
+IndividualsDistribution { type: 'individuals', participants: string[], splitMode?, participantSplits? }
+```
+All existing `families` and `mixed` distributions are migrated to `individuals` with expanded participant IDs.
+
+### `trips` table — **new column**
+```sql
+account_for_family_size BOOLEAN NOT NULL DEFAULT false  -- moved from per-expense
+```
+
+### Settlement optimizer output — simplified
+```ts
+SettlementTransaction { fromId, fromName, toId, toName, amount }
+// isFromFamily/isToFamily removed — IDs are always participant IDs
+```
+
+## Risk Register
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **Balance discrepancy after migration** | Critical | Snapshot all balances pre-migration, verify zero discrepancy at each phase boundary |
+| **Existing `families`/`mixed` expenses in production** | High | Phase 1 backfill: expand family IDs → participant IDs in distribution JSONB. Verify with snapshot. |
+| **Settlement optimizer emits family IDs** | Medium | Phase 2: V2 calculator outputs participant IDs only. Optimizer `isFamily` flag removed. |
+| **`resolveParticipantId` in QuickSettlementSheet** | Medium | Phase 3: remove entirely — IDs are always participant IDs after Phase 2 |
+| **`bankDetailsMap` keyed by family ID** | Medium | Phase 3: key by participant ID directly |
+| **`fromEmailMap` maps family_id → email** | Medium | Phase 3: simplify to participant.id → email |
+| **FamiliesSetup.tsx imported by ManageTripPage + QuickParticipantSetupSheet** | Low | Phase 3: replace imports with new ParticipantsSetup |
+| **9 existing tests cover families/mixed logic** | Low | Phase 2: parity tests verify V2 matches V1 before old tests are updated |
+| **`adults`/`children` counts on families table lost when table is dropped** | Medium | Already captured on individual participants via `is_adult`. `wallet_group` members' `is_adult` status is the source of truth after migration. |
+| **`accountForFamilySize` on existing expense distributions** | Medium | Phase 2: V2 calculator reads trip-level flag instead. Existing per-expense values honored during transition. |
+| **Edge functions** | None | No edge functions reference families or distribution types |
+
+## Phase Status
+
+| Phase | Status | PR | Sign-off |
+|---|---|---|---|
+| 1 — Migration | NOT STARTED | — | — |
+| 2 — Engine | NOT STARTED | — | — |
+| 3 — UI | NOT STARTED | — | — |
+| 4 — Feature | NOT STARTED | — | — |
+
+## Balance Snapshot
+
+_To be populated by Phase 1. Format: JSON file with per-trip, per-entity balances computed by the current `calculateBalances` function._
+
+## Phase Log
+
+_Each phase will append its findings, decisions, and any deviations from the plan here._

--- a/balance_snapshot_pre.json
+++ b/balance_snapshot_pre.json
@@ -1,0 +1,246 @@
+{
+  "snapshot_date": "2026-02-24T14:31:09.428Z",
+  "calculator_version": "v1",
+  "trips": [
+    {
+      "trip_id": "6ea50592-d325-477d-8540-fd703a4f2d3d",
+      "trip_name": "Himos 2025",
+      "tracking_mode": "families",
+      "balances": [
+        {
+          "id": "fbaa73c8-3834-404a-b92c-1398318116a5",
+          "name": "Elias",
+          "totalPaid": 3222.9,
+          "totalShare": 1191.66,
+          "balance": 0.02,
+          "isFamily": true
+        },
+        {
+          "id": "53a68bbf-aaa7-4434-a6b3-859ba4b2b00f",
+          "name": "Hindriks",
+          "totalPaid": 0,
+          "totalShare": 614.5,
+          "balance": 0,
+          "isFamily": true
+        },
+        {
+          "id": "7420a7cc-0068-4dd1-bbef-5195fd4a5cc8",
+          "name": "Küngas",
+          "totalPaid": 1097,
+          "totalShare": 1281.26,
+          "balance": 0,
+          "isFamily": true
+        },
+        {
+          "id": "0f349843-1b7c-4f15-9054-6a67a4cd66e5",
+          "name": "Maasik",
+          "totalPaid": 210,
+          "totalShare": 1442.46,
+          "balance": 0,
+          "isFamily": true
+        }
+      ],
+      "totalExpenses": 4529.9
+    },
+    {
+      "trip_id": "4bfdd500-4b75-4227-b0e3-7d3e8ff1382b",
+      "trip_name": "Norra 2026",
+      "tracking_mode": "individuals",
+      "balances": [
+        {
+          "id": "acef3682-177e-470a-9d97-968f40078635",
+          "name": "Mart",
+          "totalPaid": 2385,
+          "totalShare": 265,
+          "balance": 403.13,
+          "isFamily": false
+        },
+        {
+          "id": "5603167d-0b34-416b-85c1-71ad90f9b18f",
+          "name": "Krissu",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -15,
+          "isFamily": false
+        },
+        {
+          "id": "edbcc0c4-c93d-4e37-a1f3-7eafb37565af",
+          "name": "Kalle",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -15,
+          "isFamily": false
+        },
+        {
+          "id": "ba4dc214-4187-442a-9229-b695d5e9030d",
+          "name": "Junks",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -15,
+          "isFamily": false
+        },
+        {
+          "id": "a538cd69-2b05-46ea-aad6-fbf4129ec36d",
+          "name": "Martin",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -15,
+          "isFamily": false
+        },
+        {
+          "id": "4177944a-2bfa-4203-b0bb-f2266b7a87ac",
+          "name": "Maran",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -15,
+          "isFamily": false
+        },
+        {
+          "id": "673915f2-0916-474b-b2d3-43e49336602a",
+          "name": "Kristjan",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -15,
+          "isFamily": false
+        },
+        {
+          "id": "5c8e0ee5-7963-4d97-90f9-982a3818351e",
+          "name": "Madis",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -48.13,
+          "isFamily": false
+        },
+        {
+          "id": "c5de7697-e1d1-4107-a57c-37b213b35619",
+          "name": "Papp",
+          "totalPaid": 0,
+          "totalShare": 265,
+          "balance": -265,
+          "isFamily": false
+        }
+      ],
+      "totalExpenses": 2385
+    },
+    {
+      "trip_id": "af3252df-28c5-41bb-b5cc-2996333a36ec",
+      "trip_name": "Thai 2026",
+      "tracking_mode": "families",
+      "balances": [
+        {
+          "id": "c8adf318-09ab-4378-b4e5-f4ca670dfbd5",
+          "name": "Kivinugise Eliased",
+          "totalPaid": 14612.18,
+          "totalShare": 8518.25,
+          "balance": 3625.63,
+          "isFamily": true
+        },
+        {
+          "id": "c4518166-d26b-4d9f-9d91-19b092c14cde",
+          "name": "Tiirikud",
+          "totalPaid": 6396.68,
+          "totalShare": 6558.45,
+          "balance": -161.77,
+          "isFamily": true
+        },
+        {
+          "id": "1e0eb953-8b86-4300-943e-04e805070d0c",
+          "name": "Kersti",
+          "totalPaid": 963,
+          "totalShare": 2261.68,
+          "balance": -1298.68,
+          "isFamily": false
+        },
+        {
+          "id": "3615436f-4791-45ee-ac12-53dd90953519",
+          "name": "Lammuka Eliased",
+          "totalPaid": 309.38,
+          "totalShare": 4942.87,
+          "balance": -2165.18,
+          "isFamily": true
+        }
+      ],
+      "totalExpenses": 22281.24
+    },
+    {
+      "trip_id": "e7e2ec5c-cb55-4918-9f1b-db22d3505e6b",
+      "trip_name": "Rattalaager",
+      "tracking_mode": "individuals",
+      "balances": [
+        {
+          "id": "e44c9a51-d80b-4474-b26b-78fe9b12a6f4",
+          "name": "Rahel",
+          "totalPaid": 1550,
+          "totalShare": 387.5,
+          "balance": 387.5,
+          "isFamily": false
+        },
+        {
+          "id": "ad511734-89de-4f01-bbf5-7e1dc96436a7",
+          "name": "Pille",
+          "totalPaid": 0,
+          "totalShare": 0,
+          "balance": 0,
+          "isFamily": false
+        },
+        {
+          "id": "27f8f041-a1a3-4ecf-8c0c-dddca12b48ff",
+          "name": "Harri",
+          "totalPaid": 0,
+          "totalShare": 775,
+          "balance": 0,
+          "isFamily": false
+        },
+        {
+          "id": "d7120329-ce96-4307-a2a2-68eb77f6e604",
+          "name": "Andreas Papp",
+          "totalPaid": 0,
+          "totalShare": 387.5,
+          "balance": -387.5,
+          "isFamily": false
+        }
+      ],
+      "totalExpenses": 1550
+    },
+    {
+      "trip_id": "45b0b67d-9f0c-4791-a61a-440a20ab15e8",
+      "trip_name": "Itaalia",
+      "tracking_mode": "individuals",
+      "balances": [
+        {
+          "id": "e9748ef3-39db-4df6-a131-d510b6b43e67",
+          "name": "raido vahi",
+          "totalPaid": 0,
+          "totalShare": 0,
+          "balance": 0,
+          "isFamily": false
+        }
+      ],
+      "totalExpenses": 0
+    },
+    {
+      "trip_id": "126a8fe4-8a0e-4590-b747-864e09b40533",
+      "trip_name": "Testievent",
+      "tracking_mode": "individuals",
+      "balances": [
+        {
+          "id": "b579b5b0-b63d-4eef-a82d-662f125c1d73",
+          "name": "Kristjan Elias",
+          "totalPaid": 370,
+          "totalShare": 185,
+          "balance": 185,
+          "isFamily": false
+        },
+        {
+          "id": "14041ae1-179e-4c08-9063-5e437b7b0104",
+          "name": "Kairi",
+          "totalPaid": 0,
+          "totalShare": 185,
+          "balance": -185,
+          "isFamily": false
+        }
+      ],
+      "totalExpenses": 370
+    }
+  ]
+}

--- a/scripts/snapshot_balances.ts
+++ b/scripts/snapshot_balances.ts
@@ -1,0 +1,122 @@
+/**
+ * Snapshot all trip balances using the current (V1) balance calculator.
+ * Output: balance_snapshot_pre.json
+ *
+ * Run: npx tsx --tsconfig tsconfig.json scripts/snapshot_balances.ts
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { calculateBalances } from '../src/services/balanceCalculator'
+import type { Expense } from '../src/types/expense'
+import type { Participant, Family } from '../src/types/participant'
+import type { Settlement } from '../src/types/settlement'
+import { writeFileSync } from 'fs'
+
+const supabase = createClient(
+  'https://kojngcoxywrhpxokkuuv.supabase.co',
+  'sb_publishable_EXi_3UU-nVDdw4Tw8G3jkA_I2uD6FFh'
+)
+
+interface TripSnapshot {
+  trip_id: string
+  trip_name: string
+  tracking_mode: string
+  balances: Array<{
+    id: string
+    name: string
+    totalPaid: number
+    totalShare: number
+    balance: number
+    isFamily: boolean
+  }>
+  totalExpenses: number
+}
+
+async function main() {
+  // Fetch all trips
+  const { data: trips, error: tripErr } = await supabase
+    .from('trips')
+    .select('id, name, tracking_mode, default_currency, exchange_rates')
+
+  if (tripErr) {
+    console.error('Error fetching trips:', tripErr)
+    process.exit(1)
+  }
+
+  console.log(`Found ${trips.length} trips`)
+
+  const tripSnapshots: TripSnapshot[] = []
+
+  for (const trip of trips) {
+    // Fetch participants, families, expenses, settlements for this trip
+    const [participantsRes, familiesRes, expensesRes, settlementsRes] = await Promise.all([
+      supabase.from('participants').select('*').eq('trip_id', trip.id),
+      supabase.from('families').select('*').eq('trip_id', trip.id),
+      supabase.from('expenses').select('*').eq('trip_id', trip.id),
+      supabase.from('settlements').select('*').eq('trip_id', trip.id),
+    ])
+
+    if (participantsRes.error || familiesRes.error || expensesRes.error || settlementsRes.error) {
+      console.error(`Error fetching data for trip ${trip.name}:`, {
+        participants: participantsRes.error,
+        families: familiesRes.error,
+        expenses: expensesRes.error,
+        settlements: settlementsRes.error,
+      })
+      continue
+    }
+
+    const participants = participantsRes.data as Participant[]
+    const families = familiesRes.data as Family[]
+    const expenses = expensesRes.data as Expense[]
+    const settlements = settlementsRes.data as Settlement[]
+
+    const trackingMode = (trip.tracking_mode || 'individuals') as 'individuals' | 'families'
+    const defaultCurrency = trip.default_currency || 'EUR'
+    const exchangeRates = (trip.exchange_rates || {}) as Record<string, number>
+
+    const result = calculateBalances(
+      expenses,
+      participants,
+      families,
+      trackingMode,
+      settlements,
+      defaultCurrency,
+      exchangeRates
+    )
+
+    const snapshot: TripSnapshot = {
+      trip_id: trip.id,
+      trip_name: trip.name,
+      tracking_mode: trackingMode,
+      balances: result.balances.map(b => ({
+        id: b.id,
+        name: b.name,
+        totalPaid: Math.round(b.totalPaid * 100) / 100,
+        totalShare: Math.round(b.totalShare * 100) / 100,
+        balance: Math.round(b.balance * 100) / 100,
+        isFamily: b.isFamily,
+      })),
+      totalExpenses: Math.round(result.totalExpenses * 100) / 100,
+    }
+
+    tripSnapshots.push(snapshot)
+    console.log(`  ${trip.name}: ${expenses.length} expenses, ${participants.length} participants, ${families.length} families, mode=${trackingMode}`)
+  }
+
+  const output = {
+    snapshot_date: new Date().toISOString(),
+    calculator_version: 'v1',
+    trips: tripSnapshots,
+  }
+
+  const outPath = 'balance_snapshot_pre.json'
+  writeFileSync(outPath, JSON.stringify(output, null, 2))
+  console.log(`\nSnapshot written to ${outPath}`)
+  console.log(`Total trips: ${tripSnapshots.length}`)
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -10,6 +10,7 @@ export interface Participant {
   id: string
   trip_id: string
   family_id: string | null
+  wallet_group?: string | null
   name: string
   is_adult: boolean
   user_id?: string | null
@@ -26,6 +27,7 @@ export interface CreateFamilyInput {
 export interface CreateParticipantInput {
   trip_id: string
   family_id?: string | null
+  wallet_group?: string | null
   name: string
   is_adult: boolean
   email?: string | null
@@ -41,5 +43,6 @@ export interface UpdateParticipantInput {
   name?: string
   is_adult?: boolean
   family_id?: string | null
+  wallet_group?: string | null
   email?: string | null
 }

--- a/supabase/migrations/029_add_wallet_group.sql
+++ b/supabase/migrations/029_add_wallet_group.sql
@@ -1,0 +1,4 @@
+-- Add wallet_group column to participants
+-- This is the grouping tag that will replace the families table.
+-- Participants with the same wallet_group share a wallet (settle as a unit).
+ALTER TABLE participants ADD COLUMN wallet_group TEXT;


### PR DESCRIPTION
## Summary
- Migration 029: add `wallet_group TEXT` column to `participants` table
- Backfill `wallet_group` from `families.family_name` for all 25 participants with a `family_id`
- Add `wallet_group` to TypeScript types (`Participant`, `CreateParticipantInput`, `UpdateParticipantInput`)
- Snapshot all 6 trip balances to `balance_snapshot_pre.json` for parity verification in Phase 2
- Add planning docs (`FAMILY_REFACTOR.md`, `FAMILY_ENTITY.md`)

No application logic, calculator, or UI changes. The new column is optional (`wallet_group?: string | null`), so all 140 existing tests pass unchanged.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 140/140 passed
- [x] Backfill verification: zero mismatches (all participants with `family_id` have matching `wallet_group`)
- [x] Balance snapshot captured for all 6 production trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)