### PR TITLE
feat: email optional hint + "people you've tripped with" autocomplete

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -3,17 +3,12 @@ import { Plus, UserPlus, X, Users, Smartphone } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useTripContacts, TripContact } from '@/hooks/useTripContacts'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { logger } from '@/lib/logger'
 import { withTimeout } from '@/lib/fetchWithTimeout'
-import { useAbortController } from '@/hooks/useAbortController'
-
-interface RecentPerson {
-  name: string
-  email: string | null
-}
 
 interface QuickParticipantPickerProps {
   tripId: string
@@ -24,9 +19,8 @@ interface QuickParticipantPickerProps {
 export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickParticipantPickerProps) {
   const { user, userProfile } = useAuth()
   const { participants, createParticipant } = useParticipantContext()
-  const { newSignal, cancel } = useAbortController()
+  const { contacts } = useTripContacts(tripId)
 
-  const [recentPeople, setRecentPeople] = useState<RecentPerson[]>([])
   const [addedNames, setAddedNames] = useState<string[]>([])
   const [supportsContacts, setSupportsContacts] = useState(false)
 
@@ -40,59 +34,6 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
   useEffect(() => {
     setSupportsContacts('contacts' in navigator && typeof (navigator as any).contacts?.select === 'function')
   }, [])
-
-  // Fetch recent people from past trips by this user
-  useEffect(() => {
-    if (!user) return
-
-    const signal = newSignal()
-
-    const fetchRecent = async () => {
-      try {
-        // Fetch participants from trips created_by this user, excluding self
-        const { data, error: fetchError } = await withTimeout(
-          supabase
-            .from('participants')
-            .select('name, email, trips!inner(created_by)')
-            .eq('trips.created_by', user.id)
-            .is('user_id', null)  // exclude self (linked participants)
-            .neq('user_id', user.id)
-            .order('created_at', { ascending: false })
-            .limit(50)
-            .abortSignal(signal),
-          15000,
-          'Loading recent people timed out.'
-        )
-
-        if (signal.aborted) return
-
-        if (fetchError) {
-          logger.warn('Failed to fetch recent people', { error: fetchError.message })
-          return
-        }
-
-        // Deduplicate by email (preferred) or name
-        const seen = new Set<string>()
-        const deduped: RecentPerson[] = []
-        for (const row of (data ?? []) as any[]) {
-          const key = row.email?.toLowerCase() ?? row.name.toLowerCase()
-          if (!seen.has(key)) {
-            seen.add(key)
-            deduped.push({ name: row.name, email: row.email ?? null })
-          }
-          if (deduped.length >= 20) break
-        }
-
-        setRecentPeople(deduped)
-      } catch (err) {
-        if (signal.aborted) return
-        logger.warn('Unhandled error fetching recent people', { error: String(err) })
-      }
-    }
-
-    fetchRecent()
-    return cancel
-  }, [user?.id])
 
   const organiserName = userProfile?.display_name || user?.email?.split('@')[0] || 'Organiser'
 
@@ -132,19 +73,28 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
     }
   }
 
-  const addPerson = async (personName: string, personEmail: string | null) => {
+  const addPerson = async (personName: string, personEmail: string | null, personUserId?: string | null) => {
     const emailLower = personEmail?.trim().toLowerCase() ?? null
     if (emailLower) {
       const duplicate = participants.some(p => p.email?.toLowerCase() === emailLower)
       if (duplicate) return // silently skip duplicate
     }
 
-    const newParticipant = await createParticipant({
+    const input = {
       trip_id: tripId,
       name: personName.trim(),
       is_adult: true,
       email: emailLower || null,
-    })
+      ...(personUserId ? { user_id: personUserId } : {}),
+    }
+
+    let newParticipant = await createParticipant(input)
+
+    // If insert failed and we had a user_id, retry without it (unique constraint conflict)
+    if (!newParticipant && personUserId) {
+      const { user_id: _, ...inputWithoutUserId } = input
+      newParticipant = await createParticipant(inputWithoutUserId)
+    }
 
     if (newParticipant) {
       setAddedNames(prev => [...prev, personName.trim()])
@@ -154,8 +104,8 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
     }
   }
 
-  const handleAddRecent = async (person: RecentPerson) => {
-    await addPerson(person.name, person.email)
+  const handleAddRecent = async (contact: TripContact) => {
+    await addPerson(contact.name, contact.email, contact.user_id)
   }
 
   const handleAddFromContacts = async () => {
@@ -199,10 +149,10 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
     }
   }
 
-  const isAdded = (person: RecentPerson) =>
-    addedNames.includes(person.name) ||
-    participants.some(p => p.name === person.name && (
-      !person.email || p.email?.toLowerCase() === person.email?.toLowerCase()
+  const isAdded = (contact: TripContact) =>
+    addedNames.includes(contact.name) ||
+    participants.some(p => p.name === contact.name && (
+      !contact.email || p.email?.toLowerCase() === contact.email?.toLowerCase()
     ))
 
   const currentParticipants = participants.filter(p => p.trip_id === tripId)
@@ -223,20 +173,20 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
         </div>
       )}
 
-      {/* Section A: Recent people */}
-      {recentPeople.length > 0 && (
+      {/* Section A: People you've tripped with */}
+      {contacts.length > 0 && (
         <div className="space-y-2">
           <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
             <Users size={14} />
             Recent
           </div>
           <div className="flex flex-wrap gap-2">
-            {recentPeople.map((person, i) => {
-              const added = isAdded(person)
+            {contacts.slice(0, 20).map((contact, i) => {
+              const added = isAdded(contact)
               return (
                 <button
                   key={i}
-                  onClick={() => !added && handleAddRecent(person)}
+                  onClick={() => !added && handleAddRecent(contact)}
                   disabled={added}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm transition-colors ${
                     added
@@ -245,7 +195,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
                   }`}
                 >
                   {added ? null : <Plus size={12} />}
-                  {person.name}
+                  {contact.name}
                 </button>
               )
             })}
@@ -302,6 +252,9 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
               onChange={e => setEmail(e.target.value)}
               autoComplete="section-participant email"
             />
+            <p className="text-xs text-muted-foreground mt-1">
+              Add now or let them link themselves via the trip link
+            </p>
           </div>
           {error && (
             <p className="text-xs text-destructive">{error}</p>

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo, FormEvent } from 'react'
+import { useState, useMemo, useRef, useEffect, useCallback, FormEvent } from 'react'
 import { motion } from 'framer-motion'
 import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useAuth } from '@/contexts/AuthContext'
+import { useTripContacts, TripContact } from '@/hooks/useTripContacts'
 import { supabase } from '@/lib/supabase'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -90,6 +91,77 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
   const [editGroupValue, setEditGroupValue] = useState('')
   const [savingGroupId, setSavingGroupId] = useState<string | null>(null)
 
+  // Autocomplete: contacts from past trips
+  const { contacts } = useTripContacts(currentTrip?.id)
+  const [suggestedUserId, setSuggestedUserId] = useState<string | null>(null)
+  const [showDropdown, setShowDropdown] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const nameInputRef = useRef<HTMLInputElement>(null)
+  const emailInputRef = useRef<HTMLInputElement>(null)
+
+  // Filtered contacts based on current name input
+  const filteredContacts = useMemo(() => {
+    if (name.trim().length < 2 || contacts.length === 0) return []
+    const query = name.toLowerCase()
+    return contacts
+      .filter(c => c.name.toLowerCase().includes(query))
+      .slice(0, 5)
+  }, [name, contacts])
+
+  // Show/hide dropdown based on filtered results
+  useEffect(() => {
+    setShowDropdown(filteredContacts.length > 0)
+    setActiveIndex(-1)
+  }, [filteredContacts.length])
+
+  // Click outside to close dropdown
+  useEffect(() => {
+    if (!showDropdown) return
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
+          nameInputRef.current && !nameInputRef.current.contains(e.target as Node)) {
+        setShowDropdown(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [showDropdown])
+
+  const handleSelectContact = useCallback((contact: TripContact) => {
+    setName(contact.name)
+    setEmail(contact.email || '')
+    setSuggestedUserId(contact.user_id)
+    setShowDropdown(false)
+    setActiveIndex(-1)
+    // Focus email field so user can review/edit
+    setTimeout(() => emailInputRef.current?.focus(), 0)
+  }, [])
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value)
+    // Clear suggested user_id when user edits the name manually
+    setSuggestedUserId(null)
+  }, [])
+
+  const handleNameKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!showDropdown || filteredContacts.length === 0) return
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex(prev => (prev < filteredContacts.length - 1 ? prev + 1 : 0))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex(prev => (prev > 0 ? prev - 1 : filteredContacts.length - 1))
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault()
+      handleSelectContact(filteredContacts[activeIndex])
+    } else if (e.key === 'Escape') {
+      setShowDropdown(false)
+      setActiveIndex(-1)
+    }
+  }, [showDropdown, filteredContacts, activeIndex, handleSelectContact])
+
   const organiserName = userProfile?.display_name || user?.email?.split('@')[0] || 'Organiser'
 
   // Existing wallet_group names for autocomplete suggestions
@@ -150,15 +222,26 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
 
     setAdding(true)
     try {
-      const newParticipant = await createParticipant({
+      const input = {
         trip_id: currentTrip.id,
         name: name.trim(),
         is_adult: isAdult,
         wallet_group: walletGroup.trim() || null,
         email: email.trim() || null,
-      })
+        ...(suggestedUserId ? { user_id: suggestedUserId } : {}),
+      }
+
+      let newParticipant = await createParticipant(input)
+
+      // If insert failed and we had a user_id, retry without it (unique constraint conflict)
+      if (!newParticipant && suggestedUserId) {
+        const { user_id: _, ...inputWithoutUserId } = input
+        newParticipant = await createParticipant(inputWithoutUserId)
+      }
+
       setName('')
       setEmail('')
+      setSuggestedUserId(null)
       // Keep walletGroup — likely adding more people to the same group
       setIsAdult(true)
 
@@ -403,22 +486,62 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
             <p className="mb-3 text-sm text-destructive">{error}</p>
           )}
           <form onSubmit={handleAdd} className="space-y-4">
-            <div className="space-y-2">
+            <div className="space-y-2 relative">
               <Label htmlFor="name">Participant Name</Label>
               <Input
+                ref={nameInputRef}
                 type="text"
                 id="name"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => handleNameChange(e.target.value)}
+                onKeyDown={handleNameKeyDown}
                 placeholder="e.g., John Doe"
                 required
                 disabled={adding}
+                autoComplete="off"
+                role="combobox"
+                aria-expanded={showDropdown}
+                aria-autocomplete="list"
+                aria-controls="contact-suggestions"
               />
+              {showDropdown && (
+                <div
+                  ref={dropdownRef}
+                  id="contact-suggestions"
+                  role="listbox"
+                  className="absolute top-full left-0 right-0 z-50 bg-popover border border-border rounded-md shadow-md mt-1 max-h-[200px] overflow-y-auto"
+                >
+                  {filteredContacts.map((contact, i) => (
+                    <button
+                      key={`${contact.email ?? contact.name}-${i}`}
+                      type="button"
+                      role="option"
+                      aria-selected={i === activeIndex}
+                      className={`w-full text-left px-3 py-2 transition-colors ${
+                        i === activeIndex ? 'bg-accent/50' : 'hover:bg-accent/30'
+                      }`}
+                      onMouseDown={(e) => {
+                        e.preventDefault() // Prevent input blur
+                        handleSelectContact(contact)
+                      }}
+                    >
+                      <div className="font-medium text-sm">{contact.name}</div>
+                      {contact.email && (
+                        <div className="text-xs text-muted-foreground">{contact.email}</div>
+                      )}
+                      {contact.user_id && (
+                        <div className="text-xs text-primary">✓ Has Spl1t account</div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional — sends invite)</span></Label>
               <Input
+                ref={emailInputRef}
                 type="email"
                 inputMode="email"
                 id="email"
@@ -427,6 +550,9 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                 placeholder="e.g., john@example.com"
                 disabled={adding}
               />
+              <p className="text-xs text-muted-foreground mt-1">
+                Add now or let them link themselves via the trip link
+              </p>
             </div>
 
             <div className="space-y-2">

--- a/src/hooks/useTripContacts.test.tsx
+++ b/src/hooks/useTripContacts.test.tsx
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useTripContacts } from './useTripContacts'
+import { buildEvent } from '@/test/factories'
+
+// --- Mocks ---
+
+const mockAuth = vi.hoisted(() => ({
+  user: null as any,
+  userProfile: null,
+  session: null,
+  loading: false,
+  signInWithGoogle: vi.fn(),
+  signOut: vi.fn(),
+  updateBankDetails: vi.fn(),
+}))
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+const mockTrips = vi.hoisted(() => ({
+  trips: [] as any[],
+  loading: false,
+  error: null,
+  getTripById: vi.fn(),
+  getTripByCode: vi.fn(),
+  ensureTripLoaded: vi.fn(),
+  createTrip: vi.fn(),
+  updateTrip: vi.fn(),
+  deleteTrip: vi.fn(),
+  refreshTrips: vi.fn(),
+}))
+vi.mock('@/contexts/TripContext', () => ({
+  useTripContext: () => mockTrips,
+}))
+
+let mockQueryResult: { data: any[] | null; error: any } = { data: [], error: null }
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}))
+vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
+
+function setupQueryChain() {
+  mockSupabase.from.mockReturnValue({
+    select: () => ({
+      in: () => ({
+        limit: () => ({
+          abortSignal: () => Promise.resolve(mockQueryResult),
+        }),
+      }),
+    }),
+  })
+}
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+// --- Tests ---
+
+describe('useTripContacts', () => {
+  beforeEach(() => {
+    mockAuth.user = null
+    mockTrips.trips = []
+    mockQueryResult = { data: [], error: null }
+    mockSupabase.from.mockReset()
+    setupQueryChain()
+  })
+
+  it('returns empty array when user is not authenticated', () => {
+    mockAuth.user = null
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+    expect(result.current.contacts).toEqual([])
+    expect(result.current.loading).toBe(false)
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
+  it('returns empty array when user has only the current trip', () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [buildEvent({ id: 'trip-current' })]
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+    expect(result.current.contacts).toEqual([])
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
+  it('returns empty array when currentTripId is undefined', () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [buildEvent({ id: 'trip-1' })]
+
+    const { result } = renderHook(() => useTripContacts(undefined))
+    expect(result.current.contacts).toEqual([])
+  })
+
+  it('fetches and returns contacts from other trips', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current', end_date: '2025-08-01' }),
+      buildEvent({ id: 'trip-old', end_date: '2025-06-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Alice', email: 'alice@test.com', user_id: null, trip_id: 'trip-old' },
+        { name: 'Bob', email: 'bob@test.com', user_id: 'user-bob', trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+
+    const { result } = await renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(2)
+    })
+
+    expect(result.current.contacts[0].name).toBe('Alice')
+    expect(result.current.contacts[0].email).toBe('alice@test.com')
+    expect(result.current.contacts[1].name).toBe('Bob')
+    expect(result.current.contacts[1].user_id).toBe('user-bob')
+  })
+
+  it('excludes current user from results', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Me', email: 'me@test.com', user_id: 'user-1', trip_id: 'trip-old' },
+        { name: 'Alice', email: 'alice@test.com', user_id: null, trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].name).toBe('Alice')
+  })
+
+  it('deduplicates by email across trips, keeps most recent', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old', end_date: '2025-01-01' }),
+      buildEvent({ id: 'trip-recent', end_date: '2025-09-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Marta', email: 'marta@test.com', user_id: null, trip_id: 'trip-old' },
+        { name: 'Marta Tamm', email: 'marta@test.com', user_id: 'user-marta', trip_id: 'trip-recent' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    // Keeps the more recent record (trip-recent has later end_date)
+    expect(result.current.contacts[0].name).toBe('Marta Tamm')
+    expect(result.current.contacts[0].user_id).toBe('user-marta')
+    expect(result.current.contacts[0].lastSeenAt).toBe('2025-09-01')
+  })
+
+  it('deduplicates by name when no email exists', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-a', end_date: '2025-03-01' }),
+      buildEvent({ id: 'trip-b', end_date: '2025-06-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Carlos', email: null, user_id: null, trip_id: 'trip-a' },
+        { name: 'Carlos', email: null, user_id: null, trip_id: 'trip-b' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].name).toBe('Carlos')
+    expect(result.current.contacts[0].lastSeenAt).toBe('2025-06-01')
+  })
+
+  it('includes participants with no email', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'No Email Person', email: null, user_id: null, trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].email).toBeNull()
+    expect(result.current.contacts[0].name).toBe('No Email Person')
+  })
+
+  it('preserves user_id from participant data', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Linked User', email: 'linked@test.com', user_id: 'user-linked', trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].user_id).toBe('user-linked')
+  })
+
+  it('uses trip end_date as lastSeenAt', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old', end_date: '2025-12-25' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Santa', email: 'santa@north.pole', user_id: null, trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].lastSeenAt).toBe('2025-12-25')
+  })
+
+  it('sorts contacts by lastSeenAt descending', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old', end_date: '2024-01-01' }),
+      buildEvent({ id: 'trip-recent', end_date: '2025-12-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Old Friend', email: 'old@test.com', user_id: null, trip_id: 'trip-old' },
+        { name: 'Recent Friend', email: 'recent@test.com', user_id: null, trip_id: 'trip-recent' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(2)
+    })
+
+    expect(result.current.contacts[0].name).toBe('Recent Friend')
+    expect(result.current.contacts[1].name).toBe('Old Friend')
+  })
+})

--- a/src/hooks/useTripContacts.ts
+++ b/src/hooks/useTripContacts.ts
@@ -1,0 +1,136 @@
+import { useState, useEffect, useRef } from 'react'
+import { supabase } from '@/lib/supabase'
+import { withTimeout } from '@/lib/fetchWithTimeout'
+import { useAuth } from '@/contexts/AuthContext'
+import { useTripContext } from '@/contexts/TripContext'
+import { logger } from '@/lib/logger'
+
+export interface TripContact {
+  name: string
+  email: string | null
+  user_id: string | null
+  lastSeenAt: string
+}
+
+/**
+ * Fetches deduplicated contacts from the current user's other trips.
+ * Returns people the user has "tripped with" before — useful for
+ * autocomplete when adding participants to a new trip.
+ *
+ * Only runs for authenticated users. Returns empty array otherwise.
+ */
+export function useTripContacts(currentTripId: string | undefined) {
+  const { user } = useAuth()
+  const { trips } = useTripContext()
+  const [contacts, setContacts] = useState<TripContact[]>([])
+  const [loading, setLoading] = useState(false)
+  const cancelledRef = useRef(false)
+
+  useEffect(() => {
+    cancelledRef.current = false
+
+    if (!user || !currentTripId || trips.length === 0) {
+      setContacts([])
+      return
+    }
+
+    const otherTrips = trips.filter(t => t.id !== currentTripId)
+    const otherTripIds = otherTrips.map(t => t.id)
+
+    if (otherTripIds.length === 0) {
+      setContacts([])
+      return
+    }
+
+    // Build trip date map for lastSeenAt (use end_date as proxy)
+    const tripDateMap = new Map<string, string>()
+    for (const t of otherTrips) {
+      tripDateMap.set(t.id, t.end_date || t.start_date)
+    }
+
+    const controller = new AbortController()
+
+    const fetchContacts = async () => {
+      setLoading(true)
+      try {
+        const { data, error } = await withTimeout(
+          supabase
+            .from('participants')
+            .select('name, email, user_id, trip_id')
+            .in('trip_id', otherTripIds)
+            .limit(200)
+            .abortSignal(controller.signal),
+          15000,
+          'Loading contacts timed out.'
+        )
+
+        if (cancelledRef.current) return
+
+        if (error) {
+          logger.warn('Failed to fetch trip contacts', { error: error.message })
+          setLoading(false)
+          return
+        }
+
+        if (!data || data.length === 0) {
+          setContacts([])
+          setLoading(false)
+          return
+        }
+
+        // Filter out self
+        const filtered = data.filter(
+          (p: any) => p.user_id !== user.id
+        )
+
+        // Deduplicate: by email (lowercase) if exists, else by exact name (lowercase).
+        // Keep the record from the most recent trip (by end_date).
+        const seen = new Map<string, TripContact>()
+        for (const p of filtered as any[]) {
+          const key = p.email
+            ? `email:${p.email.toLowerCase()}`
+            : `name:${p.name.toLowerCase()}`
+
+          const lastSeenAt = tripDateMap.get(p.trip_id) || ''
+
+          const existing = seen.get(key)
+          if (!existing || lastSeenAt > existing.lastSeenAt) {
+            seen.set(key, {
+              name: p.name,
+              email: p.email ?? null,
+              user_id: p.user_id ?? null,
+              lastSeenAt,
+            })
+          }
+        }
+
+        // Sort by lastSeenAt descending (most recently tripped with first)
+        const sorted = Array.from(seen.values()).sort(
+          (a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt)
+        )
+
+        if (!cancelledRef.current) {
+          setContacts(sorted)
+        }
+      } catch (err) {
+        if (cancelledRef.current) return
+        logger.warn('Unhandled error fetching trip contacts', {
+          error: String(err),
+        })
+      } finally {
+        if (!cancelledRef.current) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchContacts()
+
+    return () => {
+      cancelledRef.current = true
+      controller.abort()
+    }
+  }, [user?.id, currentTripId, trips.length])
+
+  return { contacts, loading }
+}

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -14,6 +14,7 @@ export interface CreateParticipantInput {
   name: string
   is_adult: boolean
   email?: string | null
+  user_id?: string | null
 }
 
 export interface UpdateParticipantInput {


### PR DESCRIPTION
## Summary
- Email fields now show hint text: "Add now or let them link themselves via the trip link" (ParticipantsSetup + QuickParticipantPicker)
- New `useTripContacts` hook fetches deduplicated contacts from the user's other trips (creator OR linked participant), sorted by most recently tripped with
- Autocomplete dropdown on the name field in ParticipantsSetup — shows matching suggestions (2+ chars) with name, email, and "Has Spl1t account" indicator
- Selecting a suggestion pre-fills name + email and pre-links `user_id` on submit; unique constraint conflicts retried silently without `user_id`
- QuickParticipantPicker's inline recent-people fetch replaced with `useTripContacts` (broader data source, pre-links `user_id` on chip selection)
- `CreateParticipantInput` type extended with optional `user_id` field
- 11 new unit tests for `useTripContacts` (167 total, all passing)

## Test plan
- [ ] Add participant with name only — works
- [ ] Add participant with name + email — works, invite sent
- [ ] Email hint text visible on both ParticipantsSetup and QuickParticipantPicker
- [ ] Authenticated user with trip history: type 2+ chars → matching suggestions appear
- [ ] Tap suggestion → name + email filled, wallet_group NOT filled
- [ ] Linked indicator ("✓ Has Spl1t account") shown for suggestions with user_id
- [ ] Participant saved with correct user_id when suggestion selected
- [ ] Current trip participants not in suggestions
- [ ] Current user not in suggestions
- [ ] Unauthenticated or no history: no dropdown, name field works as plain text input
- [ ] Keyboard nav: ↑↓ arrows, Enter selects, Escape closes
- [ ] Click outside closes dropdown
- [ ] QuickParticipantPicker "Recent" chips still work with new data source
- [ ] `npm run type-check` passes
- [ ] `npm test` — 167 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)