### PR TITLE
fix: post-refactor cleanup — tracking mode, group UX, proportional splitting, within-group balances

### DIFF
--- a/FAMILY_CLEANUP.md
+++ b/FAMILY_CLEANUP.md
@@ -1,0 +1,15 @@
+# Family Refactor Cleanup
+> Date: 2026-02-25
+> Branch: fix/family-refactor-cleanup
+> Issues to fix: 7
+> Status: COMPLETE
+
+| # | Issue | Status | Notes |
+|---|---|---|---|
+| 1 | Remove Tracking Mode selector | DONE | Removed from TripForm, EventForm, ManageTripPage details + edit dialog, AdminAllTripsPage. Hardcoded `'individuals'`. Excel export updated. |
+| 2 | wallet_group inline hint text | DONE | Added `text-xs text-muted-foreground mt-1` hint below wallet_group input in ParticipantsSetup.tsx |
+| 3 | wallet_group changeable mid-trip | DONE | Already works — inline editor in ParticipantsSetup has no lock. `handleSaveGroup` calls `updateParticipant` directly. |
+| 4 | Datalist autocomplete verification | DONE | Already implemented — `existingGroups` useMemo + `<datalist id="wallet-groups">` + `list="wallet-groups"` on both add-form and inline-edit inputs. |
+| 5 | Proportional splitting → per-expense | DONE | Removed trip-level toggle from ManageTripPage. Added `accountForFamilySize` to IndividualsDistribution. Toggle in ExpenseForm + WizardStep3, only shown when wallet_group participants are selected. Calculator updated for equal-between-entities (default) vs proportional-by-size. |
+| 6 | Children folded into adults in within-group balances | DONE | Calculator folds child balances into adults. UI hides children and shows "Children's shares are split among adults" note. 2 new tests added. |
+| 7 | Within-group balances hidden in Quick mode | DONE | Removed from QuickGroupDetailPage. Added to SettlementsPage (Full mode) with toggle, "children's shares" note, same card pattern. |

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,7 +1,7 @@
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
 import { Calendar, Zap } from 'lucide-react'
-import { CreateEventInput, TrackingMode } from '@/types/trip'
+import { CreateEventInput } from '@/types/trip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -14,7 +14,6 @@ interface EventFormProps {
   initialValues?: Partial<CreateEventInput>
   submitLabel?: string
   isLoading?: boolean
-  disableTrackingMode?: boolean
   isEditMode?: boolean
 }
 
@@ -24,7 +23,6 @@ export function EventForm({
   initialValues,
   submitLabel = 'Create',
   isLoading: externalLoading,
-  disableTrackingMode = false,
   isEditMode = false,
 }: EventFormProps) {
   const today = new Date().toISOString().split('T')[0]
@@ -32,7 +30,7 @@ export function EventForm({
   const [name, setName] = useState(initialValues?.name || '')
   const [startDate, setStartDate] = useState(initialValues?.start_date || today)
   const [endDate, setEndDate] = useState(initialValues?.end_date || today)
-  const [trackingMode, setTrackingMode] = useState<TrackingMode>(initialValues?.tracking_mode || 'individuals')
+  // tracking_mode is always 'individuals' after the family refactor
   const [defaultCurrency, setDefaultCurrency] = useState(initialValues?.default_currency || 'EUR')
   const [enableMeals, setEnableMeals] = useState(initialValues?.enable_meals ?? false)
   const [enableActivities, setEnableActivities] = useState(initialValues?.enable_activities ?? false)
@@ -65,7 +63,7 @@ export function EventForm({
         start_date: startDate,
         end_date: resolvedEndDate,
         event_type: eventType,
-        tracking_mode: trackingMode,
+        tracking_mode: 'individuals',
         default_currency: defaultCurrency.trim().toUpperCase() || 'EUR',
         enable_meals: enableMeals,
         enable_activities: enableActivities,
@@ -248,52 +246,6 @@ export function EventForm({
           </div>
         </div>
       )}
-
-      <div className="space-y-3">
-        <Label>Tracking Mode</Label>
-        {disableTrackingMode && (
-          <p className="text-sm text-muted-foreground">
-            Cannot change tracking mode after adding participants
-          </p>
-        )}
-        <div className="space-y-3">
-          <label className="flex items-start p-4 rounded-lg border-2 border-border cursor-pointer transition-all hover:border-primary hover:bg-primary/5 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
-            <input
-              type="radio"
-              name="trackingMode"
-              value="individuals"
-              checked={trackingMode === 'individuals'}
-              onChange={(e) => setTrackingMode(e.target.value as TrackingMode)}
-              className="mt-0.5 mr-3 text-primary focus:ring-primary"
-              disabled={isSubmitting || disableTrackingMode}
-            />
-            <div>
-              <div className="font-medium text-foreground">Individuals only</div>
-              <div className="text-sm text-muted-foreground mt-1">
-                Track expenses per person
-              </div>
-            </div>
-          </label>
-
-          <label className="flex items-start p-4 rounded-lg border-2 border-border cursor-pointer transition-all hover:border-primary hover:bg-primary/5 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
-            <input
-              type="radio"
-              name="trackingMode"
-              value="families"
-              checked={trackingMode === 'families'}
-              onChange={(e) => setTrackingMode(e.target.value as TrackingMode)}
-              className="mt-0.5 mr-3 text-primary focus:ring-primary"
-              disabled={isSubmitting || disableTrackingMode}
-            />
-            <div>
-              <div className="font-medium text-foreground">Individuals + Families</div>
-              <div className="text-sm text-muted-foreground mt-1">
-                Track at family level with individual breakdowns
-              </div>
-            </div>
-          </label>
-        </div>
-      </div>
 
       <div className="flex gap-3 pt-2">
         <Button

--- a/src/components/TripForm.tsx
+++ b/src/components/TripForm.tsx
@@ -1,6 +1,6 @@
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import { CreateTripInput, TrackingMode } from '@/types/trip'
+import { CreateTripInput } from '@/types/trip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -13,7 +13,6 @@ interface TripFormProps {
   initialValues?: Partial<CreateTripInput>
   submitLabel?: string
   isLoading?: boolean
-  disableTrackingMode?: boolean
   isEditMode?: boolean
 }
 
@@ -23,13 +22,11 @@ export function TripForm({
   initialValues,
   submitLabel = 'Create Trip',
   isLoading: externalLoading,
-  disableTrackingMode = false,
   isEditMode = false,
 }: TripFormProps) {
   const [name, setName] = useState(initialValues?.name || '')
   const [startDate, setStartDate] = useState(initialValues?.start_date || new Date().toISOString().split('T')[0])
   const [endDate, setEndDate] = useState(initialValues?.end_date || new Date().toISOString().split('T')[0])
-  const [trackingMode, setTrackingMode] = useState<TrackingMode>(initialValues?.tracking_mode || 'individuals')
   const [defaultCurrency, setDefaultCurrency] = useState(initialValues?.default_currency || 'EUR')
   const [enableMeals, setEnableMeals] = useState(initialValues?.enable_meals ?? false)
   const [enableActivities, setEnableActivities] = useState(initialValues?.enable_activities ?? false)
@@ -59,7 +56,7 @@ export function TripForm({
         name: name.trim(),
         start_date: startDate,
         end_date: endDate,
-        tracking_mode: trackingMode,
+        tracking_mode: 'individuals',
         default_currency: defaultCurrency.trim().toUpperCase() || 'EUR',
         enable_meals: enableMeals,
         enable_activities: enableActivities,
@@ -184,52 +181,6 @@ export function TripForm({
           </div>
         </div>
       )}
-
-      <div className="space-y-3">
-        <Label>Tracking Mode</Label>
-        {disableTrackingMode && (
-          <p className="text-sm text-muted-foreground">
-            Cannot change tracking mode after adding participants
-          </p>
-        )}
-        <div className="space-y-3">
-          <label className="flex items-start p-4 rounded-lg border-2 border-border cursor-pointer transition-all hover:border-primary hover:bg-primary/5 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
-            <input
-              type="radio"
-              name="trackingMode"
-              value="individuals"
-              checked={trackingMode === 'individuals'}
-              onChange={(e) => setTrackingMode(e.target.value as TrackingMode)}
-              className="mt-0.5 mr-3 text-primary focus:ring-primary"
-              disabled={isSubmitting || disableTrackingMode}
-            />
-            <div>
-              <div className="font-medium text-foreground">Individuals only</div>
-              <div className="text-sm text-muted-foreground mt-1">
-                Track expenses per person
-              </div>
-            </div>
-          </label>
-
-          <label className="flex items-start p-4 rounded-lg border-2 border-border cursor-pointer transition-all hover:border-primary hover:bg-primary/5 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
-            <input
-              type="radio"
-              name="trackingMode"
-              value="families"
-              checked={trackingMode === 'families'}
-              onChange={(e) => setTrackingMode(e.target.value as TrackingMode)}
-              className="mt-0.5 mr-3 text-primary focus:ring-primary"
-              disabled={isSubmitting || disableTrackingMode}
-            />
-            <div>
-              <div className="font-medium text-foreground">Individuals + Families</div>
-              <div className="text-sm text-muted-foreground mt-1">
-                Track at family level with individual breakdowns
-              </div>
-            </div>
-          </label>
-        </div>
-      </div>
 
       <div className="flex gap-3 pt-2">
         <Button

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, FormEvent } from 'react'
+import { useState, useEffect, useRef, useMemo, FormEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Lightbulb, ChevronDown, ChevronRight, Users, Check } from 'lucide-react'
 import { CreateExpenseInput, ExpenseCategory, ExpenseDistribution, SplitMode } from '@/types/expense'
@@ -67,6 +67,15 @@ export function ExpenseForm({
   // Custom split values for percentage/amount modes
   const [participantSplitValues, setParticipantSplitValues] = useState<Record<string, string>>({})
 
+  // Proportional group splitting (per-expense toggle)
+  const [accountForFamilySize, setAccountForFamilySize] = useState(false)
+
+  // Show toggle only when any selected participant belongs to a wallet_group
+  const hasSelectedGroups = useMemo(() => {
+    const selectedSet = new Set(selectedParticipants)
+    return participants.some(p => selectedSet.has(p.id) && !!p.wallet_group)
+  }, [selectedParticipants, participants])
+
   // Auto-fill split value when exactly one party is selected in "By Amount" mode
   useEffect(() => {
     if (splitMode !== 'amount') return
@@ -121,6 +130,9 @@ export function ExpenseForm({
 
       if (dist.type === 'individuals') {
         setSelectedParticipants(dist.participants || [])
+        if (dist.accountForFamilySize) {
+          setAccountForFamilySize(true)
+        }
       }
 
       // Restore split mode
@@ -257,7 +269,8 @@ export function ExpenseForm({
             participantId: id,
             value: parseFloat(participantSplitValues[id] || '0')
           }))
-        : undefined
+        : undefined,
+      accountForFamilySize: hasSelectedGroups ? accountForFamilySize : undefined,
     }
 
     if (!currentTrip) {
@@ -591,6 +604,24 @@ export function ExpenseForm({
             )
           })}
         </div>
+
+        {/* Proportional group toggle — only when wallet_group participants are selected */}
+        {hasSelectedGroups && (
+          <div className="flex items-center space-x-2 mt-3">
+            <Checkbox
+              id="accountForFamilySize"
+              checked={accountForFamilySize}
+              onCheckedChange={(checked) => setAccountForFamilySize(checked as boolean)}
+              disabled={loading}
+            />
+            <div>
+              <label htmlFor="accountForFamilySize" className="text-sm text-foreground cursor-pointer">
+                Split proportionally by group size
+              </label>
+              <p className="text-xs text-muted-foreground">Larger groups pay more based on number of members</p>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Split Preview */}

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -116,6 +116,9 @@ function MobileWizard({
   // Custom split values for percentage/amount modes
   const [participantSplitValues, setParticipantSplitValues] = useState<Record<string, string>>({})
 
+  // Proportional group splitting (per-expense toggle)
+  const [accountForFamilySize, setAccountForFamilySize] = useState(false)
+
   const adults = getAdultParticipants()
 
   // Compute available currencies from trip settings
@@ -165,6 +168,7 @@ function MobileWizard({
         setErrorDetail(null)
         setSplitMode('equal')
         setParticipantSplitValues({})
+        setAccountForFamilySize(false)
         // Don't reset category, currency, date - likely to be reused
       }, 300)
       return () => clearTimeout(timer)
@@ -296,6 +300,8 @@ function MobileWizard({
       }
 
       // Build distribution — always individuals
+      // Check if any selected participant has a wallet_group
+      const hasGroups = selectedParticipants.some(pid => participants.find(p => p.id === pid)?.wallet_group)
       const distribution: ExpenseDistribution = {
         type: 'individuals',
         participants: selectedParticipants,
@@ -306,6 +312,7 @@ function MobileWizard({
               value: parseFloat(participantSplitValues[id] || '0')
             }))
           : undefined,
+        accountForFamilySize: hasGroups ? accountForFamilySize : undefined,
       }
 
       const expenseInput: CreateExpenseInput = {
@@ -473,6 +480,8 @@ function MobileWizard({
               onSelectAll={handleSelectAll}
               onDeselectAll={handleDeselectAll}
               onAdvancedClick={handleAdvanced}
+              accountForFamilySize={accountForFamilySize}
+              onAccountForFamilySizeChange={setAccountForFamilySize}
               disabled={isSubmitting}
             />
           )}

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ChevronDown, ChevronRight, Users, Check } from 'lucide-react'
 import { Label } from '@/components/ui/label'
@@ -21,6 +21,8 @@ interface WizardStep3Props {
   onSelectAll: () => void
   onDeselectAll: () => void
   onAdvancedClick: () => void
+  accountForFamilySize: boolean
+  onAccountForFamilySizeChange: (value: boolean) => void
   disabled?: boolean
 }
 
@@ -32,9 +34,17 @@ export function WizardStep3({
   onSelectAll,
   onDeselectAll,
   onAdvancedClick,
+  accountForFamilySize,
+  onAccountForFamilySizeChange,
   disabled = false,
 }: WizardStep3Props) {
   const [showDetails, setShowDetails] = useState(false)
+
+  // Show toggle only when any selected participant belongs to a wallet_group
+  const hasSelectedGroups = useMemo(() => {
+    const selectedSet = new Set(selectedParticipants)
+    return participants.some(p => selectedSet.has(p.id) && !!p.wallet_group)
+  }, [selectedParticipants, participants])
 
   const allSelected = selectedParticipants.length === participants.length
 
@@ -202,6 +212,24 @@ export function WizardStep3({
           )}
         </AnimatePresence>
       </div>
+
+      {/* Proportional group toggle — only when wallet_group participants are selected */}
+      {hasSelectedGroups && (
+        <div className="flex items-center space-x-3 min-h-[44px] py-1">
+          <Checkbox
+            id="accountForFamilySize-wizard"
+            checked={accountForFamilySize}
+            onCheckedChange={(checked) => onAccountForFamilySizeChange(checked as boolean)}
+            disabled={disabled}
+          />
+          <div>
+            <label htmlFor="accountForFamilySize-wizard" className="text-sm text-foreground cursor-pointer">
+              Split proportionally by group size
+            </label>
+            <p className="text-xs text-muted-foreground">Larger groups pay more based on number of members</p>
+          </div>
+        </div>
+      )}
 
       {/* Advanced Options */}
       <div className="pt-4 border-t border-border">

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -439,6 +439,9 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                 disabled={adding}
                 list="wallet-groups"
               />
+              <p className="text-xs text-muted-foreground mt-1">
+                People in the same group settle as a unit — e.g. a couple or parents with kids.
+              </p>
             </div>
 
             <div className="flex items-center space-x-2">

--- a/src/pages/AdminAllTripsPage.tsx
+++ b/src/pages/AdminAllTripsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Search, ExternalLink, Calendar, Users, UserCircle, ShieldAlert } from 'lucide-react'
+import { Search, ExternalLink, Calendar, UserCircle, ShieldAlert } from 'lucide-react'
 import { PageLoadingState } from '@/components/PageLoadingState'
 import { PageErrorState } from '@/components/PageErrorState'
 import { useAuth } from '@/contexts/AuthContext'
@@ -278,7 +278,6 @@ export function AdminAllTripsPage() {
                 <TableRow>
                   <TableHead>Trip Name</TableHead>
                   <TableHead>Trip Code</TableHead>
-                  <TableHead>Tracking Mode</TableHead>
                   <TableHead>Start Date</TableHead>
                   <TableHead>Owner</TableHead>
                   <TableHead>Created</TableHead>
@@ -297,12 +296,6 @@ export function AdminAllTripsPage() {
                       <code className="text-xs bg-muted px-2 py-1 rounded">
                         {trip.trip_code}
                       </code>
-                    </TableCell>
-                    <TableCell className="capitalize">
-                      <div className="flex items-center gap-1 text-sm">
-                        <Users size={14} />
-                        {trip.tracking_mode === 'families' ? 'Families' : 'Individuals'}
-                      </div>
                     </TableCell>
                     <TableCell>
                       <div className="flex items-center gap-1 text-sm">

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -90,7 +90,6 @@ export function ManageTripPage() {
         start_date: values.start_date,
         end_date: values.end_date,
         event_type: values.event_type,
-        tracking_mode: values.tracking_mode,
         default_currency: values.default_currency,
       })
 
@@ -118,17 +117,14 @@ export function ManageTripPage() {
     }
   }
 
-  const hasWalletGroups = participants.some(p => !!p.wallet_group)
-
   const featureLabels: Record<string, string> = {
     enable_meals: 'Meal planning',
     enable_activities: 'Activity planning',
     enable_shopping: 'Shopping list',
     default_split_all: 'Split between everyone',
-    account_for_family_size: 'Proportional group splitting',
   }
 
-  const handleToggleFeature = async (feature: 'enable_meals' | 'enable_activities' | 'enable_shopping' | 'default_split_all' | 'account_for_family_size', value: boolean) => {
+  const handleToggleFeature = async (feature: 'enable_meals' | 'enable_activities' | 'enable_shopping' | 'default_split_all', value: boolean) => {
     setTogglingFeatures(prev => new Set(prev).add(feature))
     try {
       const success = await updateTrip(currentTrip.id, { [feature]: value })
@@ -320,10 +316,6 @@ export function ManageTripPage() {
                 </div>
               </>
             )}
-            <div>
-              <Label className="text-muted-foreground">Tracking Mode</Label>
-              <p className="text-sm font-medium capitalize">{currentTrip.tracking_mode}</p>
-            </div>
           </div>
           <Button onClick={() => setShowEditDialog(true)} className="mt-4">
             <Edit size={16} className="mr-2" />
@@ -383,19 +375,6 @@ export function ManageTripPage() {
               disabled={togglingFeatures.has('default_split_all')}
             />
           </div>
-          {hasWalletGroups && (
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label>Proportional Group Splitting</Label>
-                <p className="text-xs text-muted-foreground">Larger groups pay proportionally more based on group size</p>
-              </div>
-              <Switch
-                checked={currentTrip.account_for_family_size}
-                onCheckedChange={(checked) => handleToggleFeature('account_for_family_size', checked)}
-                disabled={togglingFeatures.has('account_for_family_size')}
-              />
-            </div>
-          )}
         </CardContent>
       </Card>
 
@@ -533,7 +512,7 @@ export function ManageTripPage() {
           <DialogHeader>
             <DialogTitle>Edit {entityLabel} Details</DialogTitle>
             <DialogDescription>
-              Update the name, dates, or tracking mode
+              Update the name, dates, or currency
             </DialogDescription>
           </DialogHeader>
 
@@ -554,14 +533,12 @@ export function ManageTripPage() {
               start_date: currentTrip.start_date,
               end_date: currentTrip.end_date,
               event_type: currentTrip.event_type,
-              tracking_mode: currentTrip.tracking_mode,
               default_currency: currentTrip.default_currency,
             }}
             onSubmit={handleEditTrip}
             onCancel={() => setShowEditDialog(false)}
             submitLabel="Save Changes"
             isLoading={isUpdating}
-            disableTrackingMode={participants.length > 0}
             isEditMode
           />
         </DialogContent>

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -6,7 +6,7 @@ import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
 import { useReceiptContext } from '@/contexts/ReceiptContext'
-import { calculateBalances, buildEntityMap, calculateWithinGroupBalances, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { calculateBalances, buildEntityMap } from '@/services/balanceCalculator'
 import { LinkParticipantDialog } from '@/components/LinkParticipantDialog'
 import { QuickBalanceHero } from '@/components/quick/QuickBalanceHero'
 import { QuickActionButton } from '@/components/quick/QuickActionButton'
@@ -23,11 +23,9 @@ import { PageErrorState } from '@/components/PageErrorState'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useToast } from '@/hooks/use-toast'
-import { Switch } from '@/components/ui/switch'
-import { Label } from '@/components/ui/label'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
-  Loader2, Users, Check
+  Loader2, Users
 } from 'lucide-react'
 
 export function QuickGroupDetailPage() {
@@ -50,8 +48,6 @@ export function QuickGroupDetailPage() {
   const [historyOpen, setHistoryOpen] = useState(false)
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [retrying, setRetrying] = useState(false)
-  const [showWithinGroup, setShowWithinGroup] = useState(false)
-
   // Open receipt capture sheet when navigated here with openScan state
   useEffect(() => {
     if ((location.state as any)?.openScan) {
@@ -152,73 +148,6 @@ export function QuickGroupDetailPage() {
           )}
         </div>
       )}
-
-      {/* Within-group balances toggle */}
-      {!loading && !contextError && (() => {
-        const walletGroups = [...new Set(
-          participants.filter(p => p.wallet_group).map(p => p.wallet_group!)
-        )]
-        const hasGroups = walletGroups.length > 0
-
-        return (
-          <div className="mb-4">
-            <div className="flex items-center gap-2 mb-3">
-              <Switch
-                id="within-group"
-                checked={showWithinGroup}
-                onCheckedChange={setShowWithinGroup}
-                disabled={!hasGroups}
-              />
-              <Label htmlFor="within-group" className="text-sm text-muted-foreground cursor-pointer">
-                Within-group balances
-              </Label>
-            </div>
-
-            {showWithinGroup && !hasGroups && (
-              <p className="text-sm text-muted-foreground">No shared wallets on this trip</p>
-            )}
-
-            {showWithinGroup && hasGroups && walletGroups.map(groupName => {
-              const groupBalances = calculateWithinGroupBalances(
-                expenses,
-                participants,
-                groupName,
-                currentTrip!.default_currency,
-                currentTrip!.exchange_rates
-              )
-              const allEven = groupBalances.every(b => Math.abs(b.balance) < 0.01)
-              const hasExpenses = groupBalances.some(b => b.totalPaid > 0 || b.totalShare > 0)
-
-              return (
-                <Card key={groupName} className="mb-3">
-                  <CardContent className="pt-4 pb-4">
-                    <p className="font-medium text-sm mb-2">{groupName}</p>
-                    {!hasExpenses ? (
-                      <p className="text-xs text-muted-foreground">No shared expenses yet</p>
-                    ) : allEven ? (
-                      <div className="flex items-center gap-1.5 text-green-600 dark:text-green-400">
-                        <Check size={14} />
-                        <span className="text-sm">Evenly split</span>
-                      </div>
-                    ) : (
-                      <div className="space-y-1.5">
-                        {groupBalances.map(b => (
-                          <div key={b.id} className="flex justify-between items-center text-sm">
-                            <span>{b.name}</span>
-                            <span className={`tabular-nums font-medium ${getBalanceColorClass(b.balance)}`}>
-                              {formatBalance(b.balance, currentTrip!.default_currency)}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              )
-            })}
-          </div>
-        )
-      })()}
 
       {/* Pending receipts banner */}
       <div className="mb-2">

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
-import { ChevronDown, ChevronRight, Receipt, FileDown } from 'lucide-react'
+import { ChevronDown, ChevronRight, Receipt, FileDown, Users, Check } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -8,7 +8,7 @@ import { useSettlementContext } from '@/contexts/SettlementContext'
 import { PageLoadingState } from '@/components/PageLoadingState'
 import { PageErrorState } from '@/components/PageErrorState'
 import { useReceiptContext } from '@/contexts/ReceiptContext'
-import { calculateBalances, buildEntityMap } from '@/services/balanceCalculator'
+import { calculateBalances, buildEntityMap, calculateWithinGroupBalances, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
 import { calculateOptimalSettlement } from '@/services/settlementOptimizer'
 import { exportSettlementPlanToPDF } from '@/services/pdfExport'
 import type { SettlementTransaction } from '@/services/settlementOptimizer'
@@ -16,6 +16,8 @@ import type { CreateSettlementInput } from '@/types/settlement'
 import { SettlementPlan, BankDetails } from '@/components/SettlementPlan'
 import { SettlementForm } from '@/components/SettlementForm'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
 import { Card, CardContent } from '@/components/ui/card'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/lib/logger'
@@ -34,6 +36,7 @@ export function SettlementsPage() {
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
   const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
   const [retrying, setRetrying] = useState(false)
+  const [showWithinGroup, setShowWithinGroup] = useState(false)
 
   const loading = pLoading || eLoading || sLoading
   const contextError = pError || eError || sError
@@ -311,6 +314,74 @@ export function SettlementsPage() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Within-group balances */}
+        {(() => {
+          const walletGroups = [...new Set(
+            participants.filter(p => p.wallet_group).map(p => p.wallet_group!)
+          )]
+          if (walletGroups.length === 0) return null
+
+          return (
+            <Card>
+              <CardContent className="pt-6">
+                <div className="flex items-center gap-2 mb-4">
+                  <Switch
+                    id="within-group"
+                    checked={showWithinGroup}
+                    onCheckedChange={setShowWithinGroup}
+                  />
+                  <Label htmlFor="within-group" className="text-sm cursor-pointer flex items-center gap-1.5">
+                    <Users size={14} className="text-muted-foreground" />
+                    Within-group balances
+                  </Label>
+                </div>
+
+                {showWithinGroup && walletGroups.map(groupName => {
+                  const groupBalances = calculateWithinGroupBalances(
+                    expenses,
+                    participants,
+                    groupName,
+                    currentTrip.default_currency,
+                    currentTrip.exchange_rates
+                  )
+                  const allEven = groupBalances.every(b => Math.abs(b.balance) < 0.01)
+                  const hasGroupExpenses = groupBalances.some(b => b.totalPaid > 0 || b.totalShare > 0)
+                  const groupMembers = participants.filter(p => p.wallet_group === groupName)
+                  const hasChildren = groupMembers.some(p => !p.is_adult) && groupMembers.some(p => p.is_adult)
+
+                  return (
+                    <div key={groupName} className="p-3 rounded-lg bg-muted/30 mb-3 last:mb-0">
+                      <p className="font-medium text-sm mb-2">{groupName}</p>
+                      {!hasGroupExpenses ? (
+                        <p className="text-xs text-muted-foreground">No shared expenses yet</p>
+                      ) : allEven ? (
+                        <div className="flex items-center gap-1.5 text-green-600 dark:text-green-400">
+                          <Check size={14} />
+                          <span className="text-sm">Evenly split</span>
+                        </div>
+                      ) : (
+                        <div className="space-y-1.5">
+                          {groupBalances.map(b => (
+                            <div key={b.id} className="flex justify-between items-center text-sm">
+                              <span>{b.name}</span>
+                              <span className={`tabular-nums font-medium ${getBalanceColorClass(b.balance)}`}>
+                                {formatBalance(b.balance, currentTrip.default_currency)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      {hasChildren && (
+                        <p className="text-xs text-muted-foreground mt-2">Children's shares are split among adults</p>
+                      )}
+                    </div>
+                  )
+                })}
+              </CardContent>
+            </Card>
+          )
+        })()}
 
         {/* Optimal Settlement Plan */}
         {expenses.length > 0 && (

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -458,4 +458,47 @@ describe('calculateWithinGroupBalances', () => {
     const balances = calculateWithinGroupBalances([], allParticipants, 'NonExistent')
     expect(balances).toHaveLength(0)
   })
+
+  describe('children folded into adults', () => {
+    const adultA = buildParticipant({ id: 'fa1', name: 'Mom', wallet_group: 'Fam', is_adult: true })
+    const adultB = buildParticipant({ id: 'fa2', name: 'Dad', wallet_group: 'Fam', is_adult: true })
+    const child = buildParticipant({ id: 'fc1', name: 'Kid', wallet_group: 'Fam', is_adult: false })
+    const famParticipants = [adultA, adultB, child]
+
+    it('folds child balance into adults — only 2 rows returned', () => {
+      const expense = buildExpense({
+        amount: 90,
+        paid_by: 'fa1',
+        distribution: { type: 'individuals', participants: ['fa1', 'fa2', 'fc1'] },
+      })
+      const balances = calculateWithinGroupBalances([expense], famParticipants, 'Fam')
+
+      // Only adults should be returned
+      expect(balances).toHaveLength(2)
+      expect(balances.every(b => b.id !== 'fc1')).toBe(true)
+
+      // Mom paid 90, each person's share = 30
+      // Kid's balance = 0 - 30 = -30, split among 2 adults = -15 each
+      // Mom: paid 90, share 30 + 15 = 45, balance = 45
+      // Dad: paid 0, share 30 + 15 = 45, balance = -45
+      const mom = balances.find(b => b.id === 'fa1')!
+      const dad = balances.find(b => b.id === 'fa2')!
+      expect(mom.balance).toBeCloseTo(45, 2)
+      expect(dad.balance).toBeCloseTo(-45, 2)
+    })
+
+    it('returns all members when group has no adults', () => {
+      const childA = buildParticipant({ id: 'c1', name: 'ChildA', wallet_group: 'Kids', is_adult: false })
+      const childB = buildParticipant({ id: 'c2', name: 'ChildB', wallet_group: 'Kids', is_adult: false })
+      const expense = buildExpense({
+        amount: 60,
+        paid_by: 'c1',
+        distribution: { type: 'individuals', participants: ['c1', 'c2'] },
+      })
+      const balances = calculateWithinGroupBalances([expense], [childA, childB], 'Kids')
+
+      // Both children shown (no adults to fold into)
+      expect(balances).toHaveLength(2)
+    })
+  })
 })

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -121,12 +121,27 @@ export function calculateExpenseShares(
   if (distribution.type !== 'individuals') return shares
 
   const splitMode = distribution.splitMode || 'equal'
+  const accountForFamilySize = distribution.accountForFamilySize ?? false
 
   if (splitMode === 'equal') {
-    const shareAmount = expense.amount / distribution.participants.length
-    for (const pid of distribution.participants) {
-      const eid = participantToEntityId.get(pid) ?? pid
-      shares.set(eid, (shares.get(eid) || 0) + shareAmount)
+    if (!accountForFamilySize) {
+      // Equal split between entities (groups + standalone participants).
+      // Each entity pays the same regardless of group size.
+      const entityIds = new Set<string>()
+      for (const pid of distribution.participants) {
+        entityIds.add(participantToEntityId.get(pid) ?? pid)
+      }
+      const perEntity = expense.amount / entityIds.size
+      for (const eid of entityIds) {
+        shares.set(eid, perEntity)
+      }
+    } else {
+      // Proportional: per-person split — larger groups naturally pay more
+      const shareAmount = expense.amount / distribution.participants.length
+      for (const pid of distribution.participants) {
+        const eid = participantToEntityId.get(pid) ?? pid
+        shares.set(eid, (shares.get(eid) || 0) + shareAmount)
+      }
     }
   } else if (splitMode === 'percentage' && distribution.participantSplits) {
     for (const split of distribution.participantSplits) {
@@ -290,13 +305,32 @@ export function calculateWithinGroupBalances(
     // Calculate each group member's share in this expense
     const memberShares = new Map<string, number>()
     const splitMode = expense.distribution.splitMode || 'equal'
+    const accountForFamilySize = expense.distribution.accountForFamilySize ?? false
 
     if (splitMode === 'equal') {
       const memberParticipants = expense.distribution.participants.filter(pid => memberIds.has(pid))
       if (memberParticipants.length === 0) continue
-      const perPerson = expense.amount / expense.distribution.participants.length
-      for (const pid of memberParticipants) {
-        memberShares.set(pid, (memberShares.get(pid) || 0) + perPerson * conversionFactor)
+
+      if (!accountForFamilySize) {
+        // Equal between entities: group's share = total / numEntities
+        // Count unique entities in the distribution using wallet_group
+        const entitySet = new Set<string>()
+        for (const pid of expense.distribution.participants) {
+          const p = participants.find(pp => pp.id === pid)
+          entitySet.add(p?.wallet_group ?? pid)
+        }
+        const groupShare = expense.amount / entitySet.size
+        // Split group's share equally among group members in distribution
+        const perMember = groupShare / memberParticipants.length
+        for (const pid of memberParticipants) {
+          memberShares.set(pid, (memberShares.get(pid) || 0) + perMember * conversionFactor)
+        }
+      } else {
+        // Proportional: per-person split
+        const perPerson = expense.amount / expense.distribution.participants.length
+        for (const pid of memberParticipants) {
+          memberShares.set(pid, (memberShares.get(pid) || 0) + perPerson * conversionFactor)
+        }
       }
     } else if ((splitMode === 'percentage' || splitMode === 'amount') && expense.distribution.participantSplits) {
       for (const split of expense.distribution.participantSplits) {
@@ -322,20 +356,49 @@ export function calculateWithinGroupBalances(
     })
   }
 
-  // Only keep members who have any paid or share
-  // (but always return all members for completeness)
-  const balances: ParticipantBalance[] = groupMembers.map(m => {
-    const totalPaid = paid.get(m.id) || 0
-    const totalShare = share.get(m.id) || 0
-    return {
-      id: m.id,
-      name: m.name,
-      totalPaid,
-      totalShare,
-      balance: totalPaid - totalShare,
-      isFamily: false,
+  // Compute raw balances per member
+  const rawBalances = groupMembers.map(m => ({
+    id: m.id,
+    name: m.name,
+    is_adult: m.is_adult,
+    totalPaid: paid.get(m.id) || 0,
+    totalShare: share.get(m.id) || 0,
+    balance: (paid.get(m.id) || 0) - (share.get(m.id) || 0),
+  }))
+
+  // Fold children's balances into adults
+  const adults = rawBalances.filter(b => b.is_adult)
+  const children = rawBalances.filter(b => !b.is_adult)
+
+  if (adults.length > 0 && children.length > 0) {
+    // Distribute each child's balance equally among adults
+    for (const child of children) {
+      const perAdult = child.balance / adults.length
+      for (const adult of adults) {
+        adult.balance += perAdult
+        adult.totalShare += child.totalShare / adults.length
+      }
     }
-  })
+    // Return only adults
+    return adults.map(a => ({
+      id: a.id,
+      name: a.name,
+      totalPaid: a.totalPaid,
+      totalShare: a.totalShare,
+      balance: a.balance,
+      isFamily: false,
+    })).sort((a, b) => b.balance - a.balance)
+  }
+
+  // No adults or no children — return all members as-is
+  const balances: ParticipantBalance[] = rawBalances.map(m => ({
+    id: m.id,
+    name: m.name,
+    totalPaid: m.totalPaid,
+    totalShare: m.totalShare,
+    balance: m.balance,
+    isFamily: false,
+  }))
 
   return balances.sort((a, b) => b.balance - a.balance)
 }

--- a/src/services/excelExport.ts
+++ b/src/services/excelExport.ts
@@ -120,7 +120,7 @@ export function exportExpensesToExcel(
     { Metric: 'Trip Name', Value: trip.name },
     { Metric: 'Start Date', Value: trip.start_date ? new Date(trip.start_date).toLocaleDateString() : 'N/A' },
     { Metric: 'End Date', Value: trip.end_date ? new Date(trip.end_date).toLocaleDateString() : 'N/A' },
-    { Metric: 'Tracking Mode', Value: trip.tracking_mode === 'families' ? 'Families' : 'Individuals' },
+    { Metric: 'Tracking Mode', Value: 'Individuals' },
     { Metric: '', Value: '' }, // Empty row
     { Metric: 'Total Expenses', Value: totalExpenses.toFixed(2) },
     { Metric: 'Number of Expenses', Value: expenses.length.toString() },
@@ -155,10 +155,11 @@ export function exportParticipantsToExcel(
   const workbook = XLSX.utils.book_new()
 
   // Participants sheet
+  const hasWalletGroups = participants.some(p => !!p.wallet_group)
   const participantsData = participants.map(participant => ({
     Name: participant.name,
     'Is Adult': participant.is_adult ? 'Yes' : 'No',
-    ...(trip.tracking_mode === 'families' && participant.wallet_group
+    ...(hasWalletGroups && participant.wallet_group
       ? { 'Wallet Group': participant.wallet_group }
       : {}),
   }))
@@ -167,7 +168,7 @@ export function exportParticipantsToExcel(
   participantsWorksheet['!cols'] = [
     { wch: 25 }, // Name
     { wch: 10 }, // Is Adult
-    ...(trip.tracking_mode === 'families' ? [{ wch: 25 }] : []) // Wallet Group
+    ...(hasWalletGroups ? [{ wch: 25 }] : []) // Wallet Group
   ]
 
   XLSX.utils.book_append_sheet(workbook, participantsWorksheet, 'Participants')

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -19,6 +19,7 @@ export interface IndividualsDistribution {
   participants: string[]; // participant IDs
   splitMode?: SplitMode; // defaults to 'equal' if not specified
   participantSplits?: ParticipantSplit[]; // for percentage/amount modes
+  accountForFamilySize?: boolean; // when true, larger wallet_groups pay proportionally more
 }
 
 export type ExpenseDistribution = IndividualsDistribution;


### PR DESCRIPTION
## Summary

Post-family-refactor cleanup fixing 7 specific issues identified after Phase 4 completion.

- **Issue 1**: Remove Tracking Mode selector from trip creation/edit forms (TripForm, EventForm, ManageTripPage, AdminAllTripsPage). Hardcode `tracking_mode: 'individuals'`.
- **Issue 2**: Add inline hint text below wallet_group input in ParticipantsSetup.
- **Issue 3**: Verified wallet_group is already editable mid-trip (no lock exists).
- **Issue 4**: Verified datalist autocomplete for wallet_group is already implemented.
- **Issue 5**: Move proportional group splitting from trip-level toggle to per-expense toggle. Added `accountForFamilySize` to `IndividualsDistribution`. Toggle appears in ExpenseForm (desktop) and WizardStep3 (mobile) only when wallet_group participants are selected. Calculator updated for equal-between-entities (default OFF) vs proportional-by-size (ON).
- **Issue 6**: Fold children's balances into adults in within-group balance calculations. Children are hidden from the UI; note shown when applicable. 2 new tests added.
- **Issue 7**: Move within-group balances from Quick mode (QuickGroupDetailPage) to Full mode (SettlementsPage).

## Test plan

- [x] `npm run type-check` passes clean
- [x] `npm test` — 145/145 tests pass (2 new)
- [ ] Trip creation form: no Tracking Mode selector
- [ ] Adding a participant: wallet_group hint text visible, autocomplete suggestions work
- [ ] Editing a participant: wallet_group is editable
- [ ] Add expense: proportional toggle appears only when wallet_group participants are selected
- [ ] Add expense: proportional toggle does NOT appear when only standalone participants are selected
- [ ] Within-group balances: children not shown separately (folded into adults)
- [ ] Quick mode: within-group toggle is gone
- [ ] Full mode (Settlements): within-group toggle is present and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)