### PR TITLE
fix: add back arrow to Full mode header — closes #448

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useState } from 'react'
 import {
   Home, DollarSign, CreditCard, CalendarDays,
-  ShoppingCart, BarChart3, Settings2, MoreHorizontal, ScanLine, Settings, Zap, Shield
+  ShoppingCart, BarChart3, Settings2, MoreHorizontal, ScanLine, Settings, Zap, Shield, ArrowLeft
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -181,7 +181,8 @@ export function Layout() {
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">
               {currentTrip ? (
-                <Link to="/" state={{ fromTrip: true }} className="flex-1 min-w-0">
+                <Link to="/" state={{ fromTrip: true }} className="flex items-center gap-3 flex-1 min-w-0">
+                  <ArrowLeft size={20} className={`shrink-0 ${onGradient ? 'text-white/80' : 'text-muted-foreground'}`} />
                   <h1
                     className={`font-bold text-lg truncate ${onGradient ? 'text-white' : 'text-foreground'}`}
                     style={onGradient ? { textShadow: '0 1px 4px rgba(0,0,0,0.9)' } : undefined}


### PR DESCRIPTION
## Summary
- Full mode header now shows a ← back arrow before the trip name, matching the Quick mode header
- Arrow uses the same `ArrowLeft` icon (size 20) and gradient-aware styling as QuickLayout
- Both modes now navigate to home with `fromTrip` state on tap

## Test plan
- [x] Type-check clean, all 156 tests pass
- [ ] Full mode in-trip: back arrow visible next to trip name
- [ ] Tap arrow: navigates to home page
- [ ] Quick mode: unchanged, still has back arrow
- [ ] Home page (no trip): no arrow, just logo

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)