### PR TITLE
fix: hide useless bottom nav on home page + stop auto-redirect for unauthenticated users

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -271,8 +271,8 @@ export function Layout() {
         </ParticipantProvider>
       </main>
 
-      {/* Bottom navigation (mobile) */}
-      <nav className="fixed bottom-0 left-0 right-0 bg-card border-t border-border soft-shadow-lg lg:hidden z-40">
+      {/* Bottom navigation (mobile) — only shown inside a trip */}
+      {tripCode && <nav className="fixed bottom-0 left-0 right-0 bg-card border-t border-border soft-shadow-lg lg:hidden z-40">
         <div className="flex justify-around items-center h-16">
           {mobileNavItems.map((item) => {
             const Icon = iconMap[item.label as keyof typeof iconMap]
@@ -386,7 +386,7 @@ export function Layout() {
             </SheetContent>
           </Sheet>
         </div>
-      </nav>
+      </nav>}
 
       {/* Side navigation (desktop) */}
       {tripCode && <aside className="hidden lg:block fixed left-0 top-20 bottom-0 w-64 bg-card border-r border-border soft-shadow">

--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -103,6 +103,7 @@ describe('ConditionalHomePage', () => {
 
   it('navigates to /t/{code}/quick on mobile with active trip', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 375, writable: true })
+    mockAuth.user = { id: 'user-1' } as any
     const trip = buildTrip({
       id: 'trip-1',
       trip_code: 'summer-trip-Ab1234',
@@ -124,8 +125,31 @@ describe('ConditionalHomePage', () => {
     })
   })
 
+  it('skips auto-redirect for unauthenticated users', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true })
+    mockAuth.user = null
+    const trip = buildTrip({
+      id: 'trip-1',
+      trip_code: 'summer-trip-Ab1234',
+    })
+    mockTrips.trips = [trip]
+    vi.mocked(getActiveTripId).mockReturnValue('trip-1')
+
+    render(
+      <MemoryRouter>
+        <ConditionalHomePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
   it('skips auto-redirect when navigated with fromTrip state', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 375, writable: true })
+    mockAuth.user = { id: 'user-1' } as any
     const trip = buildTrip({
       id: 'trip-1',
       trip_code: 'summer-trip-Ab1234',

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
 import { getActiveTripId } from '@/lib/activeTripDetection'
-import { getMyTrips } from '@/lib/myTripsStorage'
+
 import { HomePage } from './HomePage'
 import { Loader2 } from 'lucide-react'
 
@@ -32,10 +32,12 @@ export function ConditionalHomePage() {
       return
     }
 
-    const myTrips = user
-      ? trips
-      : trips.filter(t => new Set(getMyTrips().map(e => e.tripCode)).has(t.trip_code))
-    const activeTripId = getActiveTripId(myTrips)
+    // Only auto-redirect for authenticated users. For unauthenticated users,
+    // TripContext fetches ALL trips and localStorage includes shared-link trips,
+    // so there's no reliable way to distinguish "my trip" from "visited via link".
+    if (!user) return
+
+    const activeTripId = getActiveTripId(trips)
 
     if (activeTripId) {
       const activeTrip = trips.find(t => t.id === activeTripId)


### PR DESCRIPTION
## Summary
Fixes #440

- **Bottom nav on home page**: When `!tripCode`, `getMobileNavItems()` returns a single "Trips" item pointing to `/` (current page) and `getOverflowMenuItems()` returns `[]`. The nav showed a useless "Trips" tab and empty "More" menu. Now the entire `<nav>` is wrapped in `{tripCode && ...}` so it only renders inside a trip.
- **Auto-redirect for unauthenticated users**: `TripContext` fetches ALL trips for unauthenticated users, and `useCurrentTrip()` auto-adds any visited trip (including shared links) to localStorage. This made shared-link trips auto-redirect candidates. Now only authenticated users get auto-redirected — their trips are already filtered by ownership/participation in `TripContext`.

## Test plan
- [x] `npm run type-check` passes clean
- [x] All 155 tests pass (added new test for unauthenticated redirect skip)
- [ ] Open home page on mobile viewport — no bottom nav bar
- [ ] Open a trip on mobile — bottom nav appears with trip tabs
- [ ] Unauthenticated user with shared-link trip in localStorage — no auto-redirect, sees home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)