### PR TITLE
fix: group checkbox infinite re-render loop (React error #185)

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -545,17 +545,9 @@ export function ExpenseForm({
                   >
                     <Checkbox
                       id={`group-${group.label}`}
-                      checked={allGroupSelected}
-                      ref={(el) => {
-                        if (el) {
-                          const input = el as unknown as HTMLButtonElement
-                          input.dataset.indeterminate = someGroupSelected ? 'true' : 'false'
-                          input.setAttribute('aria-checked', someGroupSelected ? 'mixed' : String(allGroupSelected))
-                        }
-                      }}
+                      checked={someGroupSelected ? 'indeterminate' : allGroupSelected}
                       onCheckedChange={() => handleGroupToggle(memberIds)}
                       disabled={loading}
-                      className={someGroupSelected ? 'opacity-60' : ''}
                     />
                     <label
                       htmlFor={`group-${group.label}`}

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -155,17 +155,9 @@ export function WizardStep3({
                           >
                             <Checkbox
                               id={`group-${group.label}`}
-                              checked={allGroupSelected}
-                              ref={(el) => {
-                                if (el) {
-                                  const input = el as unknown as HTMLButtonElement
-                                  input.dataset.indeterminate = someGroupSelected ? 'true' : 'false'
-                                  input.setAttribute('aria-checked', someGroupSelected ? 'mixed' : String(allGroupSelected))
-                                }
-                              }}
+                              checked={someGroupSelected ? 'indeterminate' : allGroupSelected}
                               onCheckedChange={() => onGroupToggle(memberIds)}
                               disabled={disabled}
-                              className={someGroupSelected ? 'opacity-60' : ''}
                             />
                             <label
                               htmlFor={`group-${group.label}`}


### PR DESCRIPTION
## Summary
- Fixes crash when opening expense form on trips with wallet_group participants
- Root cause: inline `ref` callback mutated `aria-checked` on every render, conflicting with Radix Checkbox's internal state → infinite update loop
- Fix: replace `ref` hack with Radix's native `checked='indeterminate'` prop

## Test plan
- [x] `npm run type-check` clean
- [x] 137/137 unit tests pass
- [ ] Manual: open Add Expense on a trip with wallet_groups — no crash
- [ ] Manual: group checkbox shows indeterminate state when partially selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)