### PR TITLE
fix: within-group balances now reflect group-level totals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ All expenses use a single distribution type: `individuals`. The `tracking_mode` 
 
 Participants can be grouped via `wallet_group TEXT` on the `participants` table. The balance calculator (`buildEntityMap`) groups participants by `wallet_group` at display time — each group settles as a unit. Per-expense `accountForFamilySize` toggle (on `IndividualsDistribution`, labelled "Split equally between groups") controls splitting: OFF (default) = per-person split (group of 3 pays 3× a solo participant), ON = equal per group (each group pays the same share regardless of size).
 
-`calculateWithinGroupBalances()` computes per-member share/paid/balance within a wallet_group. Only group-member-paid expenses are counted — outsider-paid expenses are skipped — so balances always sum to zero, answering "who owes whom within the group". Accepts `settlements` param for within-group settlement tracking. Children's balances are folded into adults. UI: shown in `CostBreakdownDialog` (Dashboard click-through on group entity) and `QuickGroupMembersSheet` (Quick mode expand).
+`calculateWithinGroupBalances()` computes per-member share/paid/balance within a wallet_group. Per-member totalPaid/totalShare sum to the group-level totals from `calculateBalances`, so the breakdown connects to the BalanceCard numbers. Payer is credited with the full expense amount; outsider-paid expenses contribute member shares (paid=0). Settlements applied to balance only (not totalPaid/totalShare). Children's balances are folded into adults. UI: shown in `CostBreakdownDialog` (Dashboard click-through on group entity) and `QuickGroupMembersSheet` (Quick mode expand).
 
 ### Routes
 

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -535,16 +535,58 @@ describe('calculateWithinGroupBalances', () => {
     expect(carolBal.balance).toBe(0)
   })
 
-  it('skips outsider-paid expenses — all balances stay zero', () => {
+  it('outsider-paid expenses contribute member shares (paid=0)', () => {
     const expense = buildExpense({
       amount: 120,
       paid_by: 'o1', // outsider pays
       distribution: { type: 'individuals', participants: ['g1', 'g2', 'g3', 'o1'] },
     })
     const balances = calculateWithinGroupBalances([expense], allParticipants, 'Smith')
-    // Outsider-paid expense is skipped entirely — within-group balances unaffected
-    const allEven = balances.every(b => Math.abs(b.balance) < 0.01)
-    expect(allEven).toBe(true)
+    // Each of the 4 participants owes 30. Group members have paid=0, share=30.
+    const aliceBal = balances.find(b => b.id === 'g1')!
+    const bobBal = balances.find(b => b.id === 'g2')!
+    const carolBal = balances.find(b => b.id === 'g3')!
+    expect(aliceBal.totalPaid).toBe(0)
+    expect(aliceBal.totalShare).toBe(30)
+    expect(aliceBal.balance).toBeCloseTo(-30, 2)
+    expect(bobBal.totalPaid).toBe(0)
+    expect(bobBal.totalShare).toBe(30)
+    expect(bobBal.balance).toBeCloseTo(-30, 2)
+    expect(carolBal.totalPaid).toBe(0)
+    expect(carolBal.totalShare).toBe(30)
+    expect(carolBal.balance).toBeCloseTo(-30, 2)
+  })
+
+  it('member totalPaid/totalShare sums match group-level calculateBalances output', () => {
+    // Mix of member-paid and outsider-paid expenses
+    const expenses = [
+      buildExpense({
+        id: 'e1',
+        amount: 90,
+        paid_by: 'g1', // group member pays
+        distribution: { type: 'individuals', participants: ['g1', 'g2', 'g3', 'o1'] },
+      }),
+      buildExpense({
+        id: 'e2',
+        amount: 120,
+        paid_by: 'o1', // outsider pays
+        distribution: { type: 'individuals', participants: ['g1', 'g2', 'o1'] },
+      }),
+    ]
+
+    // Group-level balances
+    const groupLevel = calculateBalances(expenses, allParticipants, 'individuals')
+    // Entity for Smith group (canonical = g1 since Alice sorts first among adults)
+    const smithGroup = groupLevel.balances.find(b => b.name === 'Smith')!
+
+    // Within-group balances
+    const memberBalances = calculateWithinGroupBalances(expenses, allParticipants, 'Smith')
+
+    const sumPaid = memberBalances.reduce((s, b) => s + b.totalPaid, 0)
+    const sumShare = memberBalances.reduce((s, b) => s + b.totalShare, 0)
+
+    expect(sumPaid).toBeCloseTo(smithGroup.totalPaid, 2)
+    expect(sumShare).toBeCloseTo(smithGroup.totalShare, 2)
   })
 
   it('returns empty array for non-existent group', () => {

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -261,12 +261,13 @@ export function calculateBalances(
 
 /**
  * Calculate balances within a single wallet_group.
- * Shows each member's paid vs share for group-member-paid expenses only.
- * Outsider-paid expenses are skipped so balances always sum to zero —
- * the view answers "who owes whom within the group".
+ * Per-member totalPaid/totalShare sum to the group-level totals from
+ * calculateBalances, so the breakdown connects to the BalanceCard numbers.
  *
- * Within-group settlements (both from and to are group members) are applied
- * after computing raw balances.
+ * Payer is credited with the full expense amount (not just the group's share).
+ * Outsider-paid expenses contribute member shares (paid=0).
+ *
+ * Within-group settlements are applied to balance only (not totalPaid/totalShare).
  */
 export function calculateWithinGroupBalances(
   expenses: Expense[],
@@ -291,12 +292,16 @@ export function calculateWithinGroupBalances(
 
   for (const expense of expenses) {
     if (expense.distribution.type !== 'individuals') continue
-    if (!memberIds.has(expense.paid_by)) continue
 
     const convertedAmount = convertToBaseCurrency(
       expense.amount, expense.currency, defaultCurrency, exchangeRates
     )
     const conversionFactor = expense.amount !== 0 ? convertedAmount / expense.amount : 1
+
+    // Credit payer with the full expense amount (if they are a group member)
+    if (memberIds.has(expense.paid_by)) {
+      paid.set(expense.paid_by, paid.get(expense.paid_by)! + convertedAmount)
+    }
 
     // Calculate each group member's share in this expense
     const memberShares = new Map<string, number>()
@@ -338,26 +343,10 @@ export function calculateWithinGroupBalances(
       }
     }
 
-    // Sum the group's total share of this expense
-    let groupTotal = 0
-    memberShares.forEach(v => { groupTotal += v })
-    if (groupTotal === 0) continue
-
-    // Credit the payer (always a group member at this point)
-    paid.set(expense.paid_by, paid.get(expense.paid_by)! + groupTotal)
-
     // Apply shares
     memberShares.forEach((amount, pid) => {
       share.set(pid, share.get(pid)! + amount)
     })
-  }
-
-  // Apply within-group settlements (both parties must be group members)
-  for (const settlement of settlements) {
-    if (!memberIds.has(settlement.from_participant_id) || !memberIds.has(settlement.to_participant_id)) continue
-    const convertedAmount = convertToBaseCurrency(settlement.amount, settlement.currency, defaultCurrency, exchangeRates)
-    paid.set(settlement.from_participant_id, (paid.get(settlement.from_participant_id) || 0) + convertedAmount)
-    paid.set(settlement.to_participant_id, (paid.get(settlement.to_participant_id) || 0) - convertedAmount)
   }
 
   // Compute raw balances per member
@@ -369,6 +358,16 @@ export function calculateWithinGroupBalances(
     totalShare: share.get(m.id) || 0,
     balance: (paid.get(m.id) || 0) - (share.get(m.id) || 0),
   }))
+
+  // Apply within-group settlements to balance only (both parties must be group members)
+  for (const settlement of settlements) {
+    if (!memberIds.has(settlement.from_participant_id) || !memberIds.has(settlement.to_participant_id)) continue
+    const convertedAmount = convertToBaseCurrency(settlement.amount, settlement.currency, defaultCurrency, exchangeRates)
+    const from = rawBalances.find(b => b.id === settlement.from_participant_id)
+    const to = rawBalances.find(b => b.id === settlement.to_participant_id)
+    if (from) from.balance += convertedAmount
+    if (to) to.balance -= convertedAmount
+  }
 
   // Fold children's balances into adults
   const adults = rawBalances.filter(b => b.is_adult)


### PR DESCRIPTION
## Summary
- **`calculateWithinGroupBalances()`** per-member `totalPaid`/`totalShare` now sum to the group-level totals from `calculateBalances()`, so the CostBreakdownDialog breakdown connects to BalanceCard numbers
- Removed outsider-paid expense filter — outsider-paid expenses now contribute member shares (paid=0)
- Payer credited with full expense amount (not just group's share)
- Settlements applied to `balance` only (not `totalPaid`/`totalShare`)

## Test plan
- [x] All 153 unit tests pass (including 44 balanceCalculator tests)
- [x] Type-check clean
- [ ] Visual: CostBreakdownDialog member rows sum to "Group paid" / "Group share" totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)