### PR TITLE
fix: gate trip deletion to creator or admin

### DIFF
--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -38,10 +38,13 @@ import { useToast } from '@/hooks/use-toast'
 import { CreateEventInput } from '@/types/trip'
 import { StaySection } from '@/components/StaySection'
 import { removeFromMyTrips } from '@/lib/myTripsStorage'
+import { useAuth } from '@/contexts/AuthContext'
+import { isAdminUser } from '@/lib/adminAuth'
 
 export function ManageTripPage() {
   const { currentTrip, tripCode } = useCurrentTrip()
   const { updateTrip, deleteTrip } = useTripContext()
+  const { user } = useAuth()
   const location = useLocation()
   const fromQuick = !!(location.state as any)?.fromQuick
   const { participants, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
@@ -81,6 +84,10 @@ export function ManageTripPage() {
 
   const entityLabel = currentTrip.event_type === 'event' ? 'Event' : 'Trip'
   const isEvent = currentTrip.event_type === 'event'
+  const canDelete = !!user && (
+    (!!currentTrip.created_by && user.id === currentTrip.created_by) ||
+    isAdminUser(user.id)
+  )
 
   const handleEditTrip = async (values: CreateEventInput) => {
     setIsUpdating(true)
@@ -466,45 +473,47 @@ export function ManageTripPage() {
       {/* Accommodations Section */}
       <StaySection />
 
-      {/* Danger Zone */}
-      <Card className="border-destructive">
-        <CardHeader>
-          <CardTitle className="text-destructive">Danger Zone</CardTitle>
-          <CardDescription>Irreversible actions</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="destructive">
-                <Trash2 size={16} className="mr-2" />
-                Delete {entityLabel}
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will permanently delete <strong>"{currentTrip.name}"</strong> and all
-                  associated data including expenses, settlements, and shopping items.
-                  <br />
-                  <br />
-                  <strong>This action cannot be undone.</strong>
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleDeleteTrip}
-                  disabled={isDeleting}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                >
-                  {isDeleting ? 'Deleting...' : `Delete ${entityLabel}`}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </CardContent>
-      </Card>
+      {/* Danger Zone — only visible to trip creator or admin */}
+      {canDelete && (
+        <Card className="border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Danger Zone</CardTitle>
+            <CardDescription>Irreversible actions</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">
+                  <Trash2 size={16} className="mr-2" />
+                  Delete {entityLabel}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete <strong>"{currentTrip.name}"</strong> and all
+                    associated data including expenses, settlements, and shopping items.
+                    <br />
+                    <br />
+                    <strong>This action cannot be undone.</strong>
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDeleteTrip}
+                    disabled={isDeleting}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    {isDeleting ? 'Deleting...' : `Delete ${entityLabel}`}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Edit Dialog */}
       <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>

--- a/supabase/migrations/033_admin_delete_trips.sql
+++ b/supabase/migrations/033_admin_delete_trips.sql
@@ -1,0 +1,13 @@
+-- Allow admin users to delete any trip (in addition to the creator).
+--
+-- Admin UUIDs here MUST stay in sync with src/lib/adminAuth.ts ADMIN_USER_IDS.
+-- If you add/remove an admin there, update this policy too.
+
+DROP POLICY IF EXISTS "trips_delete" ON trips;
+
+CREATE POLICY "trips_delete" ON trips
+  FOR DELETE
+  USING (
+    auth.uid() = created_by
+    OR auth.uid() IN ('4d07e4a8-9630-4692-93c8-c97896e6fc4d')
+  );


### PR DESCRIPTION
## Summary
- Hide Danger Zone card on ManageTripPage from non-authorized users (unauthenticated or non-creator/non-admin)
- Add RLS policy allowing admin UUID to delete any trip
- New migration `033_admin_delete_trips.sql`

Closes #434

## Test plan
- [ ] `npm run type-check` — clean
- [ ] `npm test` — 153/153 pass
- [ ] Manual: open ManageTripPage unauthenticated → no Danger Zone
- [ ] Manual: open as non-creator authenticated user → no Danger Zone
- [ ] Manual: open as trip creator → Danger Zone visible
- [ ] Apply migration with `supabase db push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)