### PR TITLE
fix: PWA bottom nav safe-area padding for iPhone home indicator — closes #457

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Spl1t" />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -265,7 +265,7 @@ export function Layout() {
       </header>
 
       {/* Main content */}
-      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
         <ParticipantProvider>
           <ExpenseProvider>
             <SettlementProvider>
@@ -287,7 +287,7 @@ export function Layout() {
       </main>
 
       {/* Bottom navigation (mobile) — only shown inside a trip */}
-      {tripCode && <nav className="fixed bottom-0 left-0 right-0 bg-card border-t border-border soft-shadow-lg lg:hidden z-40">
+      {tripCode && <nav className="fixed bottom-0 left-0 right-0 bg-card border-t border-border soft-shadow-lg lg:hidden z-40 pwa-safe-bottom">
         <div className="flex justify-around items-center h-16">
           {mobileNavItems.map((item) => {
             const Icon = iconMap[item.label as keyof typeof iconMap]

--- a/src/index.css
+++ b/src/index.css
@@ -182,4 +182,15 @@
       scroll-margin-bottom: 120px;
     }
   }
+
+  /* PWA standalone: add safe-area padding to bottom nav for iPhone home indicator */
+  @media (display-mode: standalone) {
+    .pwa-safe-bottom {
+      padding-bottom: env(safe-area-inset-bottom, 0px);
+    }
+
+    .pwa-safe-bottom-margin {
+      margin-bottom: env(safe-area-inset-bottom, 0px);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- On iPhone in PWA standalone mode, the bottom tab bar overlaps with the home indicator
- Fix applies **only in standalone PWA mode** — regular browser is unchanged
- `viewport-fit=cover` on viewport meta enables `env(safe-area-inset-bottom)` values
- New `pwa-safe-bottom` CSS utility scoped to `@media (display-mode: standalone)` — adds `padding-bottom: env(safe-area-inset-bottom)` to bottom nav
- Main content also gets matching `margin-bottom` so content isn't hidden behind the taller nav

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 156/156 pass
- [ ] Regular browser on iPhone: bottom nav unchanged (no extra padding)
- [ ] PWA standalone on iPhone: bottom nav has safe-area padding above home indicator
- [ ] Desktop: no visual change

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)