### PR TITLE
fix: demo link respects user mode preference

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -116,7 +116,7 @@ export function HomePage() {
           </Button>
           <div className="mt-3">
             <button
-              onClick={() => navigate(`/t/${DEMO_TRIP_CODE}/quick`)}
+              onClick={() => navigate(`/t/${DEMO_TRIP_CODE}`)}
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               <Sparkles size={14} />
@@ -346,7 +346,7 @@ export function HomePage() {
         {isAuthenticated && !loading && visibleTrips.length === 0 && (
           <div className="text-center -mt-3 mb-6">
             <button
-              onClick={() => navigate(`/t/${DEMO_TRIP_CODE}/quick`)}
+              onClick={() => navigate(`/t/${DEMO_TRIP_CODE}`)}
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               <Sparkles size={14} />


### PR DESCRIPTION
## Summary
- "Try a demo" link now navigates to `/t/livigno-2025` instead of `/t/livigno-2025/quick`
- `TripModeRedirect` handles routing to quick (mobile) or dashboard (desktop) based on the user's preference

## Test plan
- [ ] Desktop: click "Try a demo" → lands on `/t/livigno-2025/dashboard`
- [ ] Mobile: click "Try a demo" → lands on `/t/livigno-2025/quick`

🤖 Generated with [Claude Code](https://claude.com/claude-code)