### PR TITLE
docs: update CLAUDE.md and PLAN.md with PR #474

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,6 +447,33 @@ Shield icon button in both Layout and QuickLayout headers — visible to admin u
 
 In PWA standalone mode, the bottom tab bar needs safe-area padding so the iPhone home indicator doesn't overlap tap targets. `viewport-fit=cover` on the viewport meta enables `env(safe-area-inset-bottom)`. CSS utility `pwa-safe-bottom` in `index.css` is scoped to `@media (display-mode: standalone)` — regular browser is unaffected. Applied to bottom nav and main content margin in `Layout.tsx`.
 
+### Pull-to-Refresh (`usePullToRefresh`)
+
+In standalone PWA mode there's no address bar or refresh button. A custom pull-to-refresh gesture provides a native-feeling way to reload data.
+
+**Architecture:** `PullToRefreshProvider` (wraps each layout) stores the current page's refresh callback in a ref. Pages register their callback via `useRegisterRefresh(useCallback(...))`. The `usePullToRefresh` hook in each layout handles touch gestures and calls the registered callback.
+
+**Gesture behaviour:**
+- Only activates when `window.scrollY <= 0` (at scroll top)
+- Ignores horizontal swipes (direction locked on first significant movement)
+- Skips when any Radix sheet/dialog is open (`document.querySelector('[data-radix-dialog-overlay]')`)
+- Rubber-band resistance: `deltaY * 0.5`, capped at 120px. Threshold to trigger: 80px.
+- `touchmove` uses `passive: false` + `preventDefault()` during pull to suppress native iOS bounce and Chrome PTR
+- `overscroll-behavior-y: none` on body in `index.css` disables Chrome Android's native PTR
+
+**Indicator:** `PullToRefreshIndicator` at top of `<main>` — `ArrowDown` icon rotates 0-180deg proportional to progress; `Loader2` spinner during refresh. Transitions disabled during active drag for instant finger tracking.
+
+**Page refresh callbacks:**
+| Page | Callback |
+|------|----------|
+| HomePage | `refreshTrips()` |
+| QuickGroupDetailPage | `refreshParticipants + refreshExpenses + refreshSettlements` |
+| ExpensesPage | `refreshExpenses()` |
+| SettlementsPage | `refreshParticipants + refreshExpenses + refreshSettlements` |
+| DashboardPage | `refreshParticipants + refreshExpenses + refreshSettlements` |
+| ShoppingPage | `refreshShoppingItems()` |
+| PlannerPage | `refreshMeals + refreshActivities + refreshStays` |
+
 ### iOS `start_url` Limitation
 
 iOS Safari ignores `manifest.start_url` and saves whatever URL was in the address bar at install time. All three layers (manifest, SW, client guard) are needed because iOS is inconsistent about which defense fires across versions.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 # PLAN.md — Spl1t Feature Planning Document
 
 > **Living document.** Update at the start and end of every session.
-> Last updated: 2026-03-01 (Phases 1–7 ✅; family refactor Phases 1–4 ✅ COMPLETE; PWA ✅)
+> Last updated: 2026-03-01 (Phases 1–7 ✅; family refactor Phases 1–4 ✅ COMPLETE; PWA ✅; pull-to-refresh ✅)
 
 ---
 
@@ -771,6 +771,7 @@ Replace ad-hoc loading/error patterns with the shared components from 7a.
 | 2026-03-01 | Contact email auto-fill | PR #470: `useTripContacts` now fetches `email` from `user_profiles` alongside `display_name` — profile email as fallback enables email auto-fill, disambiguation, and invite checkbox in both Full and Quick mode. `QuickParticipantPicker` gets same autocomplete dropdown as `ParticipantsSetup` (keyboard nav, contact selection, `suggestedUserId` passthrough) + ambiguous name disambiguation on Recent chips (`"Alex · alex@…"`). |
 | 2026-03-01 | Docs update | PR #471: Updated CLAUDE.md and PLAN.md with PRs #468–#470. |
 | 2026-03-01 | Quick participant picker UX | PR #472: `QuickParticipantPicker` Recent section redesigned — pill grid replaced with collapsible disclosure list (collapsed by default, "Recent (N)" header with chevron). Each row shows name + full email + `+`/`✓` button, naturally disambiguating same-name contacts. Toast-based invite prompt replaced with global "Send invite emails when adding" checkbox (default checked). Removed `useToast`/`ToastAction` imports and `ambiguousNames` memo. |
+| 2026-03-01 | Pull-to-refresh | PR #474: Custom pull-to-refresh gesture for PWA standalone mode (no address bar = no refresh button). `usePullToRefresh` hook handles touch gestures with rubber-band resistance (0.5x), 80px threshold, 120px cap. Pages register refresh callbacks via `useRegisterRefresh` + `PullToRefreshContext`. `PullToRefreshIndicator` shows rotating arrow / spinner. Skips when sheets open or scrolled down. `overscroll-behavior-y: none` disables Chrome Android native PTR. 4 new files, 10 modified. |
 
 ---
 


### PR DESCRIPTION
## Summary
- CLAUDE.md: Added pull-to-refresh section under PWA documenting the gesture hook, context, indicator, and per-page refresh callbacks
- PLAN.md: Added PR #474 entry and updated last-updated line

🤖 Generated with [Claude Code](https://claude.com/claude-code)