### PR TITLE
fix: move birthday easter egg to App.tsx so it shows on every route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { GoogleOAuthProvider } from '@react-oauth/google'
+import { motion, AnimatePresence } from 'framer-motion'
 import { AppRoutes } from './routes'
 import { TripProvider } from './contexts/TripContext'
-import { AuthProvider } from './contexts/AuthContext'
+import { AuthProvider, useAuth } from './contexts/AuthContext'
 import { UserPreferencesProvider } from './contexts/UserPreferencesContext'
 import { SessionHealthGate } from './components/SessionHealthGate'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -31,6 +32,48 @@ function UnhandledErrorToaster() {
   return null
 }
 
+/** Birthday easter egg — self-removing after 2026-03-02 */
+function BirthdayGreeting() {
+  const { user } = useAuth()
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    const today = new Date()
+    const y = today.getFullYear()
+    const m = today.getMonth()
+    const d = today.getDate()
+    const inWindow = y === 2026 && m === 2 && (d === 1 || d === 2)
+    if (inWindow && (user.id === '8f60570a-720f-417d-b093-e13a2c260001' || user.id === '4d07e4a8-9630-4692-93c8-c97896e6fc4d')) {
+      setVisible(true)
+      const timer = setTimeout(() => setVisible(false), 6000)
+      return () => clearTimeout(timer)
+    }
+  }, [user])
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          transition={{ type: 'spring', damping: 20, stiffness: 300 }}
+          onClick={() => setVisible(false)}
+          className="fixed bottom-6 left-4 right-4 z-50 mx-auto max-w-sm cursor-pointer rounded-2xl bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 p-5 shadow-lg"
+        >
+          <p className="text-2xl mb-1">🎂</p>
+          <p className="font-semibold text-amber-900 text-base">Palju õnne, Raido!</p>
+          <p className="text-amber-700 text-sm mt-1 leading-relaxed">
+            Sünnipäeva puhul paneme kõik tänased kulud teistele :D
+          </p>
+          <p className="text-amber-600 text-xs mt-2 text-right italic">— Kristjan</p>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
 function App() {
   return (
     <GoogleOAuthProvider clientId={googleClientId}>
@@ -41,6 +84,7 @@ function App() {
               <TripProvider>
                 <UserPreferencesProvider>
                   <UnhandledErrorToaster />
+                  <BirthdayGreeting />
                   <AppRoutes />
                 </UserPreferencesProvider>
               </TripProvider>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,7 +20,7 @@ import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { useMyTripBalances } from '@/hooks/useMyTripBalances'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion } from 'framer-motion'
 
 const DEMO_TRIP_CODE = 'livigno-2025'
 
@@ -37,7 +37,6 @@ export function HomePage() {
   const [scanContextOpen, setScanContextOpen] = useState(false)
   const [scanCreateOpen, setScanCreateOpen] = useState(false)
   const { shouldShowPrompt, dismiss: dismissInstall, incrementVisit } = usePWAInstall()
-  const [birthdayVisible, setBirthdayVisible] = useState(false)
 
   const isAuthenticated = !!user
   const loading = isAuthenticated && (balancesLoading || tripsLoading)
@@ -52,21 +51,6 @@ export function HomePage() {
   useEffect(() => {
     incrementVisit()
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Birthday easter egg — self-removing after 2026-03-02
-  useEffect(() => {
-    if (!user) return
-    const today = new Date()
-    const m = today.getMonth() // 0-indexed
-    const d = today.getDate()
-    const y = today.getFullYear()
-    const inWindow = y === 2026 && m === 2 && (d === 1 || d === 2)
-    if (inWindow && (user.id === '8f60570a-720f-417d-b093-e13a2c260001' || user.id === '4d07e4a8-9630-4692-93c8-c97896e6fc4d')) {
-      setBirthdayVisible(true)
-      const timer = setTimeout(() => setBirthdayVisible(false), 6000)
-      return () => clearTimeout(timer)
-    }
-  }, [user])
 
   const visibleTrips = tripBalances.filter(tb => !hiddenCodes.has(tb.trip.trip_code))
   const hiddenTrips = tripBalances.filter(tb => hiddenCodes.has(tb.trip.trip_code))
@@ -412,26 +396,6 @@ export function HomePage() {
           </div>
         )}
       </div>
-
-      <AnimatePresence>
-        {birthdayVisible && (
-          <motion.div
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 20 }}
-            transition={{ type: 'spring', damping: 20, stiffness: 300 }}
-            onClick={() => setBirthdayVisible(false)}
-            className="fixed bottom-6 left-4 right-4 z-50 mx-auto max-w-sm cursor-pointer rounded-2xl bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 p-5 shadow-lg"
-          >
-            <p className="text-2xl mb-1">🎂</p>
-            <p className="font-semibold text-amber-900 text-base">Palju õnne, Raido!</p>
-            <p className="text-amber-700 text-sm mt-1 leading-relaxed">
-              Sünnipäeva puhul paneme kõik tänased kulud teistele :D
-            </p>
-            <p className="text-amber-600 text-xs mt-2 text-right italic">— Kristjan</p>
-          </motion.div>
-        )}
-      </AnimatePresence>
 
       <QuickCreateSheet open={createOpen} onOpenChange={setCreateOpen} />
       <QuickScanContextSheet


### PR DESCRIPTION
## Summary
- Moves the birthday greeting from `HomePage.tsx` to `App.tsx`
- Previously it only showed on the home page, but `ConditionalHomePage` auto-redirects mobile users with active trips to Quick mode — they'd never see it
- Now renders at the app root level, so it appears regardless of which route loads first

## Test plan
- [ ] `npm run type-check` passes
- [ ] Greeting appears when landing on any route (home, quick, dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)