### PR TITLE
docs: update CLAUDE.md and PLAN.md with PRs #468–#470

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,30 @@ Stays are managed separately in `StayContext`. Activities in `ActivityContext`.
 
 `participants.user_id` links a Supabase auth user to their participant record ("This is me"). One user per trip (enforced by unique index). Use `useMyParticipant()` hook to get the current user's participant. Use `useMyTripBalances()` to get the user's balance across all their trips (used on the unified home page).
 
+### Contact Autocomplete (`useTripContacts`)
+
+`useTripContacts(currentTripId)` hook (`src/hooks/useTripContacts.ts`) fetches deduplicated contacts from the current user's other trips — "people you've tripped with". Returns `TripContact[]` with `name`, `email`, `user_id`, `display_name`, `lastSeenAt`. Only runs for authenticated users.
+
+**Data sources:** Participant records from other trips + `user_profiles` table (for `display_name` and `email` of linked Spl1t accounts). Profile email serves as fallback when participant records lack email.
+
+**Dedup strategy:** Primary key = `user_id` (linked accounts) > `email` > `name`. Post-merge pass catches cross-key email matches. Prefers records with `display_name`. Sorted by recency (most recent trip first).
+
+**UI integration:**
+- **`ParticipantsSetup`** (Full mode, `src/components/setup/ParticipantsSetup.tsx`): Autocomplete dropdown on Name field. Selecting a contact auto-fills name + email + `suggestedUserId`. "Send invite email" checkbox appears when email is populated.
+- **`QuickParticipantPicker`** (Quick mode, `src/components/quick/QuickParticipantPicker.tsx`): Same autocomplete dropdown on manual add form + Recent chips for one-tap adds. Ambiguous names (same display name) show email suffix on chips for disambiguation (`"Alex · alex@…"`).
+
+Both components use identical patterns: `filteredContacts` memo (min 2 chars, limit 5), keyboard navigation (arrow keys + Enter/Escape), click-outside dismiss, `justSelectedRef` to prevent dropdown re-opening after selection.
+
+### Email Templates (`send-email` Edge Function)
+
+`supabase/functions/send-email/index.ts` — Resend API integration. Shared `baseEmailHtml()` wrapper with coral header (`#e8613a`), "Spl1t" wordmark (cream "1"), and branded footer. `BRAND` constant object for all color tokens.
+
+Two email types:
+- **Invitation**: Sent when adding a participant with email (opt-in via "Send invite email" checkbox). Creates `invitations` row, generates `/join/:token` link.
+- **Payment reminder**: Sent from SettlementsPage "Remind" button. Includes amount owed, optional receipt line-item tables (up to 3), single CTA.
+
+Deploy after changes: `supabase functions deploy send-email`
+
 ---
 
 ## Observability
@@ -379,7 +403,7 @@ and the user-friendly error message will never be shown.
 - `VITE_GOOGLE_CLIENT_ID` (Google OAuth)
 - `VITE_GRAFANA_*` (observability — set in Cloudflare dashboard)
 
-**Supabase Edge Functions:** `log-proxy`, `create-github-issue`
+**Supabase Edge Functions:** `log-proxy`, `create-github-issue`, `send-email`
 
 **Demo trip:** `livigno-2025` trip code, seeded via `scripts/seed-demo-trip.ts`. "Try a demo" link on home page navigates to `/t/livigno-2025` (uses `TripModeRedirect`).
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -15,7 +15,7 @@
 | State | React Context API (one provider per domain) |
 | Database | Supabase (PostgreSQL + RLS) |
 | Storage | Supabase Storage (`feedback-screenshots` bucket, public) |
-| Edge Functions | Supabase Edge Functions (Deno) — `log-proxy`, `create-github-issue` |
+| Edge Functions | Supabase Edge Functions (Deno) — `log-proxy`, `create-github-issue`, `send-email` |
 | Auth | Supabase Auth (Google OAuth, implicit flow) |
 | Observability | Grafana Cloud — Loki (logs) + OTLP (metrics) via `log-proxy` |
 | Deployment | Cloudflare Pages |
@@ -766,6 +766,9 @@ Replace ad-hoc loading/error patterns with the shared components from 7a.
 | 2026-03-01 | Contact display names | PR #465: `useTripContacts` now fetches `display_name` from `user_profiles` for linked Spl1t accounts. Autocomplete dropdown and quick-mode chips show full Google name (e.g. "Kairi Tamm") instead of short participant name. Dedup prefers records with display_name. 3 new tests. |
 | 2026-03-01 | Docs update | PR #466: Updated CLAUDE.md and PLAN.md with PRs #463–#465. |
 | 2026-03-01 | Contact autocomplete fixes | PR #467: Fixed contact dedup to prioritise `user_id` (linked accounts), then email, then name — with post-merge pass for cross-key email matches. Fixed dropdown reopening after selection (`justSelectedRef`). Added "Send invite email" checkbox (default checked) to ParticipantsSetup, IndividualsSetup, and QuickParticipantPicker manual form. Quick-mode chip adds show toast with Send action instead of auto-sending. 3 new tests (173 total). |
+| 2026-03-01 | Docs update | PR #468: Updated CLAUDE.md and PLAN.md with PRs #466–#467. |
+| 2026-03-01 | Email template redesign | PR #469: Unified invitation + payment reminder emails under shared `baseEmailHtml()` wrapper with coral header, "Spl1t" wordmark (cream "1"), branded footer. Replaced all purple (`#6366f1`) with coral brand tokens. Normalized inconsistent hex values into single `BRAND` constant. Simplified payment reminder to single CTA. File: `supabase/functions/send-email/index.ts`. Deploy: `supabase functions deploy send-email`. |
+| 2026-03-01 | Contact email auto-fill | PR #470: `useTripContacts` now fetches `email` from `user_profiles` alongside `display_name` — profile email as fallback enables email auto-fill, disambiguation, and invite checkbox in both Full and Quick mode. `QuickParticipantPicker` gets same autocomplete dropdown as `ParticipantsSetup` (keyboard nav, contact selection, `suggestedUserId` passthrough) + ambiguous name disambiguation on Recent chips (`"Alex · alex@…"`). |
 
 ---
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added `send-email` to Edge Functions list. New "Contact Autocomplete" section documenting `useTripContacts` hook, dedup strategy, and UI integration in both modes. New "Email Templates" section documenting `send-email` edge function, brand tokens, and two email types.
- **PLAN.md**: Added `send-email` to tech stack Edge Functions. Session log entries for PRs #468 (docs), #469 (email template redesign), #470 (contact email auto-fill + quick mode dropdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)