### PR TITLE
fix: only auto-redirect to trips happening now — closes #446

### DIFF
--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -104,9 +104,14 @@ describe('ConditionalHomePage', () => {
   it('navigates to /t/{code}/quick on mobile with active trip', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 375, writable: true })
     mockAuth.user = { id: 'user-1' } as any
+    const today = new Date()
+    const yesterday = new Date(today); yesterday.setDate(today.getDate() - 1)
+    const tomorrow = new Date(today); tomorrow.setDate(today.getDate() + 1)
     const trip = buildTrip({
       id: 'trip-1',
       trip_code: 'summer-trip-Ab1234',
+      start_date: yesterday.toISOString().slice(0, 10),
+      end_date: tomorrow.toISOString().slice(0, 10),
     })
     mockTrips.trips = [trip]
     vi.mocked(getActiveTripId).mockReturnValue('trip-1')
@@ -123,6 +128,34 @@ describe('ConditionalHomePage', () => {
         { replace: true }
       )
     })
+  })
+
+  it('does not redirect for upcoming (future) trips', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true })
+    mockAuth.user = { id: 'user-1' } as any
+    const nextMonth = new Date()
+    nextMonth.setMonth(nextMonth.getMonth() + 1)
+    const endMonth = new Date(nextMonth)
+    endMonth.setDate(endMonth.getDate() + 7)
+    const trip = buildTrip({
+      id: 'trip-1',
+      trip_code: 'future-trip-Ab1234',
+      start_date: nextMonth.toISOString().slice(0, 10),
+      end_date: endMonth.toISOString().slice(0, 10),
+    })
+    mockTrips.trips = [trip]
+    vi.mocked(getActiveTripId).mockReturnValue('trip-1')
+
+    render(
+      <MemoryRouter>
+        <ConditionalHomePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('skips auto-redirect for unauthenticated users', async () => {

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -42,7 +42,18 @@ export function ConditionalHomePage() {
     if (activeTripId) {
       const activeTrip = trips.find(t => t.id === activeTripId)
       if (activeTrip) {
-        navigate(`/t/${activeTrip.trip_code}/quick`, { replace: true })
+        // Only redirect for trips happening right now (today within date range).
+        // getActiveTripId also returns upcoming trips — don't redirect for those,
+        // it's confusing when the trip is months away.
+        const today = new Date()
+        today.setHours(0, 0, 0, 0)
+        const start = new Date(activeTrip.start_date)
+        const end = new Date(activeTrip.end_date)
+        start.setHours(0, 0, 0, 0)
+        end.setHours(23, 59, 59, 999)
+        if (today >= start && today <= end) {
+          navigate(`/t/${activeTrip.trip_code}/quick`, { replace: true })
+        }
       }
     }
   }, [isMobile, tripsLoading, user, trips, navigate, fromTrip])


### PR DESCRIPTION
## Summary
- `ConditionalHomePage` previously redirected mobile users to the nearest upcoming trip (via `getActiveTripId` fallback), even months in the future
- Now adds a date-range check: only redirects when today falls within the trip's `start_date..end_date`
- `getActiveTripId` itself is unchanged — home page card highlighting still works for upcoming trips

## Test plan
- [x] New test: does not redirect for upcoming (future) trips
- [x] Existing test updated: redirect test uses dates that include today
- [x] All 156 tests pass, type-check clean
- [ ] Manual: refresh home page on mobile with no active trip — stays on home page
- [ ] Manual: refresh home page on mobile during an active trip — redirects to quick view

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)