### PR TITLE
fix: point 'Try a demo' link to seeded livigno-2025 trip

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,8 +20,7 @@ import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { useMyTripBalances } from '@/hooks/useMyTripBalances'
 import { motion } from 'framer-motion'
 
-// TODO: Replace with actual demo trip code once seeded in production Supabase
-const DEMO_TRIP_CODE = 'demo-trip-2026-xD3mO1'
+const DEMO_TRIP_CODE = 'livigno-2025'
 
 export function HomePage() {
   const navigate = useNavigate()


### PR DESCRIPTION
## Summary
- Updates `DEMO_TRIP_CODE` from placeholder `demo-trip-2026-xD3mO1` to `livigno-2025` (seeded in #430)
- Removes the TODO comment — demo trip now exists in production

## Test plan
- [ ] Open home page unauthenticated — click "Try a demo" → opens `/t/livigno-2025/quick`
- [ ] Verify trip loads with 6 participants and 13 expenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)