### PR TITLE
fix: within-group balances — skip outsider-paid expenses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ All expenses use a single distribution type: `individuals`. The `tracking_mode` 
 
 Participants can be grouped via `wallet_group TEXT` on the `participants` table. The balance calculator (`buildEntityMap`) groups participants by `wallet_group` at display time — each group settles as a unit. Per-expense `accountForFamilySize` toggle (on `IndividualsDistribution`, labelled "Split equally between groups") controls splitting: OFF (default) = per-person split (group of 3 pays 3× a solo participant), ON = equal per group (each group pays the same share regardless of size).
 
-`calculateWithinGroupBalances()` computes per-member share/paid/balance within a wallet_group. It includes ALL expenses (including outsider-paid) for shares but only credits group-member payers — balances won't sum to zero (deficit = outsider-covered portion). Accepts `settlements` param for within-group settlement tracking. Children's balances are folded into adults. UI: shown in `CostBreakdownDialog` (Dashboard click-through on group entity) and `QuickGroupMembersSheet` (Quick mode expand).
+`calculateWithinGroupBalances()` computes per-member share/paid/balance within a wallet_group. Only group-member-paid expenses are counted — outsider-paid expenses are skipped — so balances always sum to zero, answering "who owes whom within the group". Accepts `settlements` param for within-group settlement tracking. Children's balances are folded into adults. UI: shown in `CostBreakdownDialog` (Dashboard click-through on group entity) and `QuickGroupMembersSheet` (Quick mode expand).
 
 ### Routes
 

--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -133,14 +133,9 @@ export function CostBreakdownDialog({
                   {withinGroupBalances.map(b => (
                     <div key={b.id} className="flex justify-between items-center text-sm">
                       <span>{b.name}</span>
-                      <div className="text-right">
-                        <span className={`tabular-nums font-medium ${getBalanceColorClass(b.balance)}`}>
-                          {formatBalance(b.balance, defaultCurrency)}
-                        </span>
-                        <div className="text-xs text-muted-foreground tabular-nums">
-                          Paid {fmt(b.totalPaid)} · Share {fmt(b.totalShare)}
-                        </div>
-                      </div>
+                      <span className={`tabular-nums font-medium ${getBalanceColorClass(b.balance)}`}>
+                        {formatBalance(b.balance, defaultCurrency)}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -533,23 +533,16 @@ describe('calculateWithinGroupBalances', () => {
     expect(carolBal.balance).toBe(0)
   })
 
-  it('counts shares from outsider-paid expenses (members show negative balances)', () => {
+  it('skips outsider-paid expenses — all balances stay zero', () => {
     const expense = buildExpense({
       amount: 120,
       paid_by: 'o1', // outsider pays
       distribution: { type: 'individuals', participants: ['g1', 'g2', 'g3', 'o1'] },
     })
     const balances = calculateWithinGroupBalances([expense], allParticipants, 'Smith')
-    // Each of 4 people owes 30. Group members' shares = 30 each, paid = 0.
-    // Balances: all three at -30. They don't sum to zero — deficit = outsider-covered portion.
-    const aliceBal = balances.find(b => b.id === 'g1')!
-    const bobBal = balances.find(b => b.id === 'g2')!
-    const carolBal = balances.find(b => b.id === 'g3')!
-    expect(aliceBal.totalShare).toBe(30)
-    expect(aliceBal.totalPaid).toBe(0)
-    expect(aliceBal.balance).toBeCloseTo(-30, 2)
-    expect(bobBal.balance).toBeCloseTo(-30, 2)
-    expect(carolBal.balance).toBeCloseTo(-30, 2)
+    // Outsider-paid expense is skipped entirely — within-group balances unaffected
+    const allEven = balances.every(b => Math.abs(b.balance) < 0.01)
+    expect(allEven).toBe(true)
   })
 
   it('returns empty array for non-existent group', () => {

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -257,13 +257,9 @@ export function calculateBalances(
 
 /**
  * Calculate balances within a single wallet_group.
- * Shows each member's total share (consumption) vs what they actually paid
- * toward the group.
- *
- * ALL expenses that include group members are counted for shares, but only
- * group-member-paid expenses credit the payer. This means the balances
- * won't sum to zero — the deficit equals the portion covered by outsiders,
- * which is correct and transparent.
+ * Shows each member's paid vs share for group-member-paid expenses only.
+ * Outsider-paid expenses are skipped so balances always sum to zero —
+ * the view answers "who owes whom within the group".
  *
  * Within-group settlements (both from and to are group members) are applied
  * after computing raw balances.
@@ -291,8 +287,7 @@ export function calculateWithinGroupBalances(
 
   for (const expense of expenses) {
     if (expense.distribution.type !== 'individuals') continue
-
-    const isPaidByGroupMember = memberIds.has(expense.paid_by)
+    if (!memberIds.has(expense.paid_by)) continue
 
     const convertedAmount = convertToBaseCurrency(
       expense.amount, expense.currency, defaultCurrency, exchangeRates
@@ -344,10 +339,8 @@ export function calculateWithinGroupBalances(
     memberShares.forEach(v => { groupTotal += v })
     if (groupTotal === 0) continue
 
-    // Only credit payer if they're a group member
-    if (isPaidByGroupMember) {
-      paid.set(expense.paid_by, paid.get(expense.paid_by)! + groupTotal)
-    }
+    // Credit the payer (always a group member at this point)
+    paid.set(expense.paid_by, paid.get(expense.paid_by)! + groupTotal)
 
     // Apply shares
     memberShares.forEach((amount, pid) => {


### PR DESCRIPTION
## Summary
- Reverts PR #415's change to include outsider-paid expenses in `calculateWithinGroupBalances` — balances now sum to zero again, showing fairness between group members
- Removes `Paid X · Share Y` detail line from `CostBreakdownDialog` within-group breakdown (less useful when balances sum to zero)
- Keeps the settlement support added in PR #415

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test -- --run` — 152/152 pass
- [ ] Manual: within-group balances sum to zero in Dashboard click-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)