### PR TITLE
docs: update CLAUDE.md and PLAN.md with PRs #419–#445

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Family Trip Cost Splitter — A mobile-first web application for splitting costs
 - Auth: Supabase Auth (Google OAuth supported)
 - Observability: Grafana Cloud (Loki logs + OTLP metrics) via `log-proxy` Edge Function
 - Deployment: Cloudflare Pages
-- Tests: Vitest + Testing Library (145 tests)
+- Tests: Vitest + Testing Library (155 tests)
 
 ---
 
@@ -73,6 +73,10 @@ git branch -d fix/description
 - `enable_shopping BOOLEAN` — feature toggle
 - `enable_activities BOOLEAN` — feature toggle (migration 018)
 - `default_split_all BOOLEAN DEFAULT true` — auto-select all participants when adding expense
+
+### RLS policies (migration 026, updated 033)
+- `trips`: SELECT open, INSERT auth-only, UPDATE/DELETE creator-only. Migration 033 added admin UUID delete policy.
+- Other tables: standard auth-based policies
 
 ### Newer tables
 - `user_profiles` — `bank_account_holder`, `bank_iban` (migration 008/012)
@@ -377,14 +381,50 @@ and the user-friendly error message will never be shown.
 
 **Supabase Edge Functions:** `log-proxy`, `create-github-issue`
 
+**Demo trip:** `livigno-2025` trip code, seeded via `scripts/seed-demo-trip.ts`. "Try a demo" link on home page navigates to `/t/livigno-2025` (uses `TripModeRedirect`).
+
+**Scripts:** `scripts/audit-trip-balances.ts` (8-check balance integrity audit for production trips), `scripts/seed-demo-trip.ts` (idempotent demo data seeder)
+
 **Running migrations:** Apply SQL files in `supabase/migrations/` in order against the Supabase project.
+
+---
+
+## PWA (Progressive Web App)
+
+The app can be installed as a PWA ("Add to Home Screen"). Three layers ensure it always launches to `/` (the home page), not whatever deep link was active at install time.
+
+### Manifest (`public/manifest.webmanifest`)
+
+Standard PWA manifest: `start_url: "/"`, `scope: "/"`, `display: "standalone"`, theme color `#e8613a`. Icons: 16px, 32px, 180px (apple-touch-icon), 512px. Referenced in `index.html` `<head>`.
+
+### Service Worker (`public/sw.js`)
+
+Minimal SW focused on one job: intercept home screen launches into `/t/...` deep links and redirect to `/`. Uses `sec-fetch-dest: document` + no-referrer heuristic to detect standalone launches. `skipWaiting()` + `clients.claim()` for immediate activation.
+
+Registered via inline `<script>` in `index.html` (not via Vite — must be at `/sw.js`).
+
+### Client-Side Guard (`src/main.tsx`)
+
+Fallback for when the SW doesn't fire (common on iOS). Before `ReactDOM.createRoot`, checks `navigator.standalone` (iOS) or `display-mode: standalone` media query. If standalone + pathname starts with `/t/`, calls `window.location.replace('/')` — React never renders the wrong route.
+
+### Smart Install Guide (`src/components/InstallGuide.tsx`)
+
+`usePWAInstall` hook (`src/hooks/usePWAInstall.ts`) detects mobile, standalone mode, and engagement (2+ visits via localStorage counter). Two variants:
+- **`variant="banner"`** — shown on `HomePage` for engaged mobile users who haven't installed yet; dismissible
+- **`variant="settings"`** — always available in `ManageTripPage`
+
+Platform-specific instructions (iOS: Share → Add to Home Screen; Android: menu → Add to Home screen).
+
+### iOS `start_url` Limitation
+
+iOS Safari ignores `manifest.start_url` and saves whatever URL was in the address bar at install time. All three layers (manifest, SW, client guard) are needed because iOS is inconsistent about which defense fires across versions.
 
 ---
 
 ## Testing
 
 ### Unit Tests
-Vitest + Testing Library. Run with `npm test`. 145 tests covering contexts, hooks, and key pages. Test files co-located with source (`*.test.tsx`). Use factories in `src/test/factories.ts` to build test data.
+Vitest + Testing Library. Run with `npm test`. 155 tests covering contexts, hooks, and key pages. Test files co-located with source (`*.test.tsx`). Use factories in `src/test/factories.ts` to build test data.
 
 ### E2E Smoke Tests (Playwright)
 26 automated tests: 13 routes × 2 viewports (mobile 375×812, desktop 1280×720). Supabase fully mocked via `page.route()`. Run with `npm run test:e2e` or `npm run test:e2e:ui`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 # PLAN.md — Spl1t Feature Planning Document
 
 > **Living document.** Update at the start and end of every session.
-> Last updated: 2026-02-25 (Phases 1–7 ✅; family refactor Phases 1–4 ✅ COMPLETE)
+> Last updated: 2026-03-01 (Phases 1–7 ✅; family refactor Phases 1–4 ✅ COMPLETE; PWA ✅)
 
 ---
 
@@ -19,7 +19,7 @@
 | Auth | Supabase Auth (Google OAuth, implicit flow) |
 | Observability | Grafana Cloud — Loki (logs) + OTLP (metrics) via `log-proxy` |
 | Deployment | Cloudflare Pages |
-| Tests | Vitest + Testing Library (145 unit tests, all passing), Playwright (26 E2E smoke tests) |
+| Tests | Vitest + Testing Library (155 unit tests, all passing), Playwright (26 E2E smoke tests) |
 | AI SDK | `@anthropic-ai/sdk@0.32.1` — **already installed, not yet used** |
 | PDF Export | jsPDF + jspdf-autotable |
 | Maps | Leaflet + react-leaflet |
@@ -748,6 +748,13 @@ Replace ad-hoc loading/error patterns with the shared components from 7a.
 | 2026-02-25 | iOS keyboard test checklist | Added manual iOS keyboard test checklist to CLAUDE.md Testing section — physical iPhone test protocol for PRs touching bottom sheets or `useKeyboardHeight`. Added numpad pitfall row to Common Pitfalls table. (PR #401) |
 | 2026-02-26 | Wizard Step 1 keyboard fix | PR #409: MobileWizard sheet now uses top-based positioning (`top: viewportOffset`, `bottom: 'auto'`) instead of `bottom: keyboardHeight - viewportOffset`. `window.innerHeight` is unreliable on iOS Safari for computing fixed positioning offsets — caused the Next button to float in dead space above the keyboard. New approach uses `visualViewport.offsetTop` and `visualViewport.height` directly. Closes #393. |
 | 2026-02-26 | Within-group balances fix + relocation | PR #415: Fixed `calculateWithinGroupBalances` calculation bug — was skipping outsider-paid expenses entirely (members' shares not counted). Now includes ALL expenses for share calculation but only credits group-member payers; balances won't sum to zero (deficit = outsider-covered portion). Added `settlements` parameter for within-group settlement tracking. Relocated UI: within-group breakdown now shown in `CostBreakdownDialog` (Dashboard click-through on group entities, with paid/share per member) and `QuickGroupMembersSheet` (Quick mode expand). Removed toggle + card from `SettlementsPage`. 2 new tests (settlement between members, outsider settlement ignored), 1 updated test. 152/152 tests, type-check clean. PR #417: CLAUDE.md docs update. |
+| 2026-02-26 | Within-group balances iteration | 5 follow-up PRs refining within-group balance calculation and UI. **PR #419**: reverted outsider-paid expense inclusion so balances sum to zero; removed paid/share detail from CostBreakdownDialog. **PR #421**: re-added per-member paid/share detail, within-group settlement list with arrow notation, group total summary. **PR #422**: inlined paid/share on same line as balance, renamed "Paid" to "Covered", added "Group paid" row. **PR #427**: made per-member totalPaid/totalShare sum to group-level totals from `calculateBalances()` — payer credited with full expense amount; settlements applied to balance only. **PR #429**: changed within-group balance to use internal-only money flows while keeping totalPaid/totalShare as full amounts. |
+| 2026-02-26 | BalanceCard improvements | 3 PRs improving the balance summary cards. **PR #423**: renamed "Total paid" to "Out of pocket", added `totalSettled` field to `ParticipantBalance`, added "Settled" row showing net settlements. **PR #424**: reordered breakdown to "Out of pocket / Share / Settled", replaced signed values with natural language ("sent"/"received"). **PR #425**: always show "Settled" row (dash when zero) for consistent card heights in 2-column dashboard grid. |
+| 2026-02-26 | Demo trip + home page | **PR #420**: "Try a demo" button wrapped in block div to drop below main CTA. **PR #430**: `scripts/seed-demo-trip.ts` — idempotent seeder for "Livigno Ski Trip 2025" with 6 participants (2 couples with wallet_groups + 2 solo), 13 expenses totaling EUR 4,004.80. **PR #431**: updated `DEMO_TRIP_CODE` to `livigno-2025`. **PR #433**: demo link navigates to `/t/livigno-2025` (TripModeRedirect) instead of hard-coding `/quick`. |
+| 2026-02-27 | Expenses page UX | **PR #432**: "Paid by" participant dropdown filter on ExpensesPage (adults only), 3-column filter grid on desktop. **PR #435**: Tag icon added to Category filter label for consistent icon+text alignment across all filter labels. |
+| 2026-02-27 | Bug fixes + security | **PR #436**: gate trip deletion to creator or admin — hidden Danger Zone from unauthorized users; migration 033 adds admin UUID delete policy. **PR #437**: pie chart all-black fix — `CATEGORY_COLORS` key casing mismatch; added missing `groceries`/`drinks` colors + fallback palette. **PR #438**: final within-group balance fix — apply ALL settlements involving at least one group member (not just internal); balances no longer sum to zero; remainder = family's external balance. **PR #439**: `scripts/audit-trip-balances.ts` — 8-check balance integrity audit, validated against production data. |
+| 2026-03-01 | Home page UX | PR #441: bottom nav hidden on home page (`{tripCode && ...}`); auto-redirect restricted to authenticated users only — prevents shared-link trips from causing unwanted redirects for unauthenticated visitors. |
+| 2026-03-01 | PWA install experience | **PR #442**: smart install guide — `InstallGuide` component with `usePWAInstall` hook (detects mobile, standalone, engagement via 2+ visit counter). Banner variant on HomePage for engaged mobile users; settings variant in ManageTripPage. Platform-specific iOS/Android instructions. **PR #443**: moved custom skills (gh-issue-triage, pr-branch-maintenance) from user-level to project-level `.claude/skills/`. **PR #444**: PWA manifest + service worker + client guard — three-layer fix for iOS `start_url` ignore. `manifest.webmanifest` (`start_url: "/"`), `public/sw.js` (intercepts standalone deep links → redirect to `/`), `main.tsx` guard (standalone + trip route → `window.location.replace('/')`). **PR #445**: admin nav shield icon in header for admin user in standalone PWA mode. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Record all work since last documented session (2026-02-26) across CLAUDE.md and PLAN.md
- **CLAUDE.md**: new PWA section (manifest, SW, client guard, install guide), test count 145→155, migration 033, demo trip + scripts, BalanceCard terminology
- **PLAN.md**: 7 new session log entries covering within-group balances iteration, BalanceCard improvements, demo trip, expenses page UX, bug fixes/security, home page UX, and PWA install experience
- **MEMORY.md** (auto-memory): PWA facts, BalanceCard terminology, demo trip, migration 033, pie chart colors, updated ConditionalHomePage redirect behavior

## Test plan

- [ ] Docs-only change — no code modified
- [ ] type-check passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)