### PR TITLE
fix: show admin nav button in header when running as installed PWA

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useState } from 'react'
 import {
   Home, DollarSign, CreditCard, CalendarDays,
-  ShoppingCart, BarChart3, Settings2, MoreHorizontal, ScanLine, Settings, Zap
+  ShoppingCart, BarChart3, Settings2, MoreHorizontal, ScanLine, Settings, Zap, Shield
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -23,6 +23,7 @@ import { SignInButton } from '@/components/auth/SignInButton'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { ModeToggle } from '@/components/quick/ModeToggle'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
+import { isAdminUser } from '@/lib/adminAuth'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
 import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
@@ -202,6 +203,22 @@ export function Layout() {
                 </motion.div>
               )}
               <div className="flex items-center gap-2 flex-shrink-0">
+                {user && isAdminUser(user.id) && (
+                  ('standalone' in navigator && (navigator as unknown as { standalone?: boolean }).standalone === true) ||
+                  window.matchMedia('(display-mode: standalone)').matches
+                ) && (
+                  <button
+                    onClick={() => navigate('/admin/all-trips')}
+                    className={`p-2 rounded-md transition-colors ${
+                      onGradient
+                        ? 'text-white/70 hover:text-white hover:bg-white/10'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                    }`}
+                    title="Admin"
+                  >
+                    <Shield size={18} />
+                  </button>
+                )}
                 <ReportIssueButton onGradient={onGradient} />
                 {/* In trip: show scan + mode toggle (desktop only; Row 2 handles mobile). On home: hidden (page has its own scan CTA) */}
                 {tripCode && (

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Link, useParams, useLocation, useNavigate } from 'react-router-dom'
-import { ArrowLeft, ScanLine, Settings, LayoutGrid } from 'lucide-react'
+import { ArrowLeft, ScanLine, Settings, LayoutGrid, Shield } from 'lucide-react'
 import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -20,6 +20,7 @@ import { getHiddenTripCodes } from '@/lib/mutedTripsStorage'
 import { Toaster } from '@/components/ui/toaster'
 import { getTripGradientPattern } from '@/services/tripGradientService'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
+import { isAdminUser } from '@/lib/adminAuth'
 
 export function QuickLayout() {
   const { tripCode } = useParams<{ tripCode: string }>()
@@ -112,6 +113,22 @@ export function QuickLayout() {
                 )}
               </div>
               <div className="flex items-center gap-2 flex-shrink-0">
+                {user && isAdminUser(user.id) && (
+                  ('standalone' in navigator && (navigator as unknown as { standalone?: boolean }).standalone === true) ||
+                  window.matchMedia('(display-mode: standalone)').matches
+                ) && (
+                  <button
+                    onClick={() => navigate('/admin/all-trips')}
+                    className={`p-2 rounded-md transition-colors ${
+                      onGradient
+                        ? 'text-white/70 hover:text-white hover:bg-white/10'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                    }`}
+                    title="Admin"
+                  >
+                    <Shield size={18} />
+                  </button>
+                )}
                 <ReportIssueButton onGradient={onGradient} />
                 {isInTrip && (
                   <div className="hidden lg:flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Shield icon button appears next to the feedback button in the header, visible only to the admin user in standalone PWA mode
- Navigates to `/admin/all-trips` on tap
- Hidden in regular browser, hidden for non-admin users
- Added to both `Layout.tsx` (full mode) and `QuickLayout.tsx` (quick mode)

## Test plan
- [ ] Signed in as admin in standalone PWA: shield button visible next to bug button
- [ ] Tap shield: navigates to /admin/all-trips
- [ ] Signed in as non-admin: button not visible
- [ ] Not signed in: button not visible
- [ ] Regular browser (not standalone): button not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)