### PR TITLE
fix: add hint that quick history shows only your expenses

### DIFF
--- a/src/components/quick/QuickHistorySheet.tsx
+++ b/src/components/quick/QuickHistorySheet.tsx
@@ -95,6 +95,7 @@ export function QuickHistorySheet({ open, onOpenChange }: QuickHistorySheetProps
           </button>
         ))}
       </div>
+      <p className="text-xs text-muted-foreground mb-4">Showing only expenses you're included in.</p>
 
       {/* Transaction list */}
       {loading ? (

--- a/src/pages/QuickHistoryPage.tsx
+++ b/src/pages/QuickHistoryPage.tsx
@@ -78,6 +78,7 @@ export function QuickHistoryPage() {
           </button>
         ))}
       </div>
+      <p className="text-xs text-muted-foreground mb-4">Showing only expenses you're included in.</p>
 
       {/* Transaction list */}
       {loading ? (


### PR DESCRIPTION
## Summary
- Adds a small muted hint below the filter pills: "Showing only expenses you're included in."
- Applied to both `QuickHistorySheet` (overlay) and `QuickHistoryPage` (full page)
- Clarifies that the list is filtered to the user's expenses, not all trip expenses

## Test plan
- [ ] Open Quick mode → View history → hint visible below filter pills
- [ ] Same hint visible on `/t/:code/quick/history` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)