### PR TITLE
feat: add wallet_group select-all toggle in expense split UI

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, FormEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Lightbulb, ChevronDown, ChevronRight } from 'lucide-react'
+import { Lightbulb, ChevronDown, ChevronRight, Users } from 'lucide-react'
 import { CreateExpenseInput, ExpenseCategory, ExpenseDistribution, SplitMode } from '@/types/expense'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -163,6 +163,19 @@ export function ExpenseForm({
 
   const handleDeselectAll = () => {
     setSelectedParticipants([])
+  }
+
+  const handleGroupToggle = (memberIds: string[]) => {
+    setSelectedParticipants(prev => {
+      const allSelected = memberIds.every(id => prev.includes(id))
+      if (allSelected) {
+        return prev.filter(id => !memberIds.includes(id))
+      } else {
+        const newSet = new Set(prev)
+        for (const id of memberIds) newSet.add(id)
+        return Array.from(newSet)
+      }
+    })
   }
 
   const handleParticipantSplitChange = (id: string, value: string) => {
@@ -514,41 +527,79 @@ export function ExpenseForm({
         </div>
 
         <div className="space-y-2 max-h-48 overflow-y-auto rounded-lg border border-input p-3">
-          {participantGroups.map((group, gi) => (
-            <div key={group.label ?? `standalone-${gi}`}>
-              {group.label && (
-                <p className="text-xs text-muted-foreground mb-1 mt-2 first:mt-0">{group.label}</p>
-              )}
-              {group.members.map(participant => (
-                <div key={participant.id} className="flex items-center space-x-2 min-h-[44px]">
-                  <Checkbox
-                    id={`participant-${participant.id}`}
-                    checked={selectedParticipants.includes(participant.id)}
-                    onCheckedChange={() => handleParticipantToggle(participant.id)}
-                    disabled={loading}
-                  />
-                  <label
-                    htmlFor={`participant-${participant.id}`}
-                    className="text-sm text-foreground cursor-pointer flex-1"
+          {participantGroups.map((group, gi) => {
+            const memberIds = group.members.map(m => m.id)
+            const selectedCount = memberIds.filter(id => selectedParticipants.includes(id)).length
+            const allGroupSelected = selectedCount === memberIds.length
+            const someGroupSelected = selectedCount > 0 && !allGroupSelected
+
+            return (
+              <div
+                key={group.label ?? `standalone-${gi}`}
+                className={group.label ? 'rounded-lg bg-muted/40 border border-border/50 p-2 mt-2 first:mt-0' : ''}
+              >
+                {group.label && (
+                  <div
+                    className="flex items-center space-x-2 min-h-[36px] cursor-pointer"
+                    onClick={() => handleGroupToggle(memberIds)}
                   >
-                    {participant.name} {participant.is_adult ? '' : '(child)'}
-                  </label>
-                  {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
-                    <Input
-                      type="text"
-                      inputMode="decimal"
-                      value={participantSplitValues[participant.id] || ''}
-                      onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value.replace(',', '.'))}
-                      placeholder={splitMode === 'percentage' ? '%' : currency}
-                      pattern="[0-9]*[.,]?[0-9]*"
+                    <Checkbox
+                      id={`group-${group.label}`}
+                      checked={allGroupSelected}
+                      ref={(el) => {
+                        if (el) {
+                          const input = el as unknown as HTMLButtonElement
+                          input.dataset.indeterminate = someGroupSelected ? 'true' : 'false'
+                          input.setAttribute('aria-checked', someGroupSelected ? 'mixed' : String(allGroupSelected))
+                        }
+                      }}
+                      onCheckedChange={() => handleGroupToggle(memberIds)}
                       disabled={loading}
-                      className="w-24 h-9"
+                      className={someGroupSelected ? 'opacity-60' : ''}
                     />
-                  )}
-                </div>
-              ))}
-            </div>
-          ))}
+                    <label
+                      htmlFor={`group-${group.label}`}
+                      className="text-xs font-medium text-foreground cursor-pointer flex-1 flex items-center gap-1"
+                    >
+                      <Users size={12} className="text-muted-foreground" />
+                      {group.label}
+                      <span className="text-xs text-muted-foreground font-normal">
+                        ({memberIds.length})
+                      </span>
+                    </label>
+                  </div>
+                )}
+                {group.members.map(participant => (
+                  <div key={participant.id} className={`flex items-center space-x-2 min-h-[44px] ${group.label ? 'pl-5' : ''}`}>
+                    <Checkbox
+                      id={`participant-${participant.id}`}
+                      checked={selectedParticipants.includes(participant.id)}
+                      onCheckedChange={() => handleParticipantToggle(participant.id)}
+                      disabled={loading}
+                    />
+                    <label
+                      htmlFor={`participant-${participant.id}`}
+                      className="text-sm text-foreground cursor-pointer flex-1"
+                    >
+                      {participant.name} {participant.is_adult ? '' : '(child)'}
+                    </label>
+                    {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
+                      <Input
+                        type="text"
+                        inputMode="decimal"
+                        value={participantSplitValues[participant.id] || ''}
+                        onChange={(e) => handleParticipantSplitChange(participant.id, e.target.value.replace(',', '.'))}
+                        placeholder={splitMode === 'percentage' ? '%' : currency}
+                        pattern="[0-9]*[.,]?[0-9]*"
+                        disabled={loading}
+                        className="w-24 h-9"
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
+            )
+          })}
         </div>
       </div>
 

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -185,6 +185,21 @@ function MobileWizard({
     setSelectedParticipants([])
   }
 
+  const handleGroupToggle = (memberIds: string[]) => {
+    setSelectedParticipants(prev => {
+      const allSelected = memberIds.every(id => prev.includes(id))
+      if (allSelected) {
+        // Deselect all members of the group
+        return prev.filter(id => !memberIds.includes(id))
+      } else {
+        // Select all members of the group
+        const newSet = new Set(prev)
+        for (const id of memberIds) newSet.add(id)
+        return Array.from(newSet)
+      }
+    })
+  }
+
   const handleParticipantSplitChange = (id: string, value: string) => {
     setParticipantSplitValues(prev => ({ ...prev, [id]: value }))
   }
@@ -454,6 +469,7 @@ function MobileWizard({
               participants={participants}
               selectedParticipants={selectedParticipants}
               onParticipantToggle={handleParticipantToggle}
+              onGroupToggle={handleGroupToggle}
               onSelectAll={handleSelectAll}
               onDeselectAll={handleDeselectAll}
               onAdvancedClick={handleAdvanced}

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -17,6 +17,7 @@ interface WizardStep3Props {
   participants: Participant[]
   selectedParticipants: string[]
   onParticipantToggle: (id: string) => void
+  onGroupToggle: (memberIds: string[]) => void
   onSelectAll: () => void
   onDeselectAll: () => void
   onAdvancedClick: () => void
@@ -27,6 +28,7 @@ export function WizardStep3({
   participants,
   selectedParticipants,
   onParticipantToggle,
+  onGroupToggle,
   onSelectAll,
   onDeselectAll,
   onAdvancedClick,
@@ -135,37 +137,75 @@ export function WizardStep3({
               <div className="space-y-2">
                 <Label className="text-base font-medium">Participants</Label>
                 <div className="space-y-2 rounded-lg border border-input p-3">
-                  {participantGroups.map((group, gi) => (
-                    <div key={group.label ?? `standalone-${gi}`}>
-                      {group.label && (
-                        <p className="text-xs text-muted-foreground mb-1 mt-2 first:mt-0">{group.label}</p>
-                      )}
-                      {group.members.map((participant) => (
-                        <div
-                          key={participant.id}
-                          className="flex items-center space-x-3 min-h-[44px] py-1"
-                        >
-                          <Checkbox
-                            id={`participant-${participant.id}`}
-                            checked={selectedParticipants.includes(participant.id)}
-                            onCheckedChange={() => onParticipantToggle(participant.id)}
-                            disabled={disabled}
-                          />
-                          <label
-                            htmlFor={`participant-${participant.id}`}
-                            className="text-base text-foreground cursor-pointer flex-1"
+                  {participantGroups.map((group, gi) => {
+                    const memberIds = group.members.map(m => m.id)
+                    const selectedCount = memberIds.filter(id => selectedParticipants.includes(id)).length
+                    const allGroupSelected = selectedCount === memberIds.length
+                    const someGroupSelected = selectedCount > 0 && !allGroupSelected
+
+                    return (
+                      <div
+                        key={group.label ?? `standalone-${gi}`}
+                        className={group.label ? 'rounded-lg bg-muted/40 border border-border/50 p-2 mt-2 first:mt-0' : ''}
+                      >
+                        {group.label && (
+                          <div
+                            className="flex items-center space-x-3 min-h-[44px] py-1 cursor-pointer"
+                            onClick={() => onGroupToggle(memberIds)}
                           >
-                            {participant.name}
-                            {!participant.is_adult && (
-                              <span className="text-sm text-muted-foreground ml-2">
-                                (child)
+                            <Checkbox
+                              id={`group-${group.label}`}
+                              checked={allGroupSelected}
+                              ref={(el) => {
+                                if (el) {
+                                  const input = el as unknown as HTMLButtonElement
+                                  input.dataset.indeterminate = someGroupSelected ? 'true' : 'false'
+                                  input.setAttribute('aria-checked', someGroupSelected ? 'mixed' : String(allGroupSelected))
+                                }
+                              }}
+                              onCheckedChange={() => onGroupToggle(memberIds)}
+                              disabled={disabled}
+                              className={someGroupSelected ? 'opacity-60' : ''}
+                            />
+                            <label
+                              htmlFor={`group-${group.label}`}
+                              className="text-sm font-medium text-foreground cursor-pointer flex-1 flex items-center gap-1.5"
+                            >
+                              <Users size={14} className="text-muted-foreground" />
+                              {group.label}
+                              <span className="text-xs text-muted-foreground font-normal">
+                                ({memberIds.length})
                               </span>
-                            )}
-                          </label>
-                        </div>
-                      ))}
-                    </div>
-                  ))}
+                            </label>
+                          </div>
+                        )}
+                        {group.members.map((participant) => (
+                          <div
+                            key={participant.id}
+                            className={`flex items-center space-x-3 min-h-[44px] py-1 ${group.label ? 'pl-6' : ''}`}
+                          >
+                            <Checkbox
+                              id={`participant-${participant.id}`}
+                              checked={selectedParticipants.includes(participant.id)}
+                              onCheckedChange={() => onParticipantToggle(participant.id)}
+                              disabled={disabled}
+                            />
+                            <label
+                              htmlFor={`participant-${participant.id}`}
+                              className="text-base text-foreground cursor-pointer flex-1"
+                            >
+                              {participant.name}
+                              {!participant.is_adult && (
+                                <span className="text-sm text-muted-foreground ml-2">
+                                  (child)
+                                </span>
+                              )}
+                            </label>
+                          </div>
+                        ))}
+                      </div>
+                    )
+                  })}
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
## Summary
- Adds a group-level checkbox to the expense split participant list for wallet_group members
- Tapping the group header selects/deselects all members in one tap (matching old family selection UX)
- Groups visually distinguished with subtle background, border, and indented members
- Applied to both mobile wizard (WizardStep3) and desktop dialog (ExpenseForm)

## Test plan
- [x] `npm run type-check` clean
- [x] 137/137 unit tests pass
- [ ] Manual: open expense wizard on mobile, verify wallet_group members show grouped with header checkbox
- [ ] Manual: tap group header — all members toggle on/off
- [ ] Manual: partial deselect within group — group checkbox shows reduced opacity
- [ ] Manual: desktop dialog shows same grouping behavior
- [ ] Manual: trips with no wallet_groups render unchanged (standalone participants only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)