### PR TITLE
fix: group checkbox display-only to prevent infinite re-render loop

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -540,25 +540,24 @@ export function ExpenseForm({
               >
                 {group.label && (
                   <div
+                    role="checkbox"
+                    aria-checked={someGroupSelected ? 'mixed' : allGroupSelected}
                     className="flex items-center space-x-2 min-h-[36px] cursor-pointer"
                     onClick={() => handleGroupToggle(memberIds)}
                   >
                     <Checkbox
-                      id={`group-${group.label}`}
-                      checked={someGroupSelected ? 'indeterminate' : allGroupSelected}
-                      onCheckedChange={() => handleGroupToggle(memberIds)}
+                      checked={allGroupSelected}
+                      tabIndex={-1}
                       disabled={loading}
+                      className={`pointer-events-none ${someGroupSelected ? 'opacity-60' : ''}`}
                     />
-                    <label
-                      htmlFor={`group-${group.label}`}
-                      className="text-xs font-medium text-foreground cursor-pointer flex-1 flex items-center gap-1"
-                    >
+                    <span className="text-xs font-medium text-foreground flex-1 flex items-center gap-1">
                       <Users size={12} className="text-muted-foreground" />
                       {group.label}
                       <span className="text-xs text-muted-foreground font-normal">
                         ({memberIds.length})
                       </span>
-                    </label>
+                    </span>
                   </div>
                 )}
                 {group.members.map(participant => (

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -150,25 +150,24 @@ export function WizardStep3({
                       >
                         {group.label && (
                           <div
+                            role="checkbox"
+                            aria-checked={someGroupSelected ? 'mixed' : allGroupSelected}
                             className="flex items-center space-x-3 min-h-[44px] py-1 cursor-pointer"
                             onClick={() => onGroupToggle(memberIds)}
                           >
                             <Checkbox
-                              id={`group-${group.label}`}
-                              checked={someGroupSelected ? 'indeterminate' : allGroupSelected}
-                              onCheckedChange={() => onGroupToggle(memberIds)}
+                              checked={allGroupSelected}
+                              tabIndex={-1}
                               disabled={disabled}
+                              className={`pointer-events-none ${someGroupSelected ? 'opacity-60' : ''}`}
                             />
-                            <label
-                              htmlFor={`group-${group.label}`}
-                              className="text-sm font-medium text-foreground cursor-pointer flex-1 flex items-center gap-1.5"
-                            >
+                            <span className="text-sm font-medium text-foreground flex-1 flex items-center gap-1.5">
                               <Users size={14} className="text-muted-foreground" />
                               {group.label}
                               <span className="text-xs text-muted-foreground font-normal">
                                 ({memberIds.length})
                               </span>
-                            </label>
+                            </span>
                           </div>
                         )}
                         {group.members.map((participant) => (


### PR DESCRIPTION
## Summary
- Fixes React error #185 (max update depth exceeded) when opening expense form on trips with wallet_groups
- Root cause: three overlapping click handlers on the group checkbox row (Radix `onCheckedChange`, parent div `onClick`, label `htmlFor` association) caused `handleGroupToggle` to fire multiple times, creating an infinite loop
- Fix: checkbox is now display-only (`pointer-events-none`, no `onCheckedChange`, no `id`/`htmlFor`). Parent div is the sole click handler. Partial selection shown via `opacity-60` instead of Radix `indeterminate` state.

## Test plan
- [x] `npm run type-check` clean
- [x] 137/137 unit tests pass
- [ ] Manual: open Add Expense on a trip with wallet_groups — no crash
- [ ] Manual: click group row — toggles all members
- [ ] Manual: partial selection shows reduced opacity on group checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)