### PR TITLE
fix: demo button layout in empty state — closes #416

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -115,13 +115,15 @@ export function HomePage() {
             <Plus size={18} />
             Create Your First
           </Button>
-          <button
-            onClick={() => navigate(`/t/${DEMO_TRIP_CODE}/quick`)}
-            className="mt-3 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <Sparkles size={14} />
-            Try a demo
-          </button>
+          <div className="mt-3">
+            <button
+              onClick={() => navigate(`/t/${DEMO_TRIP_CODE}/quick`)}
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Sparkles size={14} />
+              Try a demo
+            </button>
+          </div>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- "Try a demo" button was rendering inline next to "Create Your First" on wider viewports
- Wrapped it in a block-level `<div>` so it drops to its own line below the main CTA

Closes #416

## Test plan
- [x] `npm run type-check` passes
- [ ] View home page empty state (no trips) — "Try a demo" should be on its own line below "Create Your First"

🤖 Generated with [Claude Code](https://claude.com/claude-code)