### PR TITLE
fix: always show Settled row for consistent card heights

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -21,7 +21,7 @@ export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardP
   const formattedShare = fmt(balance.totalShare)
   const formattedSettled = balance.totalSettled !== 0
     ? `${fmt(Math.abs(balance.totalSettled))} ${balance.totalSettled > 0 ? 'sent' : 'received'}`
-    : null
+    : '—'
 
   const getBalanceStatus = () => {
     if (balance.balance > 0.01) {
@@ -89,12 +89,10 @@ export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardP
             <span>Share:</span>
             <span className="font-medium text-foreground tabular-nums">{formattedShare}</span>
           </div>
-          {formattedSettled && (
-            <div className="flex justify-between text-muted-foreground">
-              <span>Settled:</span>
-              <span className="font-medium text-foreground tabular-nums">{formattedSettled}</span>
-            </div>
-          )}
+          <div className="flex justify-between text-muted-foreground">
+            <span>Settled:</span>
+            <span className="font-medium text-foreground tabular-nums">{formattedSettled}</span>
+          </div>
         </div>
 
         {/* Status Badge */}


### PR DESCRIPTION
## Summary
- Always show the "Settled" row in BalanceCard — display "—" when no settlements instead of hiding the row
- Fixes uneven card heights in the 2-column dashboard grid when some entities have settlements and others don't

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test -- --run` — 152/152 pass
- [ ] Visual: all 4 cards same height on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)