### PR TITLE
docs: update PLAN.md, FAMILY_REFACTOR.md, CLAUDE.md with cleanup session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Family Trip Cost Splitter — A mobile-first web application for splitting costs
 - Auth: Supabase Auth (Google OAuth supported)
 - Observability: Grafana Cloud (Loki logs + OTLP metrics) via `log-proxy` Edge Function
 - Deployment: Cloudflare Pages
-- Tests: Vitest + Testing Library (139 tests)
+- Tests: Vitest + Testing Library (145 tests)
 
 ---
 
@@ -57,10 +57,9 @@ git branch -d fix/description
 
 ## Database Schema
 
-### Core tables (migrations 001–006)
+### Core tables (migrations 001–006, updated by family refactor migrations 029–032)
 - `trips` — trip metadata, tracking_mode (`individuals` | `families`), trip_code (URL slug), created_by
-- `families` — family groups with adults/children counts
-- `participants` — individuals linked to a family or standalone; `user_id` links to auth user ("This is me")
+- `participants` — individuals with optional `wallet_group TEXT` for shared-wallet grouping; `user_id` links to auth user ("This is me")
 - `expenses` — expense records with JSONB `distribution` field
 - `settlements` — payment transfers between participants/families
 - `meals` — meal planning (breakfast/lunch/dinner per day)
@@ -151,7 +150,7 @@ Mode is stored per-user in `user_preferences.preferred_mode` and synced from Sup
 | `AuthContext` | Supabase auth session, user profile, bank details |
 | `TripContext` | Trip list, active trip, CRUD |
 | `UserPreferencesContext` | mode (`quick`/`full`), defaultTripId, Supabase sync |
-| `ParticipantContext` | Participants + families, user↔participant link |
+| `ParticipantContext` | Participants (with wallet_group), user↔participant link |
 | `ExpenseContext` | Expense CRUD, list |
 | `SettlementContext` | Settlement CRUD |
 | `MealContext` | Meal calendar, meal↔shopping links |
@@ -162,11 +161,12 @@ Mode is stored per-user in `user_preferences.preferred_mode` and synced from Sup
 All contexts wrap Supabase calls in `withTimeout` (15 s, from `src/lib/fetchWithTimeout.ts`) so a slow network never leaves the UI stuck.
 
 ### Tracking Modes (expense splitting)
-1. **individuals** — expenses split per person
-2. **families** — expenses split per family unit (with optional proportional-by-size weighting)
-3. **mixed** — families + standalone individuals in same expense
 
-Distribution type is stored as JSONB on the expense. `balanceCalculator.ts` handles all three modes.
+All expenses use a single distribution type: `individuals`. The `tracking_mode` column still exists in the DB but is always `'individuals'` for new trips (UI selector removed).
+
+Participants can be grouped via `wallet_group TEXT` on the `participants` table. The balance calculator (`buildEntityMap`) groups participants by `wallet_group` at display time — each group settles as a unit. Per-expense `accountForFamilySize` toggle (on `IndividualsDistribution`) controls whether groups split equally between entities (default OFF) or proportionally by member count (ON).
+
+Within-group balances are shown on `SettlementsPage` (Full mode) via `calculateWithinGroupBalances()`. Children's balances are folded into adults within the group.
 
 ### Routes
 
@@ -382,7 +382,7 @@ and the user-friendly error message will never be shown.
 ## Testing
 
 ### Unit Tests
-Vitest + Testing Library. Run with `npm test`. 139 tests covering contexts, hooks, and key pages. Test files co-located with source (`*.test.tsx`). Use factories in `src/test/factories.ts` to build test data.
+Vitest + Testing Library. Run with `npm test`. 145 tests covering contexts, hooks, and key pages. Test files co-located with source (`*.test.tsx`). Use factories in `src/test/factories.ts` to build test data.
 
 ### E2E Smoke Tests (Playwright)
 26 automated tests: 13 routes × 2 viewports (mobile 375×812, desktop 1280×720). Supabase fully mocked via `page.route()`. Run with `npm run test:e2e` or `npm run test:e2e:ui`.

--- a/FAMILY_REFACTOR.md
+++ b/FAMILY_REFACTOR.md
@@ -115,9 +115,15 @@ IndividualsDistribution { type: 'individuals', participants: string[], splitMode
 ```
 All existing `families` and `mixed` distributions are migrated to `individuals` with expanded participant IDs.
 
-### `trips` table — **new column**
-```sql
-account_for_family_size BOOLEAN NOT NULL DEFAULT false  -- moved from per-expense
+### `expenses.distribution` JSONB — **per-expense field**
+```ts
+IndividualsDistribution {
+  type: 'individuals',
+  participants: string[],
+  splitMode?: SplitMode,
+  participantSplits?: ParticipantSplit[],
+  accountForFamilySize?: boolean  // per-expense toggle (cleanup PR #396)
+}
 ```
 
 ### Settlement optimizer output — simplified
@@ -150,6 +156,7 @@ SettlementTransaction { fromId, fromName, toId, toName, amount }
 | 2 — Engine | COMPLETE | #387 | type-check clean, 152/152 tests, zero snapshot discrepancies |
 | 3 — UI | COMPLETE | #388 | type-check clean, 137/137 tests, -3013 net lines |
 | 4 — Feature | COMPLETE | #395 | type-check clean, 143/143 tests |
+| Cleanup | COMPLETE | #396 | type-check clean, 145/145 tests |
 
 ## Balance Snapshot
 
@@ -274,4 +281,18 @@ Within-group balance view — the feature that motivated the entire refactor.
 
 143/143 tests pass. Type-check clean.
 
-**Family entity refactor is COMPLETE.** All 4 phases done.
+### Cleanup — 2026-02-25
+
+PR #396: 7-issue post-refactor cleanup session.
+
+1. **Tracking mode selector removed** — TripForm, EventForm, ManageTripPage, AdminAllTripsPage. Hardcoded `tracking_mode: 'individuals'` on creation. DB column still exists.
+2. **wallet_group hint text** — added to ParticipantsSetup: "People in the same group settle as a unit"
+3. **wallet_group changeable mid-trip** — verified already works (no lock existed)
+4. **Datalist autocomplete** — verified already implemented (existingGroups useMemo + datalist)
+5. **accountForFamilySize moved to per-expense** — removed trip-level `account_for_family_size` toggle from ManageTripPage. Added `accountForFamilySize?: boolean` to `IndividualsDistribution`. Toggle shown in ExpenseForm (desktop) and WizardStep3 (mobile) only when wallet_group participants are selected. Default OFF = equal split between entities; ON = proportional by member count.
+6. **Children folded into adults** — `calculateWithinGroupBalances` distributes child balances equally among adults in the same wallet_group. 2 new tests added.
+7. **Within-group balances moved to Full mode** — removed from QuickGroupDetailPage, added to SettlementsPage with toggle, group cards, and "Children's shares are split among adults" note.
+
+145/145 tests pass. Type-check clean.
+
+**Family entity refactor is COMPLETE.** All 4 phases + cleanup done.

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,7 +19,7 @@
 | Auth | Supabase Auth (Google OAuth, implicit flow) |
 | Observability | Grafana Cloud — Loki (logs) + OTLP (metrics) via `log-proxy` |
 | Deployment | Cloudflare Pages |
-| Tests | Vitest + Testing Library (137 unit tests, all passing), Playwright (26 E2E smoke tests) |
+| Tests | Vitest + Testing Library (145 unit tests, all passing), Playwright (26 E2E smoke tests) |
 | AI SDK | `@anthropic-ai/sdk@0.32.1` — **already installed, not yet used** |
 | PDF Export | jsPDF + jspdf-autotable |
 | Maps | Leaflet + react-leaflet |
@@ -743,6 +743,7 @@ Replace ad-hoc loading/error patterns with the shared components from 7a.
 | 2026-02-24 | Family refactor Phases 1–3 | **Phase 1** (PR #386): migration 029 `wallet_group TEXT` on participants, backfill from families table. **Phase 2** (PR #387): V2 balance calculator with `buildEntityMap`, 152/152 tests, zero snapshot discrepancies. **Phase 3** (PR #388): removed families entity model — deleted `FamiliesSetup.tsx`, `FamiliesDistribution`/`MixedDistribution` types, simplified 40 files, -3013 net lines, 137/137 tests. Migrations 029–032 (wallet_group → account_for_family_size → drop family_id → drop families table). See `FAMILY_REFACTOR.md` for full details. |
 | 2026-02-25 | Phase 3 regression fix | PR #392: Fixed 2 regressions from family refactor Phase 3. **Bug 1 (CRITICAL)**: Radix `Checkbox` in wallet_group group headers caused infinite re-render crash ("Maximum update depth exceeded") on trips with wallet_groups — replaced with plain `<span>` visual elements in `ExpenseForm.tsx` + `WizardStep3.tsx`. **Bug 2 (HIGH)**: SettlementsPage `fromEmailMap`, `bankDetailsMap`, `handleRemind` keyed by `p.id` instead of entity IDs from `buildEntityMap` — bank details/emails undefined for wallet_group trips. Fixed to match `QuickSettlementSheet.tsx` pattern. 137/137 tests, type-check clean. Documented in `PHASE_3_BUGS.md`. |
 | 2026-02-25 | Family refactor Phase 4 | PR #395: Within-group balance view — the feature that motivated the entire refactor. New `calculateWithinGroupBalances()` function in `balanceCalculator.ts` (only tracks expenses paid by group members; credits payer with group share only, so balances net to zero). Toggle "Within-group balances" in `QuickGroupDetailPage.tsx` — per-group Card with member balances, "Evenly split" indicator, "No shared expenses yet" empty state. 6 new tests. 143/143 tests, type-check clean. **Family entity refactor COMPLETE (all 4 phases).** |
+| 2026-02-25 | Family refactor cleanup | PR #396: 7-issue post-refactor cleanup. (1) Removed tracking_mode selector from TripForm, EventForm, ManageTripPage, AdminAllTripsPage — hardcoded `'individuals'`. (2) Added wallet_group hint text in ParticipantsSetup. (3–4) Verified wallet_group is changeable mid-trip and datalist autocomplete works (no code needed). (5) Moved `accountForFamilySize` from trip-level toggle to per-expense field on `IndividualsDistribution` — toggle shown in ExpenseForm/WizardStep3 only when wallet_group participants selected; removed from ManageTripPage. (6) `calculateWithinGroupBalances` now folds children's balances into adults (2 new tests). (7) Within-group balances moved from QuickGroupDetailPage to SettlementsPage (Full mode). 145/145 tests, type-check clean. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Update test counts (139/137 → 145) across CLAUDE.md and PLAN.md
- Update CLAUDE.md: tracking modes section rewritten (single distribution type, wallet_group, per-expense accountForFamilySize), database schema updated (families table removed), ParticipantContext description
- Add cleanup session log to PLAN.md and FAMILY_REFACTOR.md (PR #396)

🤖 Generated with [Claude Code](https://claude.com/claude-code)