### PR TITLE
fix: contact autocomplete dedup, dropdown reopen, invite opt-in

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -4,6 +4,8 @@ import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useTripContacts, TripContact } from '@/hooks/useTripContacts'
+import { useToast } from '@/hooks/use-toast'
+import { ToastAction } from '@/components/ui/toast'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -20,6 +22,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
   const { user, userProfile } = useAuth()
   const { participants, createParticipant } = useParticipantContext()
   const { contacts } = useTripContacts(tripId)
+  const { toast } = useToast()
 
   const [addedNames, setAddedNames] = useState<string[]>([])
   const [supportsContacts, setSupportsContacts] = useState(false)
@@ -29,6 +32,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
   const [email, setEmail] = useState('')
   const [adding, setAdding] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [sendInvite, setSendInvite] = useState(true)
 
   // Check contacts API support on mount
   useEffect(() => {
@@ -77,7 +81,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
     const emailLower = personEmail?.trim().toLowerCase() ?? null
     if (emailLower) {
       const duplicate = participants.some(p => p.email?.toLowerCase() === emailLower)
-      if (duplicate) return // silently skip duplicate
+      if (duplicate) return null // silently skip duplicate
     }
 
     const input = {
@@ -98,14 +102,24 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
 
     if (newParticipant) {
       setAddedNames(prev => [...prev, personName.trim()])
-      if (newParticipant.email && user) {
-        sendInvitation(newParticipant.id, newParticipant.email, newParticipant.name)
-      }
     }
+
+    return newParticipant
   }
 
   const handleAddRecent = async (contact: TripContact) => {
-    await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id)
+    const newParticipant = await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id)
+    if (newParticipant?.email && user) {
+      toast({
+        title: `${newParticipant.name} added`,
+        description: 'Send invite email?',
+        action: (
+          <ToastAction altText="Send invite" onClick={() => sendInvitation(newParticipant.id, newParticipant.email!, newParticipant.name)}>
+            Send
+          </ToastAction>
+        ),
+      })
+    }
   }
 
   const handleAddFromContacts = async () => {
@@ -116,7 +130,18 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
         const personName = contact.name?.[0] ?? ''
         const personEmail = contact.email?.[0] ?? null
         if (personName.trim()) {
-          await addPerson(personName.trim(), personEmail)
+          const newParticipant = await addPerson(personName.trim(), personEmail)
+          if (newParticipant?.email && user) {
+            toast({
+              title: `${newParticipant.name} added`,
+              description: 'Send invite email?',
+              action: (
+                <ToastAction altText="Send invite" onClick={() => sendInvitation(newParticipant.id, newParticipant.email!, newParticipant.name)}>
+                  Send
+                </ToastAction>
+              ),
+            })
+          }
         }
       }
     } catch (err) {
@@ -141,9 +166,13 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
 
     setAdding(true)
     try {
-      await addPerson(name.trim(), email.trim() || null)
+      const newParticipant = await addPerson(name.trim(), email.trim() || null)
+      if (newParticipant?.email && user && sendInvite) {
+        sendInvitation(newParticipant.id, newParticipant.email, newParticipant.name)
+      }
       setName('')
       setEmail('')
+      setSendInvite(true)
     } finally {
       setAdding(false)
     }
@@ -254,6 +283,17 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
               onChange={e => setEmail(e.target.value)}
               autoComplete="section-participant email"
             />
+            {email.trim() && (
+              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer mt-1">
+                <input
+                  type="checkbox"
+                  checked={sendInvite}
+                  onChange={(e) => setSendInvite(e.target.checked)}
+                  className="rounded border-border"
+                />
+                Send invite email
+              </label>
+            )}
             <p className="text-xs text-muted-foreground mt-1">
               Add now or let them link themselves via the trip link
             </p>

--- a/src/components/setup/IndividualsSetup.tsx
+++ b/src/components/setup/IndividualsSetup.tsx
@@ -77,6 +77,7 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
   const [isAdult, setIsAdult] = useState(true)
   const [adding, setAdding] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [sendInvite, setSendInvite] = useState(true)
 
   // Per-participant inline email editing
   const [editingEmailId, setEditingEmailId] = useState<string | null>(null)
@@ -111,10 +112,11 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
       })
       setName('')
       setEmail('')
+      setSendInvite(true)
       setIsAdult(true)
 
-      // Send invitation if email provided
-      if (newParticipant && email.trim() && user) {
+      // Send invitation if email provided and user opted in
+      if (newParticipant && email.trim() && user && sendInvite) {
         sendInvitation({
           participantId: newParticipant.id,
           participantEmail: email.trim(),
@@ -207,7 +209,7 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional — sends invite)</span></Label>
+              <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional)</span></Label>
               <Input
                 type="email"
                 inputMode="email"
@@ -217,6 +219,17 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
                 placeholder="e.g., john@example.com"
                 disabled={adding}
               />
+              {email.trim() && (
+                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={sendInvite}
+                    onChange={(e) => setSendInvite(e.target.checked)}
+                    className="rounded border-border"
+                  />
+                  Send invite email
+                </label>
+              )}
             </div>
 
             <div className="flex items-center space-x-2">

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -96,9 +96,11 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
   const [suggestedUserId, setSuggestedUserId] = useState<string | null>(null)
   const [showDropdown, setShowDropdown] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
+  const [sendInvite, setSendInvite] = useState(true)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const nameInputRef = useRef<HTMLInputElement>(null)
   const emailInputRef = useRef<HTMLInputElement>(null)
+  const justSelectedRef = useRef(false)
 
   // Filtered contacts based on current name input
   const filteredContacts = useMemo(() => {
@@ -114,6 +116,10 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
 
   // Show/hide dropdown based on filtered results
   useEffect(() => {
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false
+      return
+    }
     setShowDropdown(filteredContacts.length > 0)
     setActiveIndex(-1)
   }, [filteredContacts.length])
@@ -132,6 +138,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
   }, [showDropdown])
 
   const handleSelectContact = useCallback((contact: TripContact) => {
+    justSelectedRef.current = true
     setName(contact.display_name ?? contact.name)
     setEmail(contact.email || '')
     setSuggestedUserId(contact.user_id)
@@ -245,11 +252,12 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
       setName('')
       setEmail('')
       setSuggestedUserId(null)
+      setSendInvite(true)
       // Keep walletGroup — likely adding more people to the same group
       setIsAdult(true)
 
-      // Send invitation if email provided
-      if (newParticipant && email.trim() && user) {
+      // Send invitation if email provided and user opted in
+      if (newParticipant && email.trim() && user && sendInvite) {
         sendInvitation({
           participantId: newParticipant.id,
           participantEmail: email.trim(),
@@ -544,7 +552,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional — sends invite)</span></Label>
+              <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional)</span></Label>
               <Input
                 ref={emailInputRef}
                 type="email"
@@ -555,6 +563,17 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                 placeholder="e.g., john@example.com"
                 disabled={adding}
               />
+              {email.trim() && (
+                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={sendInvite}
+                    onChange={(e) => setSendInvite(e.target.checked)}
+                    className="rounded border-border"
+                  />
+                  Send invite email
+                </label>
+              )}
               <p className="text-xs text-muted-foreground mt-1">
                 Add now or let them link themselves via the trip link
               </p>

--- a/src/hooks/useTripContacts.test.tsx
+++ b/src/hooks/useTripContacts.test.tsx
@@ -354,6 +354,89 @@ describe('useTripContacts', () => {
     expect(result.current.contacts[0].display_name).toBeNull()
   })
 
+  it('deduplicates by user_id across trips and preserves email from the record that has it', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old', end_date: '2025-01-01' }),
+      buildEvent({ id: 'trip-recent', end_date: '2025-09-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        // Older trip has email
+        { name: 'Kairi', email: 'kairi@test.com', user_id: 'user-kairi', trip_id: 'trip-old' },
+        // Newer trip has no email (participant record without email)
+        { name: 'Kairi T', email: null, user_id: 'user-kairi', trip_id: 'trip-recent' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    // Should keep email from the older record (best email preserved)
+    expect(result.current.contacts[0].email).toBe('kairi@test.com')
+    // Name from newer record
+    expect(result.current.contacts[0].name).toBe('Kairi T')
+    expect(result.current.contacts[0].lastSeenAt).toBe('2025-09-01')
+  })
+
+  it('deduplicates by user_id when only older record has email', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-a', end_date: '2025-03-01' }),
+      buildEvent({ id: 'trip-b', end_date: '2025-06-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        // Older record has email
+        { name: 'Bob', email: 'bob@test.com', user_id: 'user-bob', trip_id: 'trip-a' },
+        // Newer record does not
+        { name: 'Bob', email: null, user_id: 'user-bob', trip_id: 'trip-b' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(1)
+    })
+
+    expect(result.current.contacts[0].email).toBe('bob@test.com')
+    expect(result.current.contacts[0].lastSeenAt).toBe('2025-06-01')
+  })
+
+  it('does NOT dedup contacts with same name but different user_ids', async () => {
+    mockAuth.user = { id: 'user-1' }
+    mockTrips.trips = [
+      buildEvent({ id: 'trip-current' }),
+      buildEvent({ id: 'trip-old', end_date: '2025-06-01' }),
+    ]
+    mockQueryResult = {
+      data: [
+        { name: 'Alex', email: null, user_id: 'user-alex-1', trip_id: 'trip-old' },
+        { name: 'Alex', email: null, user_id: 'user-alex-2', trip_id: 'trip-old' },
+      ],
+      error: null,
+    }
+
+    const { result } = renderHook(() => useTripContacts('trip-current'))
+
+    await waitFor(() => {
+      expect(result.current.contacts).toHaveLength(2)
+    })
+
+    // Both should be present — different user_ids means different people
+    const userIds = result.current.contacts.map(c => c.user_id)
+    expect(userIds).toContain('user-alex-1')
+    expect(userIds).toContain('user-alex-2')
+  })
+
   it('prefers record with display_name when deduplicating by email', async () => {
     mockAuth.user = { id: 'user-1' }
     mockTrips.trips = [

--- a/src/hooks/useTripContacts.ts
+++ b/src/hooks/useTripContacts.ts
@@ -110,14 +110,17 @@ export function useTripContacts(currentTripId: string | undefined) {
           }
         }
 
-        // Deduplicate: by email (lowercase) if exists, else by exact name (lowercase).
+        // Deduplicate: by user_id first (linked accounts), then email, then name.
         // Keep the record from the most recent trip (by end_date).
         // Prefer records that have a display_name.
+        // Merge rule: preserve the best email across records.
         const seen = new Map<string, TripContact>()
         for (const p of filtered as any[]) {
-          const key = p.email
-            ? `email:${p.email.toLowerCase()}`
-            : `name:${p.name.toLowerCase()}`
+          const key = p.user_id
+            ? `uid:${p.user_id}`
+            : p.email
+              ? `email:${p.email.toLowerCase()}`
+              : `name:${p.name.toLowerCase()}`
 
           const lastSeenAt = tripDateMap.get(p.trip_id) || ''
           const display_name = p.user_id ? displayNameMap.get(p.user_id) ?? null : null
@@ -126,13 +129,40 @@ export function useTripContacts(currentTripId: string | undefined) {
           const isNewer = !existing || lastSeenAt > existing.lastSeenAt
           const hasNewDisplayName = display_name && !existing?.display_name
           if (isNewer || hasNewDisplayName) {
+            const bestEmail = p.email ?? existing?.email ?? null
             seen.set(key, {
               name: p.name,
-              email: p.email ?? null,
+              email: bestEmail,
               user_id: p.user_id ?? null,
               display_name,
               lastSeenAt: isNewer ? lastSeenAt : existing!.lastSeenAt,
             })
+          }
+        }
+
+        // Post-pass: merge entries that share the same email but got different keys
+        // (e.g. uid:X from one trip + email:Y from another trip for the same person)
+        const emailToKey = new Map<string, string>()
+        for (const [key, contact] of seen) {
+          if (!contact.email) continue
+          const emailLower = contact.email.toLowerCase()
+          const existingKey = emailToKey.get(emailLower)
+          if (existingKey && existingKey !== key) {
+            const keepKey = key.startsWith('uid:') ? key : existingKey
+            const removeKey = key.startsWith('uid:') ? existingKey : key
+            const keepEntry = seen.get(keepKey)!
+            const removeEntry = seen.get(removeKey)!
+            keepEntry.email = keepEntry.email ?? removeEntry.email
+            if (removeEntry.lastSeenAt > keepEntry.lastSeenAt) {
+              keepEntry.lastSeenAt = removeEntry.lastSeenAt
+            }
+            if (removeEntry.display_name && !keepEntry.display_name) {
+              keepEntry.display_name = removeEntry.display_name
+            }
+            seen.delete(removeKey)
+            emailToKey.set(emailLower, keepKey)
+          } else {
+            emailToKey.set(emailLower, key)
           }
         }
 


### PR DESCRIPTION
## Summary

- **Dedup by `user_id`**: Contacts from past trips now dedup by linked Spl1t account first (`uid:`), then email, then name. A post-merge pass consolidates entries that share an email but got different dedup keys (e.g. one record has `user_id`, another from an older trip only has email). Best email is preserved across records.
- **Dropdown stays closed after selection**: `justSelectedRef` guards the `useEffect` that reopens the dropdown based on `filteredContacts.length`, preventing it from re-triggering when the selected name still matches.
- **Invite email opt-in**: "Send invite email" checkbox (checked by default) added to ParticipantsSetup, IndividualsSetup, and QuickParticipantPicker manual form. Email label changed from "(optional — sends invite)" to "(optional)".
- **Toast for quick chip adds**: QuickParticipantPicker chip/recent contact adds show a toast with a "Send" action button instead of auto-sending invite emails. Toast auto-dismisses if user doesn't click Send.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — all 173 tests pass (3 new dedup tests added)
- [ ] Manual: type name matching 2 contacts with same name → dropdown shows emails to disambiguate
- [ ] Manual: select linked Spl1t contact with no email on participant record → email auto-fills from aggregated records
- [ ] Manual: select from dropdown → dropdown closes, doesn't reopen
- [ ] Manual (ParticipantsSetup): add participant with email, checkbox checked → invite sent. Uncheck → no invite.
- [ ] Manual (QuickParticipantPicker): tap recent chip with email → toast appears with Send action

🤖 Generated with [Claude Code](https://claude.com/claude-code)