### PR TITLE
docs: update within-group balances documentation (PR #415)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ All expenses use a single distribution type: `individuals`. The `tracking_mode` 
 
 Participants can be grouped via `wallet_group TEXT` on the `participants` table. The balance calculator (`buildEntityMap`) groups participants by `wallet_group` at display time — each group settles as a unit. Per-expense `accountForFamilySize` toggle (on `IndividualsDistribution`, labelled "Split equally between groups") controls splitting: OFF (default) = per-person split (group of 3 pays 3× a solo participant), ON = equal per group (each group pays the same share regardless of size).
 
-Within-group balances are shown on `SettlementsPage` (Full mode) via `calculateWithinGroupBalances()`. Children's balances are folded into adults within the group.
+`calculateWithinGroupBalances()` computes per-member share/paid/balance within a wallet_group. It includes ALL expenses (including outsider-paid) for shares but only credits group-member payers — balances won't sum to zero (deficit = outsider-covered portion). Accepts `settlements` param for within-group settlement tracking. Children's balances are folded into adults. UI: shown in `CostBreakdownDialog` (Dashboard click-through on group entity) and `QuickGroupMembersSheet` (Quick mode expand).
 
 ### Routes
 


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md to reflect PR #415 changes: within-group balances now in CostBreakdownDialog + QuickGroupMembersSheet (removed from SettlementsPage), outsider-paid expenses included, settlements param added.

## Test plan
- [x] Documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)