### PR TITLE
chore: move custom skills to project-level

### DIFF
--- a/.claude/skills/gh-issue-triage/SKILL.md
+++ b/.claude/skills/gh-issue-triage/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: gh-issue-triage
+description: Triage open GitHub issues — group by topic, cross-reference existing fixes, then resolve each group with a focused PR.
+---
+
+# GitHub Issue Triage
+
+Autonomously triage, group, cross-reference, and resolve open GitHub issues — one topic group per PR, no mixing.
+
+## Instructions
+
+When the user invokes this skill, perform the following steps in order:
+
+### 0. Read Project Context (MANDATORY — do not skip)
+
+**Before doing anything else**, use the Read tool to read these files from the repo root:
+
+1. **`CLAUDE.md`** — project conventions, architecture, safety rules, access model, common pitfalls. **You must read this file in full.** It contains critical rules (auth safety, RLS access model, timeout architecture) that constrain how fixes can be implemented.
+2. **`PLAN.md`** — feature roadmap, completed phases, known issues. **You must read this file in full.** It tells you what has already been built and what issues may already be resolved by completed work.
+3. **`AUDIT.md`** — audit findings, already-addressed items (if it exists).
+
+**Do not proceed to step 1 until you have read CLAUDE.md and PLAN.md.** The information in these files is essential for:
+- Correctly classifying issues as ALREADY FIXED vs NEW
+- Understanding architecture constraints before proposing fixes
+- Avoiding safety violations (auth deadlocks, RLS breakage, timeout misuse)
+- Following the project's git workflow and coding conventions
+
+### 1. Fetch All Open Issues
+
+```bash
+gh issue list --state open --json number,title,body,labels,createdAt,updatedAt,comments --limit 200
+```
+
+Display a quick summary: total count and titles.
+
+### 1b. Read Issue Comments and Attached Images
+
+For each open issue, fetch comments to get the full context:
+
+```bash
+gh issue view <number> --json body,comments
+```
+
+**Comments often contain critical context** — reproduction steps, "actually this is about X", confirmations that a fix worked, or additional screenshots. Do not skip this step.
+
+**Attached images** (screenshots, recordings): GitHub issues embed images as markdown `![alt](https://...)` in the body and comments. To view these:
+
+1. Extract image URLs from the issue body and comment markdown
+2. Download them directly using `curl` — they are publicly accessible URLs:
+   ```bash
+   curl -L -o /tmp/issue-<number>-img-1.png "https://github.com/user-attachments/assets/..."
+   ```
+3. Use the Read tool to view the downloaded image files
+
+**Do NOT use Playwright MCP to screenshot issue pages.** The `gh` CLI + `curl` gives you everything — body, comments, and image attachments — without needing a browser.
+
+### 2. Group and Deduplicate
+
+Analyze the issues and organize them into **topic groups**:
+
+- Group issues that describe the same bug, feature area, or component
+- Flag duplicates explicitly (same root cause or identical request)
+- Each group gets a short topic label (e.g., "iOS keyboard handling", "settlement calculation", "dark mode")
+
+### 3. Cross-Reference Existing Fixes
+
+For each group, check:
+
+- **PLAN.md**: Was this addressed in a completed phase?
+- **AUDIT.md**: Was this flagged and resolved?
+- **Recent commits**: `git log --oneline -50` — was a fix already merged?
+- **Closed issues/PRs**: `gh issue list --state closed --limit 50` / `gh pr list --state merged --limit 50`
+
+Classify each group:
+
+| Status | Meaning |
+|--------|---------|
+| **ALREADY FIXED** | Code fix exists, issue can be closed with a comment pointing to the fix |
+| **NEW** | Genuine unresolved issue requiring code changes |
+| **INVALID** | Not a real bug, misunderstanding, or out of scope |
+| **DUPLICATE** | Covered by another open issue (close with cross-reference) |
+
+### 4. Present Triage Report
+
+Before making any changes, present the full triage analysis:
+
+```
+## Triage Report
+
+### Group 1: [Topic] — ALREADY FIXED
+Issues: #12, #15
+Fixed in: PR #140 / commit abc1234
+Action: Close with comment
+
+### Group 2: [Topic] — NEW (Priority: High)
+Issues: #18, #22
+Affected files: src/components/...
+Plan: [brief fix description]
+
+### Group 3: [Topic] — DUPLICATE
+Issues: #20 (duplicate of #18)
+Action: Close #20, reference #18
+```
+
+**Wait for user approval** before proceeding to fixes.
+
+### 5. Close Already-Fixed and Duplicate Issues
+
+For **ALREADY FIXED** issues:
+```bash
+gh issue close <number> --comment "This was fixed in PR #N / commit SHA. Closing."
+```
+
+For **DUPLICATE** issues:
+```bash
+gh issue close <number> --comment "Duplicate of #N. Closing in favor of that issue."
+```
+
+For **INVALID** issues:
+```bash
+gh issue close <number> --comment "Closing as not applicable — [brief reason]."
+```
+
+### 6. Fix NEW Issues — One Group at a Time
+
+For each NEW group, in priority order:
+
+1. **Create a branch**: `git checkout -b fix/topic-description`
+2. **Read affected files** before making changes
+3. **Implement the fix** — address all issues in the group
+4. **Run checks**:
+   ```bash
+   npm run type-check   # must pass clean
+   npm test             # must pass
+   ```
+5. **Commit**: Message references all issues in the group
+6. **Push and open PR**:
+   ```bash
+   git push -u origin fix/topic-description
+   gh pr create --title "fix: [topic] — closes #N, #N" --body "..."
+   ```
+7. **Squash-merge the PR**:
+   ```bash
+   gh pr merge <N> --squash --delete-branch
+   git checkout main && git pull
+   ```
+8. **Close resolved issues** (if not auto-closed by PR):
+   ```bash
+   gh issue close <number> --comment "Fixed in PR #N."
+   ```
+9. Move to the next group — do NOT start the next group until the current PR is merged
+
+### 7. Final Summary
+
+After all groups are processed, present:
+
+- Issues closed (with reasons)
+- PRs opened/merged
+- Any issues left open and why
+
+## Safety Rules
+
+- **Never close an issue** without a confirmed code fix or verified existing fix
+- **Never touch auth code** without re-reading the auth safety rule in CLAUDE.md
+- **Never touch RLS or DB access** without re-reading the access model in CLAUDE.md
+- **Always run type-check and tests** before opening a PR — they must pass clean
+- **One PR per topic group** — never mix unrelated fixes
+- **Wait for user approval** after presenting the triage report before making changes
+- **Ask before closing** any issue classified as INVALID — the user may disagree
+- If a fix is complex or risky, describe the approach and get confirmation before implementing

--- a/.claude/skills/pr-branch-maintenance/SKILL.md
+++ b/.claude/skills/pr-branch-maintenance/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: pr-branch-maintenance
+description: Check and maintain PR branches - identify stale branches, show sync status, and offer rebase/merge actions.
+---
+
+# PR Branch Maintenance
+
+Skill for keeping PR branches up-to-date and identifying stale work.
+
+## Instructions
+
+When the user invokes this skill, perform the following steps:
+
+### 1. Current Branch Sync Check
+
+First, check if the user's current branch is out of sync with its base:
+
+```bash
+# Get current branch
+current=$(git branch --show-current)
+
+# Find the base branch (usually main or master)
+base=$(git remote show origin | grep 'HEAD branch' | awk '{print $NF}')
+
+# Fetch latest from remote
+git fetch origin "$base" --quiet
+
+# Check how far behind
+behind=$(git rev-list --count "HEAD..origin/$base")
+ahead=$(git rev-list --count "origin/$base..HEAD")
+```
+
+If the current branch is behind, **warn the user immediately**:
+- Show how many commits behind
+- Ask if they want to rebase before continuing work
+
+### 2. Scan All PR Branches
+
+List all branches with open PRs and their sync status:
+
+```bash
+# Get all open PRs with branch info
+gh pr list --state open --json number,title,headRefName,baseRefName,updatedAt --jq '.[] | "\(.number)\t\(.headRefName)\t\(.baseRefName)\t\(.updatedAt)\t\(.title)"'
+```
+
+For each PR branch:
+- Fetch the base branch: `git fetch origin <base> --quiet`
+- Count commits behind: `git rev-list --count <branch>..origin/<base>`
+- Calculate days since last update from `updatedAt`
+
+### 3. Report Format
+
+Present results in a table:
+
+```
+PR #  | Branch              | Behind | Last Updated | Status
+------|---------------------|--------|--------------|--------
+#42   | fix/loading-hang    | 0      | 2h ago       | Up to date
+#38   | feature/oauth       | 12     | 5d ago       | Needs rebase
+#35   | fix/old-bug         | 28     | 14d ago      | STALE
+```
+
+Status definitions:
+- **Up to date**: 0 commits behind base
+- **Needs rebase**: 1+ commits behind base
+- **STALE**: No updates in 7+ days AND behind base
+
+### 4. Offer Actions
+
+After showing the report, offer these actions:
+
+- **Rebase a branch**: `git checkout <branch> && git rebase origin/<base> && git push --force-with-lease`
+- **Merge base into branch**: `git checkout <branch> && git merge origin/<base> && git push`
+- **Rebase all outdated branches**: Loop through all behind branches and rebase each
+- **Close stale PRs**: Use `gh pr close <number>` for abandoned work
+
+### 5. Safety Rules
+
+- Always use `--force-with-lease` instead of `--force` when pushing after rebase
+- Before rebasing, check for uncommitted changes and stash them
+- After rebase, verify the branch still builds (run `npm run type-check` or equivalent if available)
+- Never force-push to main/master
+- Ask for confirmation before closing any PR
+- If rebase has conflicts, stop and report them to the user rather than attempting automatic resolution


### PR DESCRIPTION
## Summary
- Move `gh-issue-triage` and `pr-branch-maintenance` skills from `~/.claude/skills/` (user-level, local only) to `.claude/skills/` (project-level, in repo)
- Skills are now available on any machine that clones the repo

## Test plan
- [x] Verified both skills appear in Claude Code's skill list after the move
- [x] Confirmed user-level copies removed (no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)