### PR TITLE
feat: improve BalanceCard summary with settled row

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -13,14 +13,15 @@ interface BalanceCardProps {
 export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardProps) {
   const balanceColorClass = getBalanceColorClass(balance.balance)
   const formattedBalance = formatBalance(balance.balance, currency)
-  const formattedPaid = new Intl.NumberFormat('en-US', {
+  const fmt = (value: number) => new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: currency,
-  }).format(balance.totalPaid)
-  const formattedShare = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currency,
-  }).format(balance.totalShare)
+  }).format(value)
+  const formattedPaid = fmt(balance.totalPaid)
+  const formattedShare = fmt(balance.totalShare)
+  const formattedSettled = balance.totalSettled !== 0
+    ? (balance.totalSettled > 0 ? '+' : '') + fmt(balance.totalSettled)
+    : null
 
   const getBalanceStatus = () => {
     if (balance.balance > 0.01) {
@@ -81,11 +82,17 @@ export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardP
         {/* Breakdown */}
         <div className="space-y-1 text-sm">
           <div className="flex justify-between text-muted-foreground">
-            <span>Total paid:</span>
+            <span>Out of pocket:</span>
             <span className="font-medium text-foreground tabular-nums">{formattedPaid}</span>
           </div>
+          {formattedSettled && (
+            <div className="flex justify-between text-muted-foreground">
+              <span>Settled:</span>
+              <span className="font-medium text-foreground tabular-nums">{formattedSettled}</span>
+            </div>
+          )}
           <div className="flex justify-between text-muted-foreground">
-            <span>Total share:</span>
+            <span>Share:</span>
             <span className="font-medium text-foreground tabular-nums">{formattedShare}</span>
           </div>
         </div>

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -297,7 +297,9 @@ describe('calculateBalances', () => {
     const bobBalance = result.balances.find(b => b.id === 'p2')!
 
     expect(aliceBalance.balance).toBeCloseTo(0, 2)
+    expect(aliceBalance.totalSettled).toBe(-50) // received 50
     expect(bobBalance.balance).toBeCloseTo(0, 2)
+    expect(bobBalance.totalSettled).toBe(50) // sent 50
   })
 
   it('sorts by balance descending', () => {
@@ -394,7 +396,7 @@ describe('calculateBalances', () => {
 // ─── getBalanceForEntity ──────────────────────────────────────────
 describe('getBalanceForEntity', () => {
   const balances = [
-    { id: 'p1', name: 'Alice', totalPaid: 100, totalShare: 50, balance: 50, isFamily: false },
+    { id: 'p1', name: 'Alice', totalPaid: 100, totalShare: 50, totalSettled: 0, balance: 50, isFamily: false },
   ]
 
   it('returns balance when entity is found', () => {

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -7,6 +7,7 @@ export interface ParticipantBalance {
   name: string
   totalPaid: number
   totalShare: number
+  totalSettled: number
   balance: number
   isFamily: boolean
 }
@@ -194,6 +195,7 @@ export function calculateBalances(
       name: entity.name,
       totalPaid: 0,
       totalShare: 0,
+      totalSettled: 0,
       balance: 0,
       isFamily: entity.isFamily,
     })
@@ -239,9 +241,11 @@ export function calculateBalances(
 
     if (fromEntityId && balances.has(fromEntityId)) {
       balances.get(fromEntityId)!.balance += convertedAmount
+      balances.get(fromEntityId)!.totalSettled += convertedAmount
     }
     if (toEntityId && balances.has(toEntityId)) {
       balances.get(toEntityId)!.balance -= convertedAmount
+      balances.get(toEntityId)!.totalSettled -= convertedAmount
     }
   }
 
@@ -385,6 +389,7 @@ export function calculateWithinGroupBalances(
       name: a.name,
       totalPaid: a.totalPaid,
       totalShare: a.totalShare,
+      totalSettled: 0,
       balance: a.balance,
       isFamily: false,
     })).sort((a, b) => b.balance - a.balance)
@@ -396,6 +401,7 @@ export function calculateWithinGroupBalances(
     name: m.name,
     totalPaid: m.totalPaid,
     totalShare: m.totalShare,
+    totalSettled: 0,
     balance: m.balance,
     isFamily: false,
   }))

--- a/src/services/settlementOptimizer.test.ts
+++ b/src/services/settlementOptimizer.test.ts
@@ -10,7 +10,7 @@ import {
 import type { ParticipantBalance } from './balanceCalculator'
 
 function balance(id: string, name: string, bal: number): ParticipantBalance {
-  return { id, name, totalPaid: 0, totalShare: 0, balance: bal, isFamily: false }
+  return { id, name, totalPaid: 0, totalShare: 0, totalSettled: 0, balance: bal, isFamily: false }
 }
 
 // ─── calculateOptimalSettlement ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Rename "Total paid" → "Out of pocket" on BalanceCard for clarity
- Add `totalSettled` field to `ParticipantBalance` interface tracking net settlements (sent − received)
- Show a "Settled" row on BalanceCard when settlements exist, so numbers visibly add up: `out_of_pocket + settled - share = balance`

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test -- --run` — 152/152 pass
- [ ] Visual: verify BalanceCard on Dashboard shows "Out of pocket" + optional "Settled" + "Share"

🤖 Generated with [Claude Code](https://claude.com/claude-code)