### PR TITLE
feat: add pull-to-refresh gesture for PWA

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -27,6 +27,9 @@ import { isAdminUser } from '@/lib/adminAuth'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
 import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
+import { PullToRefreshProvider } from '@/contexts/PullToRefreshContext'
+import { usePullToRefresh } from '@/hooks/usePullToRefresh'
+import { PullToRefreshIndicator } from '@/components/PullToRefreshIndicator'
 import { getHiddenTripCodes } from '@/lib/mutedTripsStorage'
 import {
   Sheet,
@@ -149,6 +152,7 @@ export function Layout() {
   const onGradient = !!pattern
 
   return (
+    <PullToRefreshProvider>
     <div className="min-h-screen bg-background">
       {/* Header */}
       <header className={`fixed top-0 left-0 right-0 z-50 ${pattern ? 'bg-black' : 'bg-card border-b border-border soft-shadow-sm'}`}>
@@ -266,6 +270,7 @@ export function Layout() {
 
       {/* Main content */}
       <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
+        <LayoutPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>
             <SettlementProvider>
@@ -452,5 +457,11 @@ export function Layout() {
       {/* Toast notifications */}
       <Toaster />
     </div>
+    </PullToRefreshProvider>
   )
+}
+
+function LayoutPullIndicator() {
+  const { pullDistance, isPulling, isRefreshing } = usePullToRefresh()
+  return <PullToRefreshIndicator pullDistance={pullDistance} isPulling={isPulling} isRefreshing={isRefreshing} />
 }

--- a/src/components/PullToRefreshIndicator.tsx
+++ b/src/components/PullToRefreshIndicator.tsx
@@ -1,0 +1,38 @@
+import { ArrowDown, Loader2 } from 'lucide-react'
+
+const THRESHOLD = 80
+
+interface Props {
+  pullDistance: number
+  isPulling: boolean
+  isRefreshing: boolean
+}
+
+export function PullToRefreshIndicator({ pullDistance, isPulling, isRefreshing }: Props) {
+  if (!isPulling && !isRefreshing && pullDistance === 0) return null
+
+  const height = isRefreshing ? 48 : pullDistance
+  const progress = Math.min(pullDistance / THRESHOLD, 1)
+  const rotation = progress * 180
+
+  return (
+    <div
+      className="flex items-end justify-center overflow-hidden"
+      style={{
+        height,
+        transition: isPulling ? 'none' : 'height 200ms ease-out',
+      }}
+    >
+      <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center mb-2">
+        {isRefreshing ? (
+          <Loader2 className="w-4 h-4 text-muted-foreground animate-spin" />
+        ) : (
+          <ArrowDown
+            className="w-4 h-4 text-muted-foreground transition-transform"
+            style={{ transform: `rotate(${rotation}deg)`, transition: isPulling ? 'none' : 'transform 200ms ease-out' }}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -21,6 +21,9 @@ import { Toaster } from '@/components/ui/toaster'
 import { getTripGradientPattern } from '@/services/tripGradientService'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
 import { isAdminUser } from '@/lib/adminAuth'
+import { PullToRefreshProvider } from '@/contexts/PullToRefreshContext'
+import { usePullToRefresh } from '@/hooks/usePullToRefresh'
+import { PullToRefreshIndicator } from '@/components/PullToRefreshIndicator'
 
 export function QuickLayout() {
   const { tripCode } = useParams<{ tripCode: string }>()
@@ -51,6 +54,7 @@ export function QuickLayout() {
   const onGradient = !!pattern
 
   return (
+    <PullToRefreshProvider>
     <div className="min-h-screen bg-background">
       {/* Simplified header */}
       <header className={`fixed top-0 left-0 right-0 z-50 ${pattern ? 'bg-black' : 'bg-card border-b border-border soft-shadow-sm'}`}>
@@ -187,6 +191,7 @@ export function QuickLayout() {
 
       {/* Main content — extra top padding when two-row header is active */}
       <main className={isInTrip && !isSubPage ? 'pt-[108px] lg:pt-16' : 'pt-16'}>
+        <QuickPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>
             <SettlementProvider>
@@ -212,5 +217,11 @@ export function QuickLayout() {
 
       <Toaster />
     </div>
+    </PullToRefreshProvider>
   )
+}
+
+function QuickPullIndicator() {
+  const { pullDistance, isPulling, isRefreshing } = usePullToRefresh()
+  return <PullToRefreshIndicator pullDistance={pullDistance} isPulling={isPulling} isRefreshing={isRefreshing} />
 }

--- a/src/contexts/PullToRefreshContext.tsx
+++ b/src/contexts/PullToRefreshContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useRef, useState, useCallback, type ReactNode } from 'react'
+
+interface PullToRefreshContextValue {
+  onRefreshRef: React.MutableRefObject<(() => Promise<void>) | null>
+  isRefreshing: boolean
+  setIsRefreshing: (v: boolean) => void
+  registerRefresh: (fn: () => Promise<void>) => void
+  unregisterRefresh: (fn: () => Promise<void>) => void
+}
+
+const PullToRefreshContext = createContext<PullToRefreshContextValue | null>(null)
+
+export function PullToRefreshProvider({ children }: { children: ReactNode }) {
+  const onRefreshRef = useRef<(() => Promise<void>) | null>(null)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const registerRefresh = useCallback((fn: () => Promise<void>) => {
+    onRefreshRef.current = fn
+  }, [])
+
+  const unregisterRefresh = useCallback((fn: () => Promise<void>) => {
+    if (onRefreshRef.current === fn) {
+      onRefreshRef.current = null
+    }
+  }, [])
+
+  return (
+    <PullToRefreshContext.Provider value={{ onRefreshRef, isRefreshing, setIsRefreshing, registerRefresh, unregisterRefresh }}>
+      {children}
+    </PullToRefreshContext.Provider>
+  )
+}
+
+export function usePullToRefreshContext() {
+  const ctx = useContext(PullToRefreshContext)
+  if (!ctx) throw new Error('usePullToRefreshContext must be used within PullToRefreshProvider')
+  return ctx
+}

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,117 @@
+import { useRef, useState, useEffect, useCallback } from 'react'
+import { usePullToRefreshContext } from '@/contexts/PullToRefreshContext'
+
+const THRESHOLD = 80
+const MAX_PULL = 120
+const RESISTANCE = 0.5
+
+export function usePullToRefresh() {
+  const { onRefreshRef, isRefreshing, setIsRefreshing } = usePullToRefreshContext()
+  const [pullDistance, setPullDistance] = useState(0)
+  const [isPulling, setIsPulling] = useState(false)
+
+  const startYRef = useRef(0)
+  const startXRef = useRef(0)
+  const currentPullRef = useRef(0)
+  const directionLockedRef = useRef<'vertical' | 'horizontal' | null>(null)
+  const pullingRef = useRef(false)
+
+  const isSheetOpen = useCallback(() => {
+    return !!document.querySelector('[data-radix-dialog-overlay]')
+  }, [])
+
+  useEffect(() => {
+    const onTouchStart = (e: TouchEvent) => {
+      if (isRefreshing) return
+      if (window.scrollY > 0) return
+      if (isSheetOpen()) return
+
+      startYRef.current = e.touches[0].clientY
+      startXRef.current = e.touches[0].clientX
+      directionLockedRef.current = null
+    }
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (isRefreshing) return
+      if (isSheetOpen()) {
+        // Sheet opened mid-gesture — abort
+        if (pullingRef.current) {
+          pullingRef.current = false
+          setIsPulling(false)
+          setPullDistance(0)
+          currentPullRef.current = 0
+        }
+        return
+      }
+
+      const deltaY = e.touches[0].clientY - startYRef.current
+      const deltaX = e.touches[0].clientX - startXRef.current
+
+      // Lock direction on first significant movement
+      if (!directionLockedRef.current) {
+        if (Math.abs(deltaX) > 10 || Math.abs(deltaY) > 10) {
+          directionLockedRef.current = Math.abs(deltaX) > Math.abs(deltaY) ? 'horizontal' : 'vertical'
+        }
+      }
+
+      // Ignore horizontal swipes
+      if (directionLockedRef.current === 'horizontal') return
+
+      // Only activate when pulling down from scroll top
+      if (deltaY <= 0 || window.scrollY > 0) {
+        if (pullingRef.current) {
+          pullingRef.current = false
+          setIsPulling(false)
+          setPullDistance(0)
+          currentPullRef.current = 0
+        }
+        return
+      }
+
+      // Prevent native scroll/bounce during pull
+      e.preventDefault()
+
+      const pull = Math.min(deltaY * RESISTANCE, MAX_PULL)
+      currentPullRef.current = pull
+      pullingRef.current = true
+      setIsPulling(true)
+      setPullDistance(pull)
+    }
+
+    const onTouchEnd = async () => {
+      if (!pullingRef.current) return
+
+      const pull = currentPullRef.current
+      pullingRef.current = false
+      directionLockedRef.current = null
+
+      if (pull >= THRESHOLD && onRefreshRef.current) {
+        setIsRefreshing(true)
+        setPullDistance(0)
+        setIsPulling(false)
+        try {
+          await onRefreshRef.current()
+        } finally {
+          setIsRefreshing(false)
+        }
+      } else {
+        setPullDistance(0)
+        setIsPulling(false)
+      }
+
+      currentPullRef.current = 0
+    }
+
+    window.addEventListener('touchstart', onTouchStart, { passive: true })
+    window.addEventListener('touchmove', onTouchMove, { passive: false })
+    window.addEventListener('touchend', onTouchEnd, { passive: true })
+
+    return () => {
+      window.removeEventListener('touchstart', onTouchStart)
+      window.removeEventListener('touchmove', onTouchMove)
+      window.removeEventListener('touchend', onTouchEnd)
+    }
+  }, [isRefreshing, isSheetOpen, onRefreshRef, setIsRefreshing])
+
+  return { pullDistance, isPulling, isRefreshing }
+}

--- a/src/hooks/useRegisterRefresh.ts
+++ b/src/hooks/useRegisterRefresh.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+import { usePullToRefreshContext } from '@/contexts/PullToRefreshContext'
+
+export function useRegisterRefresh(onRefresh: () => Promise<void>) {
+  const { registerRefresh, unregisterRefresh } = usePullToRefreshContext()
+
+  useEffect(() => {
+    registerRefresh(onRefresh)
+    return () => unregisterRefresh(onRefresh)
+  }, [onRefresh, registerRefresh, unregisterRefresh])
+}

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,7 @@
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overscroll-behavior-y: none;
   }
 
   #root {

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useState } from 'react'
+import { lazy, Suspense, useState, useCallback } from 'react'
+import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Lightbulb, Receipt, FileDown, Share2 } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -28,6 +29,12 @@ export function DashboardPage() {
   const { settlements, loading: sLoading, error: sError, refreshSettlements } = useSettlementContext()
   const [selectedBalance, setSelectedBalance] = useState<ParticipantBalance | null>(null)
   const [retrying, setRetrying] = useState(false)
+
+  const handleRefresh = useCallback(
+    () => Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()]).then(() => {}),
+    [refreshParticipants, refreshExpenses, refreshSettlements]
+  )
+  useRegisterRefresh(handleRefresh)
 
   const loading = pLoading || eLoading || sLoading
   const contextError = pError || eError || sError

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
+import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Plus, Search, Receipt, FileDown, SlidersHorizontal, ScanLine, User, Tag } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
@@ -45,6 +46,9 @@ export function ExpensesPage() {
   const { settlements } = useSettlementContext()
   const { pendingReceipts, receiptByExpenseId, dismissReceiptTask } = useReceiptContext()
   const { toast } = useToast()
+
+  const handleRefresh = useCallback(() => refreshExpenses(), [refreshExpenses])
+  useRegisterRefresh(handleRefresh)
 
   const [showForm, setShowForm] = useState(false)
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null)

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { useNavigate } from 'react-router-dom'
 import { Plus, Calendar, Trash2, Share2, ChevronRight, ScanLine, ChevronDown, Eye, ExternalLink, Sparkles } from 'lucide-react'
 import { InstallGuide } from '@/components/InstallGuide'
@@ -27,7 +28,7 @@ const DEMO_TRIP_CODE = 'livigno-2025'
 export function HomePage() {
   const navigate = useNavigate()
   const { user, userProfile } = useAuth()
-  const { loading: tripsLoading } = useTripContext()
+  const { loading: tripsLoading, refreshTrips } = useTripContext()
   const { mode } = useUserPreferences()
   const { tripBalances, loading: balancesLoading } = useMyTripBalances()
   const [localTrips, setLocalTrips] = useState<MyTripEntry[]>([])
@@ -37,6 +38,9 @@ export function HomePage() {
   const [scanContextOpen, setScanContextOpen] = useState(false)
   const [scanCreateOpen, setScanCreateOpen] = useState(false)
   const { shouldShowPrompt, dismiss: dismissInstall, incrementVisit } = usePWAInstall()
+
+  const handleRefresh = useCallback(async () => { await refreshTrips() }, [refreshTrips])
+  useRegisterRefresh(handleRefresh)
 
   const isAuthenticated = !!user
   const loading = isAuthenticated && (balancesLoading || tripsLoading)

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, lazy, Suspense } from 'react'
+import { useState, useEffect, lazy, Suspense, useCallback } from 'react'
+import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { CalendarDays, Map } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMealContext } from '@/contexts/MealContext'
@@ -25,6 +26,12 @@ export function PlannerPage() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [showMap, setShowMap] = useState(true)
   const [retrying, setRetrying] = useState(false)
+
+  const handleRefresh = useCallback(
+    () => Promise.all([refreshMeals(), refreshActivities(), refreshStays()]).then(() => {}),
+    [refreshMeals, refreshActivities, refreshStays]
+  )
+  useRegisterRefresh(handleRefresh)
 
   const loading = mealsLoading || activitiesLoading || staysLoading
   const contextError = mealError || activityError || stayError

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
@@ -39,6 +40,12 @@ export function QuickGroupDetailPage() {
 
   const { pendingReceipts, dismissReceiptTask } = useReceiptContext()
   const { toast } = useToast()
+
+  const handleRefresh = useCallback(
+    () => Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()]).then(() => {}),
+    [refreshParticipants, refreshExpenses, refreshSettlements]
+  )
+  useRegisterRefresh(handleRefresh)
 
   const [expenseOpen, setExpenseOpen] = useState(false)
   const [settlementOpen, setSettlementOpen] = useState(false)

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
+import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { ChevronDown, ChevronRight, Receipt, FileDown } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
@@ -34,6 +35,12 @@ export function SettlementsPage() {
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
   const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
   const [retrying, setRetrying] = useState(false)
+
+  const handleRefresh = useCallback(
+    () => Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()]).then(() => {}),
+    [refreshParticipants, refreshExpenses, refreshSettlements]
+  )
+  useRegisterRefresh(handleRefresh)
 
   const loading = pLoading || eLoading || sLoading
   const contextError = pError || eError || sError

--- a/src/pages/ShoppingPage.tsx
+++ b/src/pages/ShoppingPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Plus, ShoppingCart, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useShoppingContext } from '@/contexts/ShoppingContext'
@@ -28,6 +29,9 @@ export function ShoppingPage() {
   const [sortColumn, setSortColumn] = useState<SortColumn>('status')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [retrying, setRetrying] = useState(false)
+
+  const handleRefresh = useCallback(() => refreshShoppingItems(), [refreshShoppingItems])
+  useRegisterRefresh(handleRefresh)
 
   useEffect(() => {
     const loadItemsWithMeals = async () => {


### PR DESCRIPTION
## Summary
- Adds native-feeling pull-to-refresh gesture for standalone PWA mode (no address bar = no refresh button)
- `usePullToRefresh` hook handles touch gestures with rubber-band resistance (0.5x), 80px threshold, 120px cap
- Pages register their refresh callbacks via `useRegisterRefresh` hook + lightweight `PullToRefreshContext`
- `PullToRefreshIndicator` shows arrow (rotates 0-180deg) while pulling, spinner while refreshing
- Skips when sheets/dialogs are open (`[data-radix-dialog-overlay]`), horizontal swipes, or scrolled down
- `overscroll-behavior-y: none` on body disables Chrome Android's native PTR

### New files (4)
- `src/contexts/PullToRefreshContext.tsx` — stores current onRefresh callback + isRefreshing state
- `src/hooks/usePullToRefresh.ts` — core touch gesture hook
- `src/hooks/useRegisterRefresh.ts` — one-liner for pages to register their refresh function
- `src/components/PullToRefreshIndicator.tsx` — visual indicator (arrow/spinner)

### Modified files (10)
- `src/index.css` — `overscroll-behavior-y: none` on body
- `src/components/Layout.tsx` — PullToRefreshProvider + indicator
- `src/components/QuickLayout.tsx` — PullToRefreshProvider + indicator
- 7 pages: HomePage, QuickGroupDetailPage, ExpensesPage, SettlementsPage, DashboardPage, ShoppingPage, PlannerPage

## Test plan
- [x] `npm run type-check` passes clean
- [x] `npm test` — all 173 unit tests pass
- [x] `npm run test:e2e` — all 26 E2E tests pass
- [ ] Manual test on iPhone Safari (standalone PWA): pull down on home → trips reload
- [ ] Manual test: pull down on quick view → expenses/settlements reload
- [ ] Manual test: open a sheet → pull gesture must NOT activate
- [ ] Manual test: horizontal swipe → must NOT trigger pull
- [ ] Manual test on Android Chrome — native PTR disabled, custom PTR works

🤖 Generated with [Claude Code](https://claude.com/claude-code)