### PR TITLE
feat: show full Google name for linked contacts in autocomplete

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -105,7 +105,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
   }
 
   const handleAddRecent = async (contact: TripContact) => {
-    await addPerson(contact.name, contact.email, contact.user_id)
+    await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id)
   }
 
   const handleAddFromContacts = async () => {
@@ -149,11 +149,13 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
     }
   }
 
-  const isAdded = (contact: TripContact) =>
-    addedNames.includes(contact.name) ||
-    participants.some(p => p.name === contact.name && (
-      !contact.email || p.email?.toLowerCase() === contact.email?.toLowerCase()
-    ))
+  const isAdded = (contact: TripContact) => {
+    const contactDisplayName = contact.display_name ?? contact.name
+    return addedNames.includes(contactDisplayName) ||
+      participants.some(p => (p.name === contact.name || p.name === contactDisplayName) && (
+        !contact.email || p.email?.toLowerCase() === contact.email?.toLowerCase()
+      ))
+  }
 
   const currentParticipants = participants.filter(p => p.trip_id === tripId)
 
@@ -195,7 +197,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
                   }`}
                 >
                   {added ? null : <Plus size={12} />}
-                  {contact.name}
+                  {contact.display_name ?? contact.name}
                 </button>
               )
             })}

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -105,7 +105,10 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
     if (name.trim().length < 2 || contacts.length === 0) return []
     const query = name.toLowerCase()
     return contacts
-      .filter(c => c.name.toLowerCase().includes(query))
+      .filter(c =>
+        c.name.toLowerCase().includes(query) ||
+        c.display_name?.toLowerCase().includes(query)
+      )
       .slice(0, 5)
   }, [name, contacts])
 
@@ -129,7 +132,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
   }, [showDropdown])
 
   const handleSelectContact = useCallback((contact: TripContact) => {
-    setName(contact.name)
+    setName(contact.display_name ?? contact.name)
     setEmail(contact.email || '')
     setSuggestedUserId(contact.user_id)
     setShowDropdown(false)
@@ -525,7 +528,9 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                         handleSelectContact(contact)
                       }}
                     >
-                      <div className="font-medium text-sm">{contact.name}</div>
+                      <div className="font-medium text-sm">
+                        {contact.display_name ?? contact.name}
+                      </div>
                       {contact.email && (
                         <div className="text-xs text-muted-foreground">{contact.email}</div>
                       )}

--- a/src/hooks/useTripContacts.test.tsx
+++ b/src/hooks/useTripContacts.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@/contexts/TripContext', () => ({
 }))
 
 let mockQueryResult: { data: any[] | null; error: any } = { data: [], error: null }
+let mockProfilesResult: { data: any[] | null; error: any } = { data: [], error: null }
 
 const mockSupabase = vi.hoisted(() => ({
   from: vi.fn(),
@@ -42,14 +43,26 @@ const mockSupabase = vi.hoisted(() => ({
 vi.mock('@/lib/supabase', () => ({ supabase: mockSupabase }))
 
 function setupQueryChain() {
-  mockSupabase.from.mockReturnValue({
-    select: () => ({
-      in: () => ({
-        limit: () => ({
-          abortSignal: () => Promise.resolve(mockQueryResult),
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'user_profiles') {
+      return {
+        select: () => ({
+          in: () => ({
+            abortSignal: () => Promise.resolve(mockProfilesResult),
+          }),
+        }),
+      }
+    }
+    // participants
+    return {
+      select: () => ({
+        in: () => ({
+          limit: () => ({
+            abortSignal: () => Promise.resolve(mockQueryResult),
+          }),
         }),
       }),
-    }),
+    }
   })
 }
 
@@ -64,6 +77,7 @@ describe('useTripContacts', () => {
     mockAuth.user = null
     mockTrips.trips = []
     mockQueryResult = { data: [], error: null }
+    mockProfilesResult = { data: [], error: null }
     mockSupabase.from.mockReset()
     setupQueryChain()
   })
@@ -115,8 +129,10 @@ describe('useTripContacts', () => {
 
     expect(result.current.contacts[0].name).toBe('Alice')
     expect(result.current.contacts[0].email).toBe('alice@test.com')
+    expect(result.current.contacts[0].display_name).toBeNull()
     expect(result.current.contacts[1].name).toBe('Bob')
     expect(result.current.contacts[1].user_id).toBe('user-bob')
+    expect(result.current.contacts[1].display_name).toBeNull()
   })
 
   it('excludes current user from results', async () => {
@@ -284,5 +300,93 @@ describe('useTripContacts', () => {
 
     expect(result.current.contacts[0].name).toBe('Recent Friend')
     expect(result.current.contacts[1].name).toBe('Old Friend')
+  })
+
+  it('populates display_name from user_profiles for linked users', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Kairi', email: 'kairi@test.com', user_id: 'user-kairi', trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+    mockProfilesResult = {
+      data: [
+        { id: 'user-kairi', display_name: 'Kairi Tamm' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].name).toBe('Kairi')
+    expect(result.current.contacts[0].display_name).toBe('Kairi Tamm')
+    expect(result.current.contacts[0].user_id).toBe('user-kairi')
+  })
+
+  it('returns display_name null for contacts without user_id', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'No Account', email: 'noaccount@test.com', user_id: null, trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].display_name).toBeNull()
+  })
+
+  it('prefers record with display_name when deduplicating by email', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old', end_date: '2025-01-01' }),
+      buildEvent({ id: 'trip-recent', end_date: '2025-09-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        // More recent trip but no user_id (no display_name)
+        { name: 'Marta', email: 'marta@test.com', user_id: null, trip_id: 'trip-recent' },
+        // Older trip but has user_id with display_name
+        { name: 'Marta', email: 'marta@test.com', user_id: 'user-marta', trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+    mockProfilesResult = {
+      data: [
+        { id: 'user-marta', display_name: 'Marta Tamm' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    // Should prefer the record with display_name even though the other is more recent
+    expect(result.current.contacts[0].display_name).toBe('Marta Tamm')
+    expect(result.current.contacts[0].user_id).toBe('user-marta')
+    // lastSeenAt should still be the most recent date
+    expect(result.current.contacts[0].lastSeenAt).toBe('2025-09-01')
   })
 })

--- a/src/hooks/useTripContacts.ts
+++ b/src/hooks/useTripContacts.ts
@@ -9,6 +9,7 @@ export interface TripContact {
   name: string
   email: string | null
   user_id: string | null
+  display_name: string | null
   lastSeenAt: string
 }
 
@@ -83,8 +84,35 @@ export function useTripContacts(currentTripId: string | undefined) {
           (p: any) => p.user_id !== user.id
         )
 
+        // Fetch display_names for linked users (separate query — no direct FK)
+        const userIds = [...new Set(
+          filtered.filter((p: any) => p.user_id).map((p: any) => p.user_id as string)
+        )]
+        const displayNameMap = new Map<string, string>()
+        if (userIds.length > 0) {
+          try {
+            const { data: profiles } = await withTimeout<{ data: any[]; error: any }>(
+              (supabase as any)
+                .from('user_profiles')
+                .select('id, display_name')
+                .in('id', userIds)
+                .abortSignal(controller.signal),
+              15000,
+              'Loading profiles timed out.'
+            )
+            if (profiles) {
+              for (const p of profiles as any[]) {
+                if (p.display_name) displayNameMap.set(p.id, p.display_name)
+              }
+            }
+          } catch {
+            // Non-critical — proceed without display names
+          }
+        }
+
         // Deduplicate: by email (lowercase) if exists, else by exact name (lowercase).
         // Keep the record from the most recent trip (by end_date).
+        // Prefer records that have a display_name.
         const seen = new Map<string, TripContact>()
         for (const p of filtered as any[]) {
           const key = p.email
@@ -92,14 +120,18 @@ export function useTripContacts(currentTripId: string | undefined) {
             : `name:${p.name.toLowerCase()}`
 
           const lastSeenAt = tripDateMap.get(p.trip_id) || ''
+          const display_name = p.user_id ? displayNameMap.get(p.user_id) ?? null : null
 
           const existing = seen.get(key)
-          if (!existing || lastSeenAt > existing.lastSeenAt) {
+          const isNewer = !existing || lastSeenAt > existing.lastSeenAt
+          const hasNewDisplayName = display_name && !existing?.display_name
+          if (isNewer || hasNewDisplayName) {
             seen.set(key, {
               name: p.name,
               email: p.email ?? null,
               user_id: p.user_id ?? null,
-              lastSeenAt,
+              display_name,
+              lastSeenAt: isNewer ? lastSeenAt : existing!.lastSeenAt,
             })
           }
         }


### PR DESCRIPTION
## Summary
- Fetch `display_name` from `user_profiles` for contacts with linked Spl1t accounts (separate query — no direct FK between participants and user_profiles)
- Autocomplete dropdown in ParticipantsSetup and quick-mode chips in QuickParticipantPicker now show the full Google name (e.g. "Kairi Tamm") instead of the short participant name
- On contact selection, the name field is pre-filled with `display_name` when available
- Deduplication prefers records that have a `display_name` (even from older trips)

## Test plan
- [x] `npm run type-check` passes clean
- [x] `npm test` — all 170 tests pass (3 new tests for display_name)
- [ ] Manual: authenticated user types partial name → dropdown shows full Google name with email and linked indicator
- [ ] Manual: contact without Spl1t account → shows participant name only (no display_name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)