### PR TITLE
feat: smart install guide — open like an app for engaged mobile users

### DIFF
--- a/src/components/InstallGuide.tsx
+++ b/src/components/InstallGuide.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { X, ChevronRight, Smartphone } from 'lucide-react'
+import { usePWAInstall } from '@/hooks/usePWAInstall'
+
+interface InstallGuideProps {
+  variant: 'banner' | 'settings'
+  onDismiss?: () => void
+}
+
+function IOSInstructions() {
+  return (
+    <ol className="list-decimal list-inside space-y-2 text-xs text-muted-foreground">
+      <li>
+        Tap the <strong className="text-foreground">Share</strong> button
+        (the box with the arrow) at the bottom of Safari
+      </li>
+      <li>
+        Scroll down and tap <strong className="text-foreground">"Add to Home Screen"</strong>
+      </li>
+      <li>
+        Tap <strong className="text-foreground">"Add"</strong> — done!
+      </li>
+    </ol>
+  )
+}
+
+function AndroidInstructions() {
+  return (
+    <ol className="list-decimal list-inside space-y-2 text-xs text-muted-foreground">
+      <li>
+        Tap the <strong className="text-foreground">three dots</strong> (&#8942;)
+        in Chrome's top-right corner
+      </li>
+      <li>
+        Tap <strong className="text-foreground">"Add to Home screen"</strong>
+      </li>
+      <li>
+        Tap <strong className="text-foreground">"Add"</strong> — done!
+      </li>
+    </ol>
+  )
+}
+
+function GenericInstructions() {
+  return (
+    <p className="text-xs text-muted-foreground">
+      Open your browser menu and look for{' '}
+      <strong className="text-foreground">"Add to Home Screen"</strong> or{' '}
+      <strong className="text-foreground">"Install app"</strong>.
+    </p>
+  )
+}
+
+function PlatformInstructions({ isIOS, isAndroid }: { isIOS: boolean; isAndroid: boolean }) {
+  return (
+    <div className="mt-3 space-y-3">
+      {isIOS ? <IOSInstructions /> : isAndroid ? <AndroidInstructions /> : <GenericInstructions />}
+      {(isIOS || isAndroid) && (
+        <p className="text-xs text-muted-foreground/70 italic">
+          Make sure you're on the home page when you do this, so the app
+          always opens in the right place.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function InstallGuide({ variant, onDismiss }: InstallGuideProps) {
+  const [expanded, setExpanded] = useState(false)
+  const { isIOS, isAndroid } = usePWAInstall()
+
+  if (variant === 'banner') {
+    return (
+      <div className="bg-muted/50 rounded-lg border border-border/50 p-3 mb-6">
+        <div className="flex items-start gap-3">
+          <Smartphone size={18} className="text-muted-foreground shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-sm font-medium text-foreground">
+                Open Spl1t like an app
+              </p>
+              <button
+                onClick={onDismiss}
+                aria-label="Dismiss"
+                className="shrink-0 rounded-full w-6 h-6 flex items-center justify-center hover:bg-muted transition-colors -mt-0.5 -mr-0.5"
+              >
+                <X size={14} className="text-muted-foreground" />
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Open instantly from your phone — no browser needed
+            </p>
+            {!expanded && (
+              <button
+                onClick={() => setExpanded(true)}
+                className="mt-2 text-xs font-medium text-foreground hover:underline"
+              >
+                Show me
+              </button>
+            )}
+            {expanded && (
+              <PlatformInstructions isIOS={isIOS} isAndroid={isAndroid} />
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Settings variant
+  return (
+    <button
+      onClick={() => setExpanded(prev => !prev)}
+      className="w-full text-left bg-muted/50 rounded-lg border border-border/50 p-3"
+    >
+      <div className="flex items-center gap-3">
+        <Smartphone size={16} className="text-muted-foreground shrink-0" />
+        <span className="text-sm font-medium text-foreground flex-1">
+          Open Spl1t like an app
+        </span>
+        <ChevronRight
+          size={16}
+          className={`text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`}
+        />
+      </div>
+      {expanded && (
+        <div className="mt-2 pl-7" onClick={(e) => e.stopPropagation()}>
+          <p className="text-xs text-muted-foreground mb-1">
+            Works like a regular app — no browser needed
+          </p>
+          <PlatformInstructions isIOS={isIOS} isAndroid={isAndroid} />
+        </div>
+      )}
+    </button>
+  )
+}

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -1,0 +1,81 @@
+import { useState, useCallback } from 'react'
+
+const DISMISSED_KEY = 'spl1t:install-prompt-dismissed'
+const VISITS_KEY = 'spl1t:visit-count'
+
+function readBool(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function readInt(key: string): number {
+  try {
+    return parseInt(localStorage.getItem(key) || '0', 10) || 0
+  } catch {
+    return 0
+  }
+}
+
+export function usePWAInstall() {
+  // Is the app already running installed (standalone)?
+  const isInstalled =
+    ('standalone' in navigator &&
+      (navigator as unknown as { standalone?: boolean }).standalone === true) ||
+    window.matchMedia('(display-mode: standalone)').matches
+
+  // Has the user dismissed the prompt before?
+  const [isDismissed, setIsDismissed] = useState(() => readBool(DISMISSED_KEY))
+
+  // Is this a mobile device? Use userAgent — viewport width unreliable at init
+  const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+
+  // Platform detection for instructions
+  const isIOS =
+    /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+    !(window as unknown as { MSStream?: unknown }).MSStream
+  const isAndroid = /Android/i.test(navigator.userAgent)
+
+  // Engagement: visit count
+  const visitCount = readInt(VISITS_KEY)
+  const isEngaged = visitCount >= 2
+
+  const incrementVisit = useCallback(() => {
+    try {
+      const current = readInt(VISITS_KEY)
+      localStorage.setItem(VISITS_KEY, String(current + 1))
+    } catch {
+      // localStorage unavailable — silently ignore
+    }
+  }, [])
+
+  // Show banner on home page: mobile + not installed + not dismissed + engaged
+  const shouldShowPrompt =
+    isMobile && !isInstalled && !isDismissed && isEngaged
+
+  // Show in Manage Trip: mobile + not installed (regardless of dismissal)
+  const shouldShowInSettings = isMobile && !isInstalled
+
+  const dismiss = useCallback(() => {
+    try {
+      localStorage.setItem(DISMISSED_KEY, 'true')
+    } catch {
+      // localStorage unavailable — silently ignore
+    }
+    setIsDismissed(true)
+  }, [])
+
+  return {
+    isInstalled,
+    isDismissed,
+    isMobile,
+    isIOS,
+    isAndroid,
+    shouldShowPrompt,
+    shouldShowInSettings,
+    incrementVisit,
+    dismiss,
+  }
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Plus, Calendar, Trash2, Share2, ChevronRight, ScanLine, ChevronDown, Eye, ExternalLink, Sparkles } from 'lucide-react'
+import { InstallGuide } from '@/components/InstallGuide'
+import { usePWAInstall } from '@/hooks/usePWAInstall'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { getMyTrips, removeFromMyTrips, type MyTripEntry } from '@/lib/myTripsStorage'
@@ -34,6 +36,7 @@ export function HomePage() {
   const [createOpen, setCreateOpen] = useState(false)
   const [scanContextOpen, setScanContextOpen] = useState(false)
   const [scanCreateOpen, setScanCreateOpen] = useState(false)
+  const { shouldShowPrompt, dismiss: dismissInstall, incrementVisit } = usePWAInstall()
 
   const isAuthenticated = !!user
   const loading = isAuthenticated && (balancesLoading || tripsLoading)
@@ -44,6 +47,10 @@ export function HomePage() {
       setLocalTrips(getMyTrips())
     }
   }, [isAuthenticated])
+
+  useEffect(() => {
+    incrementVisit()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const visibleTrips = tripBalances.filter(tb => !hiddenCodes.has(tb.trip.trip_code))
   const hiddenTrips = tripBalances.filter(tb => hiddenCodes.has(tb.trip.trip_code))
@@ -317,6 +324,10 @@ export function HomePage() {
             </h1>
           )}
         </div>
+
+        {shouldShowPrompt && (
+          <InstallGuide variant="banner" onDismiss={dismissInstall} />
+        )}
 
         <OnboardingPrompts />
 

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -37,8 +37,10 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { useToast } from '@/hooks/use-toast'
 import { CreateEventInput } from '@/types/trip'
 import { StaySection } from '@/components/StaySection'
+import { InstallGuide } from '@/components/InstallGuide'
 import { removeFromMyTrips } from '@/lib/myTripsStorage'
 import { useAuth } from '@/contexts/AuthContext'
+import { usePWAInstall } from '@/hooks/usePWAInstall'
 import { isAdminUser } from '@/lib/adminAuth'
 
 export function ManageTripPage() {
@@ -47,6 +49,7 @@ export function ManageTripPage() {
   const { user } = useAuth()
   const location = useLocation()
   const fromQuick = !!(location.state as any)?.fromQuick
+  const { shouldShowInSettings } = usePWAInstall()
   const { participants, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
   const { meals } = useMealContext()
   const { toast } = useToast()
@@ -472,6 +475,11 @@ export function ManageTripPage() {
 
       {/* Accommodations Section */}
       <StaySection />
+
+      {/* PWA install guide — mobile only, hidden when already installed */}
+      {shouldShowInSettings && (
+        <InstallGuide variant="settings" />
+      )}
 
       {/* Danger Zone — only visible to trip creator or admin */}
       {canDelete && (


### PR DESCRIPTION
## Summary
- Adds a dismissible install prompt on the home page after 2+ visits on mobile, using plain language ("open like an app") instead of developer terms
- Always findable in Manage Trip settings for users who previously dismissed it
- Hidden entirely when already running as standalone (installed) or on desktop
- Platform-specific iOS/Android instructions expand inline

## New files
- `src/hooks/usePWAInstall.ts` — install state detection, engagement tracking (visit count in localStorage), platform detection, dismiss logic
- `src/components/InstallGuide.tsx` — two variants: `banner` (home page, dismissible) and `settings` (Manage Trip, always visible if mobile + not installed)

## Changes
- `HomePage.tsx` — renders install banner below greeting when `shouldShowPrompt`, increments visit count on mount
- `ManageTripPage.tsx` — renders settings variant after Accommodations section when `shouldShowInSettings`

## Test plan
- [ ] **First visit (count 0–1):** Home page — no install banner visible
- [ ] **Second visit (count ≥ 2):** Home page — install banner visible below greeting
- [ ] **Tap ✕:** Banner disappears; refresh — still gone
- [ ] **Manage Trip:** "Open Spl1t like an app" entry always visible on mobile (even after dismiss)
- [ ] **Tap settings entry:** Instructions expand with platform-specific steps
- [ ] **Standalone mode:** No banner on home, no entry in Manage Trip
- [ ] **Desktop viewport (1280px):** No banner, no entry
- [ ] **Reset:** `localStorage.removeItem('spl1t:install-prompt-dismissed'); localStorage.removeItem('spl1t:visit-count')`
- [ ] `npm run type-check` ✅
- [ ] `npm test` — 155/155 passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)