### PR TITLE
fix: improve BalanceCard settled row formatting

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -20,7 +20,7 @@ export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardP
   const formattedPaid = fmt(balance.totalPaid)
   const formattedShare = fmt(balance.totalShare)
   const formattedSettled = balance.totalSettled !== 0
-    ? (balance.totalSettled > 0 ? '+' : '') + fmt(balance.totalSettled)
+    ? `${fmt(Math.abs(balance.totalSettled))} ${balance.totalSettled > 0 ? 'sent' : 'received'}`
     : null
 
   const getBalanceStatus = () => {
@@ -85,16 +85,16 @@ export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardP
             <span>Out of pocket:</span>
             <span className="font-medium text-foreground tabular-nums">{formattedPaid}</span>
           </div>
+          <div className="flex justify-between text-muted-foreground">
+            <span>Share:</span>
+            <span className="font-medium text-foreground tabular-nums">{formattedShare}</span>
+          </div>
           {formattedSettled && (
             <div className="flex justify-between text-muted-foreground">
               <span>Settled:</span>
               <span className="font-medium text-foreground tabular-nums">{formattedSettled}</span>
             </div>
           )}
-          <div className="flex justify-between text-muted-foreground">
-            <span>Share:</span>
-            <span className="font-medium text-foreground tabular-nums">{formattedShare}</span>
-          </div>
         </div>
 
         {/* Status Badge */}


### PR DESCRIPTION
## Summary
- Reorder breakdown rows: **Out of pocket → Share → Settled** (was Out of pocket → Settled → Share) so the numbers read in natural reasoning order
- Replace cryptic signed values (`+€1,500` / `-€2,468`) with natural language: `€1,500.00 sent` / `€2,468.30 received`
- Settled row still hidden when `totalSettled === 0`

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test -- --run` — 152/152 pass
- [ ] Visual check: verify card reads naturally for overpaid (received) and underpaid (sent) cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)