### PR TITLE
chore: temporarily show birthday easter egg to admin for verification

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -61,7 +61,7 @@ export function HomePage() {
     const d = today.getDate()
     const y = today.getFullYear()
     const inWindow = y === 2026 && m === 2 && (d === 1 || d === 2)
-    if (inWindow && user.id === '8f60570a-720f-417d-b093-e13a2c260001') {
+    if (inWindow && (user.id === '8f60570a-720f-417d-b093-e13a2c260001' || user.id === '4d07e4a8-9630-4692-93c8-c97896e6fc4d')) {
       setBirthdayVisible(true)
       const timer = setTimeout(() => setBirthdayVisible(false), 6000)
       return () => clearTimeout(timer)


### PR DESCRIPTION
## Summary
- Adds admin UUID to the birthday easter egg check so it can be verified on production
- Date gate still active (March 1–2 only)
- Will remove admin UUID in a follow-up once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)