### PR TITLE
docs: update CLAUDE.md and PLAN.md with PRs #449–#453

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Family Trip Cost Splitter — A mobile-first web application for splitting costs
 - Auth: Supabase Auth (Google OAuth supported)
 - Observability: Grafana Cloud (Loki logs + OTLP metrics) via `log-proxy` Edge Function
 - Deployment: Cloudflare Pages
-- Tests: Vitest + Testing Library (155 tests)
+- Tests: Vitest + Testing Library (156 tests)
 
 ---
 
@@ -142,7 +142,7 @@ Mode is stored per-user in `user_preferences.preferred_mode` and synced from Sup
 
 **Key behaviour:**
 - **Unified home**: `HomePage` (`src/pages/HomePage.tsx`) renders at `/` for all users. Both modes see the same greeting, scan CTA, and trip cards. There is no separate Quick home page.
-- `ConditionalHomePage` wraps `HomePage` — on **mobile viewports (< 768 px) with an active trip**, auto-redirects to `/t/:code/quick`. Otherwise always renders `HomePage`. When navigated to with `location.state.fromTrip` (set by back arrows and home links), the redirect is skipped once so the user can reach the home page from within a trip.
+- `ConditionalHomePage` wraps `HomePage` — on **mobile viewports (< 768 px) for authenticated users with a trip happening now** (today within start_date..end_date), auto-redirects to `/t/:code/quick`. Otherwise always renders `HomePage`. When navigated to with `location.state.fromTrip` (set by back arrows and home links), the redirect is skipped once so the user can reach the home page from within a trip.
 - `/quick` redirects to `/` (backward compat).
 - Trip card clicks navigate to Quick or Full based on stored mode preference.
 - `ModeToggle` derives `effectiveMode` from the **current pathname** (contains `/quick`?), not solely from the stored pref. Only navigates when inside a trip; on the home page it just updates the preference.
@@ -196,8 +196,8 @@ All trip-scoped routes are wrapped in `TripRouteGuard`. Full-mode routes render 
 
 Both layouts use the same responsive header pattern:
 
-- **Mobile (in-trip, not sub-page):** Two-row header. Row 1: back arrow + trip name + avatar. Row 2: `grid-cols-3` action pills (Scan / Manage / mode toggle). Row 2 is `lg:hidden`. Back arrows and home links pass `state: { fromTrip: true }` to prevent `ConditionalHomePage` redirect loop.
-- **Desktop (in-trip):** Single-row header. Trip name (clickable `<Link>` to home with `fromTrip` state) on left. Scan button + `ModeToggle` + avatar on right (`hidden lg:flex`).
+- **Mobile (in-trip, not sub-page):** Two-row header. Row 1: back arrow + trip name + avatar. Row 2: `grid-cols-3` action pills (Scan / Manage / mode toggle). Row 2 is `lg:hidden`. Back arrows and home links pass `state: { fromTrip: true }` to prevent `ConditionalHomePage` redirect loop. Both Full and Quick mode headers show the back arrow (← `ArrowLeft` size 20) before the trip name.
+- **Desktop (in-trip):** Single-row header. Back arrow + trip name (clickable `<Link>` to home with `fromTrip` state) on left. Scan button + `ModeToggle` + avatar on right (`hidden lg:flex`).
 - **Home page:** Single-row. Logo on left, avatar on right. No scan/toggle (the page has its own scan CTA).
 
 Header container: `max-w-lg lg:max-w-7xl mx-auto px-4 lg:px-8`. Main content padding: `pt-[108px] lg:pt-16` (two-row) or `pt-16` (single-row).
@@ -414,6 +414,10 @@ Fallback for when the SW doesn't fire (common on iOS). Before `ReactDOM.createRo
 - **`variant="settings"`** — always available in `ManageTripPage`
 
 Platform-specific instructions (iOS: Share → Add to Home Screen; Android: menu → Add to Home screen).
+
+### Admin in PWA
+
+Shield icon button in both Layout and QuickLayout headers — visible to admin user in both browser and standalone PWA mode, navigates to `/admin/all-trips`. In standalone PWA mode, `AdminAllTripsPage` uses `navigate()` instead of `window.open(_blank)` to load trips (new browser contexts in standalone trigger the SW/client guard redirect). Mobile-responsive: card layout at < lg, table at >= lg.
 
 ### iOS `start_url` Limitation
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,7 +19,7 @@
 | Auth | Supabase Auth (Google OAuth, implicit flow) |
 | Observability | Grafana Cloud — Loki (logs) + OTLP (metrics) via `log-proxy` |
 | Deployment | Cloudflare Pages |
-| Tests | Vitest + Testing Library (155 unit tests, all passing), Playwright (26 E2E smoke tests) |
+| Tests | Vitest + Testing Library (156 unit tests, all passing), Playwright (26 E2E smoke tests) |
 | AI SDK | `@anthropic-ai/sdk@0.32.1` — **already installed, not yet used** |
 | PDF Export | jsPDF + jspdf-autotable |
 | Maps | Leaflet + react-leaflet |
@@ -755,6 +755,8 @@ Replace ad-hoc loading/error patterns with the shared components from 7a.
 | 2026-02-27 | Bug fixes + security | **PR #436**: gate trip deletion to creator or admin — hidden Danger Zone from unauthorized users; migration 033 adds admin UUID delete policy. **PR #437**: pie chart all-black fix — `CATEGORY_COLORS` key casing mismatch; added missing `groceries`/`drinks` colors + fallback palette. **PR #438**: final within-group balance fix — apply ALL settlements involving at least one group member (not just internal); balances no longer sum to zero; remainder = family's external balance. **PR #439**: `scripts/audit-trip-balances.ts` — 8-check balance integrity audit, validated against production data. |
 | 2026-03-01 | Home page UX | PR #441: bottom nav hidden on home page (`{tripCode && ...}`); auto-redirect restricted to authenticated users only — prevents shared-link trips from causing unwanted redirects for unauthenticated visitors. |
 | 2026-03-01 | PWA install experience | **PR #442**: smart install guide — `InstallGuide` component with `usePWAInstall` hook (detects mobile, standalone, engagement via 2+ visit counter). Banner variant on HomePage for engaged mobile users; settings variant in ManageTripPage. Platform-specific iOS/Android instructions. **PR #443**: moved custom skills (gh-issue-triage, pr-branch-maintenance) from user-level to project-level `.claude/skills/`. **PR #444**: PWA manifest + service worker + client guard — three-layer fix for iOS `start_url` ignore. `manifest.webmanifest` (`start_url: "/"`), `public/sw.js` (intercepts standalone deep links → redirect to `/`), `main.tsx` guard (standalone + trip route → `window.location.replace('/')`). **PR #445**: admin nav shield icon in header for admin user in standalone PWA mode. |
+| 2026-03-01 | Redirect + header fixes | **PR #449**: `ConditionalHomePage` auto-redirect now requires trip to be happening today (start_date ≤ today ≤ end_date) — no more redirecting to future trips months away. New test added (156 total). **PR #451**: added doc update step (step 7) to `gh-issue-triage` skill. **PR #452**: Full mode header now shows ← back arrow before trip name, matching Quick mode; both navigate home with `fromTrip` state. |
+| 2026-03-01 | Admin page fixes | PR #453: 3 fixes. (1) Admin Shield button visible in both browser and PWA (removed standalone-only check). (2) `AdminAllTripsPage` uses `navigate()` in standalone mode instead of `window.open(_blank)` — new browser contexts in PWA trigger SW/client guard redirect to `/`. (3) Admin page mobile-responsive: card layout at < lg, table at >= lg — no horizontal scrolling at 375px. |
 
 ---
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: test count 155→156, ConditionalHomePage date-range redirect, Full mode back arrow in header, admin PWA section
- **PLAN.md**: 2 new session log entries (redirect+header fixes, admin page fixes)

## Test plan

- [ ] Docs-only — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)