### PR TITLE
fix: buildEntityMap always groups by wallet_group — closes #401, #403, #404

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -630,6 +630,7 @@ export function ExpenseForm({
           type: 'individuals',
           participants: selectedParticipants,
           splitMode,
+          accountForFamilySize: hasSelectedGroups ? accountForFamilySize : undefined,
         }
         if (splitMode === 'percentage' || splitMode === 'amount') {
           previewDistribution.participantSplits = selectedParticipants.map(id => ({

--- a/src/components/expenses/ExpenseSplitPreview.tsx
+++ b/src/components/expenses/ExpenseSplitPreview.tsx
@@ -31,19 +31,47 @@ export function ExpenseSplitPreview({
     const splitMode = distribution.splitMode || 'equal'
 
     if (splitMode === 'equal') {
-      const shareCount = distribution.participants.length
-      const shareAmount = amount / shareCount
+      const accountForFamilySize = distribution.accountForFamilySize ?? false
 
-      distribution.participants.forEach(participantId => {
-        const participant = participants.find(p => p.id === participantId)
-        if (participant) {
-          entries.push({
-            id: participantId,
-            name: participant.name,
-            amount: shareAmount,
-          })
+      if (accountForFamilySize) {
+        // "Split equally between groups" — each group pays the same share
+        const entityMap = new Map<string, { name: string; memberIds: string[] }>()
+        for (const pid of distribution.participants) {
+          const p = participants.find(pp => pp.id === pid)
+          if (!p) continue
+          const key = p.wallet_group ?? pid
+          const existing = entityMap.get(key)
+          if (existing) {
+            existing.memberIds.push(pid)
+          } else {
+            entityMap.set(key, { name: p.wallet_group ?? p.name, memberIds: [pid] })
+          }
         }
-      })
+        const perEntity = amount / entityMap.size
+        for (const [, entity] of entityMap) {
+          const perMember = perEntity / entity.memberIds.length
+          for (const mid of entity.memberIds) {
+            const p = participants.find(pp => pp.id === mid)
+            if (p) {
+              entries.push({ id: mid, name: p.name, amount: perMember })
+            }
+          }
+        }
+      } else {
+        const shareCount = distribution.participants.length
+        const shareAmount = amount / shareCount
+
+        distribution.participants.forEach(participantId => {
+          const participant = participants.find(p => p.id === participantId)
+          if (participant) {
+            entries.push({
+              id: participantId,
+              name: participant.name,
+              amount: shareAmount,
+            })
+          }
+        })
+      }
     } else if (splitMode === 'percentage' && distribution.participantSplits) {
       distribution.participantSplits.forEach(split => {
         const participant = participants.find(p => p.id === split.participantId)

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -34,13 +34,27 @@ describe('convertToBaseCurrency', () => {
 
 // ─── buildEntityMap ───────────────────────────────────────────────
 describe('buildEntityMap', () => {
-  it('maps each participant as standalone in individuals mode', () => {
-    const p1 = buildParticipant({ id: 'p1', name: 'Alice', wallet_group: 'Smith' })
+  it('groups by wallet_group even in individuals mode', () => {
+    const p1 = buildParticipant({ id: 'p1', name: 'Alice', wallet_group: 'Smith', is_adult: true })
+    const p2 = buildParticipant({ id: 'p2', name: 'Bob' })
+    const result = buildEntityMap([p1, p2], 'individuals')
+    // Alice is grouped as "Smith", Bob is standalone
+    expect(result.entities).toHaveLength(2)
+    const smith = result.entities.find(e => e.name === 'Smith')!
+    expect(smith.isFamily).toBe(true)
+    expect(smith.id).toBe('p1') // canonical = only adult in group
+    expect(result.participantToEntityId.get('p1')).toBe('p1')
+    expect(result.participantToEntityId.get('p2')).toBe('p2')
+  })
+
+  it('treats participants without wallet_group as standalone in individuals mode', () => {
+    const p1 = buildParticipant({ id: 'p1', name: 'Alice' })
     const p2 = buildParticipant({ id: 'p2', name: 'Bob' })
     const result = buildEntityMap([p1, p2], 'individuals')
     expect(result.entities).toHaveLength(2)
     expect(result.participantToEntityId.get('p1')).toBe('p1')
     expect(result.participantToEntityId.get('p2')).toBe('p2')
+    expect(result.entities.every(e => !e.isFamily)).toBe(true)
   })
 
   it('groups by wallet_group in families mode', () => {
@@ -102,6 +116,16 @@ describe('calculateExpenseShares', () => {
       // Both p3 and p4 belong to Smith group, canonical = p3
       expect(shares.get('p3')).toBe(100)
     })
+
+    it('aggregates to wallet_group entity in individuals tracking mode', () => {
+      const expense = buildExpense({
+        amount: 100,
+        distribution: { type: 'individuals', participants: ['p3', 'p4'] },
+      })
+      const shares = calculateExpenseShares(expense, participants, 'individuals')
+      // Both p3 and p4 belong to Smith group, canonical = p3
+      expect(shares.get('p3')).toBe(100)
+    })
   })
 
   describe('individuals + percentage', () => {
@@ -141,6 +165,41 @@ describe('calculateExpenseShares', () => {
       const shares = calculateExpenseShares(expense, participants, 'individuals')
       expect(shares.get('p1')).toBe(100)
       expect(shares.get('p2')).toBe(50)
+    })
+  })
+
+  describe('accountForFamilySize in individuals mode', () => {
+    it('splits equally per entity when accountForFamilySize is true', () => {
+      // Alice (standalone) + Carol+Dave (Smith group) + Eve (Jones group)
+      const expense = buildExpense({
+        amount: 300,
+        distribution: {
+          type: 'individuals',
+          participants: ['p1', 'p3', 'p4', 'p5'],
+          accountForFamilySize: true,
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, 'individuals')
+      // 3 entities: Alice, Smith, Jones → 100 each
+      expect(shares.get('p1')).toBe(100) // Alice
+      expect(shares.get('p3')).toBe(100) // Smith (Carol+Dave)
+      expect(shares.get('p5')).toBe(100) // Jones (Eve)
+    })
+
+    it('splits per person when accountForFamilySize is false', () => {
+      const expense = buildExpense({
+        amount: 400,
+        distribution: {
+          type: 'individuals',
+          participants: ['p1', 'p3', 'p4', 'p5'],
+          accountForFamilySize: false,
+        },
+      })
+      const shares = calculateExpenseShares(expense, participants, 'individuals')
+      // 4 people → 100 each, but Carol+Dave aggregate to Smith
+      expect(shares.get('p1')).toBe(100)  // Alice
+      expect(shares.get('p3')).toBe(200)  // Smith (Carol 100 + Dave 100)
+      expect(shares.get('p5')).toBe(100)  // Jones (Eve)
     })
   })
 
@@ -268,6 +327,37 @@ describe('calculateBalances', () => {
     })
     const result = calculateBalances([expense], participants, 'individuals')
     expect(result.suggestedNextPayer?.id).toBe('p2') // Bob owes the most
+  })
+
+  it('groups by wallet_group in individuals tracking mode', () => {
+    const famP1 = buildParticipant({ id: 'fp1', name: 'FamAlice', wallet_group: 'Smith', is_adult: true })
+    const famP2 = buildParticipant({ id: 'fp2', name: 'FamBob', wallet_group: 'Smith', is_adult: true })
+    const standalone = buildParticipant({ id: 'sp1', name: 'Standalone' })
+
+    const expense = buildExpense({
+      amount: 90,
+      paid_by: 'fp1',
+      distribution: { type: 'individuals', participants: ['fp1', 'fp2', 'sp1'] },
+    })
+
+    const result = calculateBalances(
+      [expense], [famP1, famP2, standalone], 'individuals'
+    )
+    // Should have 2 entities: Smith (canonical fp1) and Standalone (sp1)
+    expect(result.balances).toHaveLength(2)
+    const smith = result.balances.find(b => b.name === 'Smith')!
+    const stand = result.balances.find(b => b.name === 'Standalone')!
+
+    expect(smith.id).toBe('fp1')
+    expect(smith.isFamily).toBe(true)
+    // Smith paid 90, Smith's share = 60 (2 people × 30), balance = +30
+    expect(smith.totalPaid).toBe(90)
+    expect(smith.totalShare).toBe(60)
+    expect(smith.balance).toBeCloseTo(30, 2)
+
+    expect(stand.totalPaid).toBe(0)
+    expect(stand.totalShare).toBe(30)
+    expect(stand.balance).toBeCloseTo(-30, 2)
   })
 
   it('handles families tracking mode with wallet_group', () => {

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -47,52 +47,48 @@ export interface EntityMapResult {
 
 /**
  * Build entity map from wallet_group on participants.
- * In families mode: groups participants by wallet_group, standalone if null.
- * In individuals mode: each participant is a standalone entity.
+ * Always groups participants by wallet_group when present;
+ * participants without wallet_group are standalone entities.
  *
  * Canonical ID for a wallet_group = first adult participant sorted by name.
+ *
+ * The trackingMode parameter is kept for API compatibility but no longer
+ * affects grouping — wallet_group is always respected.
  */
 export function buildEntityMap(
   participants: Participant[],
   trackingMode: 'individuals' | 'families'
 ): EntityMapResult {
+  void trackingMode // kept for call-site compat; grouping is always wallet_group-based
   const entities: EntityInfo[] = []
   const participantToEntityId = new Map<string, string>()
 
-  if (trackingMode === 'individuals') {
-    for (const p of participants) {
+  const walletGroups = new Map<string, Participant[]>()
+
+  for (const p of participants) {
+    if (p.wallet_group) {
+      const group = walletGroups.get(p.wallet_group) || []
+      group.push(p)
+      walletGroups.set(p.wallet_group, group)
+    } else {
+      // Standalone participant (no wallet_group)
       entities.push({ id: p.id, name: p.name, isFamily: false })
       participantToEntityId.set(p.id, p.id)
     }
-  } else {
-    // Group by wallet_group
-    const walletGroups = new Map<string, Participant[]>()
+  }
 
-    for (const p of participants) {
-      if (p.wallet_group) {
-        const group = walletGroups.get(p.wallet_group) || []
-        group.push(p)
-        walletGroups.set(p.wallet_group, group)
-      } else {
-        // Standalone participant (no wallet_group)
-        entities.push({ id: p.id, name: p.name, isFamily: false })
-        participantToEntityId.set(p.id, p.id)
-      }
-    }
+  for (const [groupName, members] of walletGroups) {
+    // Canonical ID: first adult member sorted alphabetically by name
+    const sortedAdults = members
+      .filter(m => m.is_adult)
+      .sort((a, b) => a.name.localeCompare(b.name))
+    const sortedAll = [...members].sort((a, b) => a.name.localeCompare(b.name))
+    const canonical = sortedAdults[0] ?? sortedAll[0]
 
-    for (const [groupName, members] of walletGroups) {
-      // Canonical ID: first adult member sorted alphabetically by name
-      const sortedAdults = members
-        .filter(m => m.is_adult)
-        .sort((a, b) => a.name.localeCompare(b.name))
-      const sortedAll = [...members].sort((a, b) => a.name.localeCompare(b.name))
-      const canonical = sortedAdults[0] ?? sortedAll[0]
+    entities.push({ id: canonical.id, name: groupName, isFamily: true })
 
-      entities.push({ id: canonical.id, name: groupName, isFamily: true })
-
-      for (const member of members) {
-        participantToEntityId.set(member.id, canonical.id)
-      }
+    for (const member of members) {
+      participantToEntityId.set(member.id, canonical.id)
     }
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `buildEntityMap` only grouped participants by `wallet_group` when `trackingMode === 'families'`, but after the family refactor all trips use `trackingMode: 'individuals'` — making wallet groups completely ignored in balance calculations, settlements, and display
- **Fix**: Remove the `trackingMode` branch — always group by `wallet_group` when present, regardless of tracking mode
- **Also fixed**: `ExpenseSplitPreview` now handles `accountForFamilySize` toggle, and `ExpenseForm` passes it to the preview

## Test plan

- [x] All 150 unit tests pass (41 balance calculator tests, including 5 new ones)
- [x] TypeScript type-check clean
- [ ] Verify on production: groups display correctly on balance/settlement views
- [ ] Verify "Split equally between groups" toggle changes the split preview
- [ ] Verify settlement amounts are correct with wallet_group participants

Closes #401, closes #403, closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)