### PR TITLE
fix: improve within-group balances UI in CostBreakdownDialog

### DIFF
--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -145,15 +145,15 @@ export function CostBreakdownDialog({
               return (
                 <div className="space-y-1.5">
                   {withinGroupBalances.map(b => (
-                    <div key={b.id} className="flex justify-between items-center text-sm">
+                    <div key={b.id} className="flex justify-between items-baseline text-sm">
                       <span>{b.name}</span>
-                      <div className="text-right">
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          Covered {fmt(b.totalPaid)} · Share {fmt(b.totalShare)}
+                        </span>
                         <span className={`tabular-nums font-medium ${getBalanceColorClass(b.balance)}`}>
                           {formatBalance(b.balance, defaultCurrency)}
                         </span>
-                        <div className="text-xs text-muted-foreground tabular-nums">
-                          Paid {fmt(b.totalPaid)} · Share {fmt(b.totalShare)}
-                        </div>
                       </div>
                     </div>
                   ))}
@@ -183,9 +183,15 @@ export function CostBreakdownDialog({
             {hasChildren && (
               <p className="text-xs text-muted-foreground mt-2">Children's shares are split among adults</p>
             )}
-            <div className="mt-2 pt-2 border-t border-border/50 flex justify-between text-sm">
-              <span className="text-muted-foreground">Group share</span>
-              <span className="tabular-nums font-medium">{fmt(balance.totalShare)}</span>
+            <div className="mt-2 pt-2 border-t border-border/50 space-y-1 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Group paid</span>
+                <span className="tabular-nums font-medium">{fmt(balance.totalPaid)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Group share</span>
+                <span className="tabular-nums font-medium">{fmt(balance.totalShare)}</span>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Inline paid/share detail on the same line as balance for tighter visual grouping
- Rename "Paid" → "Covered" to distinguish from actual out-of-pocket spending in the "Expenses paid" section
- Add "Group paid" row alongside "Group share" in the summary footer

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test -- --run` — 152/152 pass
- [ ] Visual check: open CostBreakdownDialog for a wallet_group entity, confirm inline layout and both summary rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)