### PR TITLE
fix: group toggle naming, dialog a11y, remove group badge

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -3,7 +3,6 @@ import { ArrowDownToLine, ArrowUpFromLine, CheckCircle2 } from 'lucide-react'
 import { ParticipantBalance } from '@/services/balanceCalculator'
 import { formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
 import { Card } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 
 interface BalanceCardProps {
   balance: ParticipantBalance
@@ -67,14 +66,9 @@ export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardP
         {/* Header */}
         <div className="flex items-start justify-between mb-3">
           <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <h3 className="text-lg font-semibold text-foreground">
-                {balance.name}
-              </h3>
-              {balance.isFamily && (
-                <Badge variant="soft">Group</Badge>
-              )}
-            </div>
+            <h3 className="text-lg font-semibold text-foreground">
+              {balance.name}
+            </h3>
           </div>
           <div className="flex flex-col items-end">
             <span className="text-xs text-muted-foreground mb-1">{status.text}</span>

--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -77,10 +77,7 @@ export function CostBreakdownDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            {balance.name}
-            {balance.isFamily && <Badge variant="soft">Group</Badge>}
-          </DialogTitle>
+          <DialogTitle>{balance.name}</DialogTitle>
           <DialogDescription>
             Balance: <span className={`font-semibold ${balanceColorClass}`}>{formatBalance(balance.balance, defaultCurrency)}</span>
           </DialogDescription>

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -616,9 +616,9 @@ export function ExpenseForm({
             />
             <div>
               <label htmlFor="accountForFamilySize" className="text-sm text-foreground cursor-pointer">
-                Split proportionally by group size
+                Split equally between groups
               </label>
-              <p className="text-xs text-muted-foreground">Larger groups pay more based on number of members</p>
+              <p className="text-xs text-muted-foreground">Each group pays the same share, regardless of how many members it has</p>
             </div>
           </div>
         )}

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -16,7 +16,7 @@ import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 
 import { X } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { ExpenseForm } from './ExpenseForm'
 import { WizardProgress } from './wizard/WizardProgress'
 import { WizardNavigation } from './wizard/WizardNavigation'
@@ -46,7 +46,10 @@ export function ExpenseWizard({
   if (mode === 'edit' || !isMobile) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto" aria-describedby={undefined}>
+          <DialogTitle className="sr-only">
+            {mode === 'edit' ? 'Edit Expense' : 'Add Expense'}
+          </DialogTitle>
           <ExpenseForm
             onSubmit={onSubmit}
             onCancel={() => onOpenChange(false)}

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -224,9 +224,9 @@ export function WizardStep3({
           />
           <div>
             <label htmlFor="accountForFamilySize-wizard" className="text-sm text-foreground cursor-pointer">
-              Split proportionally by group size
+              Split equally between groups
             </label>
-            <p className="text-xs text-muted-foreground">Larger groups pay more based on number of members</p>
+            <p className="text-xs text-muted-foreground">Each group pays the same share, regardless of how many members it has</p>
           </div>
         </div>
       )}

--- a/src/components/quick/QuickBalanceHero.tsx
+++ b/src/components/quick/QuickBalanceHero.tsx
@@ -38,11 +38,6 @@ export function QuickBalanceHero({ balance }: QuickBalanceHeroProps) {
           : formatBalance(balance.balance).replace(/^[+-]/, '')
         }
       </p>
-      {balance.isFamily && (
-        <p className="text-xs text-muted-foreground mt-2">
-          Group: {balance.name}
-        </p>
-      )}
     </motion.div>
   )
 }

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -124,9 +124,9 @@ export function calculateExpenseShares(
   const accountForFamilySize = distribution.accountForFamilySize ?? false
 
   if (splitMode === 'equal') {
-    if (!accountForFamilySize) {
-      // Equal split between entities (groups + standalone participants).
-      // Each entity pays the same regardless of group size.
+    if (accountForFamilySize) {
+      // "Split equally between groups" — each entity pays the same
+      // regardless of group size.
       const entityIds = new Set<string>()
       for (const pid of distribution.participants) {
         entityIds.add(participantToEntityId.get(pid) ?? pid)
@@ -136,7 +136,7 @@ export function calculateExpenseShares(
         shares.set(eid, perEntity)
       }
     } else {
-      // Proportional: per-person split — larger groups naturally pay more
+      // Default: per-person split — larger groups naturally pay more
       const shareAmount = expense.amount / distribution.participants.length
       for (const pid of distribution.participants) {
         const eid = participantToEntityId.get(pid) ?? pid
@@ -311,8 +311,8 @@ export function calculateWithinGroupBalances(
       const memberParticipants = expense.distribution.participants.filter(pid => memberIds.has(pid))
       if (memberParticipants.length === 0) continue
 
-      if (!accountForFamilySize) {
-        // Equal between entities: group's share = total / numEntities
+      if (accountForFamilySize) {
+        // "Split equally between groups": group's share = total / numEntities
         // Count unique entities in the distribution using wallet_group
         const entitySet = new Set<string>()
         for (const pid of expense.distribution.participants) {
@@ -326,7 +326,7 @@ export function calculateWithinGroupBalances(
           memberShares.set(pid, (memberShares.get(pid) || 0) + perMember * conversionFactor)
         }
       } else {
-        // Proportional: per-person split
+        // Default: per-person split
         const perPerson = expense.amount / expense.distribution.participants.length
         for (const pid of memberParticipants) {
           memberShares.set(pid, (memberShares.get(pid) || 0) + perPerson * conversionFactor)


### PR DESCRIPTION
## Summary

Fixes 3 post-refactor UX issues identified from screenshots:

- **Toggle naming & logic** — Renamed "Split proportionally by group size" → "Split equally between groups". Inverted `accountForFamilySize` logic so toggle ON = equal-per-group (each group pays the same regardless of size), toggle OFF (default) = per-person split (group of 3 pays 3× a solo participant)
- **Dialog accessibility** — Added `sr-only` DialogTitle to ExpenseWizard desktop dialog, suppressing Radix `DialogContent requires a DialogTitle` console warning
- **Group badge removal** — Removed redundant "Group" badge from BalanceCard, QuickBalanceHero, and CostBreakdownDialog. Group entities already have compound names that signal their type

## Test plan

- [x] `npm run type-check` passes clean
- [x] `npm test` — all 145 tests pass
- [ ] Add expense with wallet_group participants: toggle OFF → per-person split, toggle ON → equal per group
- [ ] Split Preview updates correctly when toggling
- [ ] Console: no Radix DialogTitle warnings on desktop Add Expense dialog
- [ ] Balance cards render correctly for both individual and group entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)