### PR TITLE
fix: within-group balances — outsider shares + settlements + UI relocation

### DIFF
--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
-import { Receipt, Wallet } from 'lucide-react'
+import { Receipt, Wallet, Users, Check } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
-import { ParticipantBalance, formatBalance, getBalanceColorClass, convertToBaseCurrency, calculateExpenseShares, buildEntityMap } from '@/services/balanceCalculator'
+import { ParticipantBalance, formatBalance, getBalanceColorClass, convertToBaseCurrency, calculateExpenseShares, buildEntityMap, calculateWithinGroupBalances } from '@/services/balanceCalculator'
 import { Expense } from '@/types/expense'
 import { Participant } from '@/types/participant'
+import { Settlement } from '@/types/settlement'
 
 interface CostBreakdownDialogProps {
   open: boolean
@@ -15,6 +16,7 @@ interface CostBreakdownDialogProps {
   trackingMode: 'individuals' | 'families'
   defaultCurrency: string
   exchangeRates: Record<string, number>
+  settlements?: Settlement[]
 }
 
 interface ExpenseShareItem {
@@ -31,6 +33,7 @@ export function CostBreakdownDialog({
   trackingMode,
   defaultCurrency,
   exchangeRates,
+  settlements = [],
 }: CostBreakdownDialogProps) {
   const entityMap = useMemo(() => buildEntityMap(participants, trackingMode), [participants, trackingMode])
 
@@ -73,6 +76,27 @@ export function CostBreakdownDialog({
 
   const balanceColorClass = getBalanceColorClass(balance.balance)
 
+  // Within-group breakdown (only for family/group entities)
+  const groupName = useMemo(() => {
+    if (!balance.isFamily) return null
+    const p = participants.find(pp => pp.id === balance.id)
+    return p?.wallet_group ?? null
+  }, [balance.id, balance.isFamily, participants])
+
+  const withinGroupBalances = useMemo(() => {
+    if (!groupName) return null
+    return calculateWithinGroupBalances(
+      expenses, participants, groupName, defaultCurrency, exchangeRates, settlements
+    )
+  }, [expenses, participants, groupName, defaultCurrency, exchangeRates, settlements])
+
+  const groupMembers = useMemo(() => {
+    if (!groupName) return []
+    return participants.filter(p => p.wallet_group === groupName)
+  }, [participants, groupName])
+
+  const hasChildren = groupMembers.some(p => !p.is_adult) && groupMembers.some(p => p.is_adult)
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
@@ -82,6 +106,51 @@ export function CostBreakdownDialog({
             Balance: <span className={`font-semibold ${balanceColorClass}`}>{formatBalance(balance.balance, defaultCurrency)}</span>
           </DialogDescription>
         </DialogHeader>
+
+        {/* Within-group breakdown */}
+        {withinGroupBalances && withinGroupBalances.length > 0 && (
+          <div className="p-3 rounded-lg bg-muted/30">
+            <h4 className="flex items-center gap-2 text-sm font-semibold text-foreground mb-2">
+              <Users size={16} />
+              Within-group balances
+            </h4>
+            {(() => {
+              const allEven = withinGroupBalances.every(b => Math.abs(b.balance) < 0.01)
+              const hasActivity = withinGroupBalances.some(b => b.totalPaid > 0 || b.totalShare > 0)
+              if (!hasActivity) {
+                return <p className="text-xs text-muted-foreground">No shared expenses yet</p>
+              }
+              if (allEven) {
+                return (
+                  <div className="flex items-center gap-1.5 text-green-600 dark:text-green-400">
+                    <Check size={14} />
+                    <span className="text-sm">Evenly split</span>
+                  </div>
+                )
+              }
+              return (
+                <div className="space-y-1.5">
+                  {withinGroupBalances.map(b => (
+                    <div key={b.id} className="flex justify-between items-center text-sm">
+                      <span>{b.name}</span>
+                      <div className="text-right">
+                        <span className={`tabular-nums font-medium ${getBalanceColorClass(b.balance)}`}>
+                          {formatBalance(b.balance, defaultCurrency)}
+                        </span>
+                        <div className="text-xs text-muted-foreground tabular-nums">
+                          Paid {fmt(b.totalPaid)} · Share {fmt(b.totalShare)}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )
+            })()}
+            {hasChildren && (
+              <p className="text-xs text-muted-foreground mt-2">Children's shares are split among adults</p>
+            )}
+          </div>
+        )}
 
         {/* Expenses Paid */}
         <div>

--- a/src/components/quick/QuickGroupMembersSheet.tsx
+++ b/src/components/quick/QuickGroupMembersSheet.tsx
@@ -4,6 +4,7 @@ import { UserCheck, X, ChevronDown, Check } from 'lucide-react'
 import { ParticipantBalance, formatBalance, getBalanceColorClass, calculateWithinGroupBalances } from '@/services/balanceCalculator'
 import { Participant } from '@/types/participant'
 import { Expense } from '@/types/expense'
+import { Settlement } from '@/types/settlement'
 
 interface QuickGroupMembersSheetProps {
   open: boolean
@@ -14,6 +15,7 @@ interface QuickGroupMembersSheetProps {
   participants: Participant[]
   expenses?: Expense[]
   exchangeRates?: Record<string, number>
+  settlements?: Settlement[]
 }
 
 export function QuickGroupMembersSheet({
@@ -25,6 +27,7 @@ export function QuickGroupMembersSheet({
   participants,
   expenses = [],
   exchangeRates = {},
+  settlements = [],
 }: QuickGroupMembersSheetProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
 
@@ -129,6 +132,7 @@ export function QuickGroupMembersSheet({
                     participants={participants}
                     currency={currency}
                     exchangeRates={exchangeRates}
+                    settlements={settlements}
                   />
                 )}
 
@@ -150,15 +154,17 @@ function WithinGroupBreakdown({
   participants,
   currency,
   exchangeRates,
+  settlements,
 }: {
   groupName: string
   expenses: Expense[]
   participants: Participant[]
   currency: string
   exchangeRates: Record<string, number>
+  settlements: Settlement[]
 }) {
   const groupBalances = calculateWithinGroupBalances(
-    expenses, participants, groupName, currency, exchangeRates
+    expenses, participants, groupName, currency, exchangeRates, settlements
   )
   const allEven = groupBalances.every(b => Math.abs(b.balance) < 0.01)
   const hasGroupExpenses = groupBalances.some(b => b.totalPaid > 0 || b.totalShare > 0)

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -290,6 +290,7 @@ export function DashboardPage() {
           trackingMode={currentTrip.tracking_mode}
           defaultCurrency={currentTrip.default_currency}
           exchangeRates={currentTrip.exchange_rates}
+          settlements={settlements}
         />
       )}
     </div>

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -255,6 +255,7 @@ export function QuickGroupDetailPage() {
         participants={participants}
         expenses={expenses}
         exchangeRates={currentTrip.exchange_rates}
+        settlements={settlements}
       />
 
       {/* History sheet */}

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
-import { ChevronDown, ChevronRight, Receipt, FileDown, Users, Check } from 'lucide-react'
+import { ChevronDown, ChevronRight, Receipt, FileDown } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -8,7 +8,7 @@ import { useSettlementContext } from '@/contexts/SettlementContext'
 import { PageLoadingState } from '@/components/PageLoadingState'
 import { PageErrorState } from '@/components/PageErrorState'
 import { useReceiptContext } from '@/contexts/ReceiptContext'
-import { calculateBalances, buildEntityMap, calculateWithinGroupBalances, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { calculateBalances, buildEntityMap } from '@/services/balanceCalculator'
 import { calculateOptimalSettlement } from '@/services/settlementOptimizer'
 import { exportSettlementPlanToPDF } from '@/services/pdfExport'
 import type { SettlementTransaction } from '@/services/settlementOptimizer'
@@ -16,8 +16,6 @@ import type { CreateSettlementInput } from '@/types/settlement'
 import { SettlementPlan, BankDetails } from '@/components/SettlementPlan'
 import { SettlementForm } from '@/components/SettlementForm'
 import { Button } from '@/components/ui/button'
-import { Switch } from '@/components/ui/switch'
-import { Label } from '@/components/ui/label'
 import { Card, CardContent } from '@/components/ui/card'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/lib/logger'
@@ -36,7 +34,6 @@ export function SettlementsPage() {
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
   const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
   const [retrying, setRetrying] = useState(false)
-  const [showWithinGroup, setShowWithinGroup] = useState(false)
 
   const loading = pLoading || eLoading || sLoading
   const contextError = pError || eError || sError
@@ -314,74 +311,6 @@ export function SettlementsPage() {
             </CardContent>
           </Card>
         </div>
-
-        {/* Within-group balances */}
-        {(() => {
-          const walletGroups = [...new Set(
-            participants.filter(p => p.wallet_group).map(p => p.wallet_group!)
-          )]
-          if (walletGroups.length === 0) return null
-
-          return (
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-2 mb-4">
-                  <Switch
-                    id="within-group"
-                    checked={showWithinGroup}
-                    onCheckedChange={setShowWithinGroup}
-                  />
-                  <Label htmlFor="within-group" className="text-sm cursor-pointer flex items-center gap-1.5">
-                    <Users size={14} className="text-muted-foreground" />
-                    Within-group balances
-                  </Label>
-                </div>
-
-                {showWithinGroup && walletGroups.map(groupName => {
-                  const groupBalances = calculateWithinGroupBalances(
-                    expenses,
-                    participants,
-                    groupName,
-                    currentTrip.default_currency,
-                    currentTrip.exchange_rates
-                  )
-                  const allEven = groupBalances.every(b => Math.abs(b.balance) < 0.01)
-                  const hasGroupExpenses = groupBalances.some(b => b.totalPaid > 0 || b.totalShare > 0)
-                  const groupMembers = participants.filter(p => p.wallet_group === groupName)
-                  const hasChildren = groupMembers.some(p => !p.is_adult) && groupMembers.some(p => p.is_adult)
-
-                  return (
-                    <div key={groupName} className="p-3 rounded-lg bg-muted/30 mb-3 last:mb-0">
-                      <p className="font-medium text-sm mb-2">{groupName}</p>
-                      {!hasGroupExpenses ? (
-                        <p className="text-xs text-muted-foreground">No shared expenses yet</p>
-                      ) : allEven ? (
-                        <div className="flex items-center gap-1.5 text-green-600 dark:text-green-400">
-                          <Check size={14} />
-                          <span className="text-sm">Evenly split</span>
-                        </div>
-                      ) : (
-                        <div className="space-y-1.5">
-                          {groupBalances.map(b => (
-                            <div key={b.id} className="flex justify-between items-center text-sm">
-                              <span>{b.name}</span>
-                              <span className={`tabular-nums font-medium ${getBalanceColorClass(b.balance)}`}>
-                                {formatBalance(b.balance, currentTrip.default_currency)}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                      {hasChildren && (
-                        <p className="text-xs text-muted-foreground mt-2">Children's shares are split among adults</p>
-                      )}
-                    </div>
-                  )
-                })}
-              </CardContent>
-            </Card>
-          )
-        })()}
 
         {/* Optimal Settlement Plan */}
         {expenses.length > 0 && (

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -533,15 +533,23 @@ describe('calculateWithinGroupBalances', () => {
     expect(carolBal.balance).toBe(0)
   })
 
-  it('ignores expenses paid by outsiders (evenly split)', () => {
+  it('counts shares from outsider-paid expenses (members show negative balances)', () => {
     const expense = buildExpense({
-      amount: 90,
+      amount: 120,
       paid_by: 'o1', // outsider pays
       distribution: { type: 'individuals', participants: ['g1', 'g2', 'g3', 'o1'] },
     })
     const balances = calculateWithinGroupBalances([expense], allParticipants, 'Smith')
-    const allEven = balances.every(b => Math.abs(b.balance) < 0.01)
-    expect(allEven).toBe(true)
+    // Each of 4 people owes 30. Group members' shares = 30 each, paid = 0.
+    // Balances: all three at -30. They don't sum to zero — deficit = outsider-covered portion.
+    const aliceBal = balances.find(b => b.id === 'g1')!
+    const bobBal = balances.find(b => b.id === 'g2')!
+    const carolBal = balances.find(b => b.id === 'g3')!
+    expect(aliceBal.totalShare).toBe(30)
+    expect(aliceBal.totalPaid).toBe(0)
+    expect(aliceBal.balance).toBeCloseTo(-30, 2)
+    expect(bobBal.balance).toBeCloseTo(-30, 2)
+    expect(carolBal.balance).toBeCloseTo(-30, 2)
   })
 
   it('returns empty array for non-existent group', () => {
@@ -589,6 +597,53 @@ describe('calculateWithinGroupBalances', () => {
 
       // Both children shown (no adults to fold into)
       expect(balances).toHaveLength(2)
+    })
+  })
+
+  describe('within-group settlements', () => {
+    it('applies settlement between group members', () => {
+      const expense = buildExpense({
+        amount: 90,
+        paid_by: 'g1',
+        distribution: { type: 'individuals', participants: ['g1', 'g2', 'g3'] },
+      })
+      const settlement = buildSettlement({
+        from_participant_id: 'g2',
+        to_participant_id: 'g1',
+        amount: 30,
+        currency: 'EUR',
+      })
+      const balances = calculateWithinGroupBalances(
+        [expense], allParticipants, 'Smith', 'EUR', {}, [settlement]
+      )
+      // Before settlement: Alice +60, Bob -30, Carol -30
+      // After settlement (Bob→Alice 30): Alice +30, Bob 0, Carol -30
+      const aliceBal = balances.find(b => b.id === 'g1')!
+      const bobBal = balances.find(b => b.id === 'g2')!
+      const carolBal = balances.find(b => b.id === 'g3')!
+      expect(aliceBal.balance).toBeCloseTo(30, 2)
+      expect(bobBal.balance).toBeCloseTo(0, 2)
+      expect(carolBal.balance).toBeCloseTo(-30, 2)
+    })
+
+    it('ignores settlements where one party is outside the group', () => {
+      const expense = buildExpense({
+        amount: 90,
+        paid_by: 'g1',
+        distribution: { type: 'individuals', participants: ['g1', 'g2', 'g3'] },
+      })
+      const settlement = buildSettlement({
+        from_participant_id: 'o1', // outsider
+        to_participant_id: 'g1',
+        amount: 30,
+        currency: 'EUR',
+      })
+      const balances = calculateWithinGroupBalances(
+        [expense], allParticipants, 'Smith', 'EUR', {}, [settlement]
+      )
+      // Settlement ignored — balances unchanged
+      const aliceBal = balances.find(b => b.id === 'g1')!
+      expect(aliceBal.balance).toBeCloseTo(60, 2)
     })
   })
 })

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -257,21 +257,24 @@ export function calculateBalances(
 
 /**
  * Calculate balances within a single wallet_group.
- * Shows who overpaid / underpaid relative to other group members.
+ * Shows each member's total share (consumption) vs what they actually paid
+ * toward the group.
  *
- * Only considers expenses where a group member was the payer.
- * Expenses paid by outsiders don't affect within-group fairness
- * (that debt is tracked by the main balance calculator).
+ * ALL expenses that include group members are counted for shares, but only
+ * group-member-paid expenses credit the payer. This means the balances
+ * won't sum to zero — the deficit equals the portion covered by outsiders,
+ * which is correct and transparent.
  *
- * Payer is credited with the group's share only (not the full expense),
- * so within-group balances always net to zero.
+ * Within-group settlements (both from and to are group members) are applied
+ * after computing raw balances.
  */
 export function calculateWithinGroupBalances(
   expenses: Expense[],
   participants: Participant[],
   walletGroup: string,
   defaultCurrency: string = 'EUR',
-  exchangeRates: Record<string, number> = {}
+  exchangeRates: Record<string, number> = {},
+  settlements: Settlement[] = []
 ): ParticipantBalance[] {
   const groupMembers = participants.filter(p => p.wallet_group === walletGroup)
   if (groupMembers.length === 0) return []
@@ -289,9 +292,7 @@ export function calculateWithinGroupBalances(
   for (const expense of expenses) {
     if (expense.distribution.type !== 'individuals') continue
 
-    // Skip expenses not paid by a group member — external payers don't
-    // affect within-group fairness
-    if (!memberIds.has(expense.paid_by)) continue
+    const isPaidByGroupMember = memberIds.has(expense.paid_by)
 
     const convertedAmount = convertToBaseCurrency(
       expense.amount, expense.currency, defaultCurrency, exchangeRates
@@ -343,13 +344,23 @@ export function calculateWithinGroupBalances(
     memberShares.forEach(v => { groupTotal += v })
     if (groupTotal === 0) continue
 
-    // Credit payer with the group's share only (not the full expense)
-    paid.set(expense.paid_by, paid.get(expense.paid_by)! + groupTotal)
+    // Only credit payer if they're a group member
+    if (isPaidByGroupMember) {
+      paid.set(expense.paid_by, paid.get(expense.paid_by)! + groupTotal)
+    }
 
     // Apply shares
     memberShares.forEach((amount, pid) => {
       share.set(pid, share.get(pid)! + amount)
     })
+  }
+
+  // Apply within-group settlements (both parties must be group members)
+  for (const settlement of settlements) {
+    if (!memberIds.has(settlement.from_participant_id) || !memberIds.has(settlement.to_participant_id)) continue
+    const convertedAmount = convertToBaseCurrency(settlement.amount, settlement.currency, defaultCurrency, exchangeRates)
+    paid.set(settlement.from_participant_id, (paid.get(settlement.from_participant_id) || 0) + convertedAmount)
+    paid.set(settlement.to_participant_id, (paid.get(settlement.to_participant_id) || 0) - convertedAmount)
   }
 
   // Compute raw balances per member


### PR DESCRIPTION
## Summary
- **Fixed calculation bug**: `calculateWithinGroupBalances` now includes ALL expenses for share calculation, not just group-member-paid ones. Members' shares reflect true consumption, and the deficit from outsider-covered expenses is transparent.
- **Added settlements support**: New `settlements` parameter filters for within-group settlements and applies them to balances.
- **Relocated UI**: Within-group breakdown now appears in `CostBreakdownDialog` (Dashboard click-through) and `QuickGroupMembersSheet` (Quick mode expand). Removed the toggle from SettlementsPage.

## Test plan
- [x] `npm run type-check` passes clean
- [x] `npm test` — 152/152 tests pass (2 new settlement tests, 1 updated outsider test)
- [ ] Dashboard: click a group entity → dialog shows within-group breakdown with paid/share per member
- [ ] Quick mode: expand group in members sheet → within-group breakdown shown
- [ ] Settlements page: no more within-group toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)