### PR TITLE
fix: update What's New link to correct path and v1.0.0

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -373,12 +373,12 @@ export function HomePage() {
         {isAuthenticated && (
           <div className="mt-8 text-center">
             <a
-              href="https://github.com/kristjanelias-xtian/trip-splitter-pro/blob/main/RELEASE_NOTES.md"
+              href="https://github.com/kristjanelias-xtian/trip-splitter-pro/blob/main/docs/RELEASE_NOTES.md"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
-              What's New · v0.9.4
+              What's New · v1.0.0
               <ExternalLink size={12} />
             </a>
           </div>


### PR DESCRIPTION
## Summary
- Fixed GitHub link from `RELEASE_NOTES.md` (root, doesn't exist) to `docs/RELEASE_NOTES.md`
- Updated version label from `v0.9.4` to `v1.0.0`

## Test plan
- [x] `npm run type-check` passes
- [ ] Verify link opens correct file on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)