### PR TITLE
fix: only activate pull-to-refresh in PWA standalone mode

### DIFF
--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -5,6 +5,13 @@ const THRESHOLD = 80
 const MAX_PULL = 120
 const RESISTANCE = 0.5
 
+function isStandalone() {
+  return (
+    ('standalone' in navigator && (navigator as { standalone?: boolean }).standalone === true) ||
+    window.matchMedia('(display-mode: standalone)').matches
+  )
+}
+
 export function usePullToRefresh() {
   const { onRefreshRef, isRefreshing, setIsRefreshing } = usePullToRefreshContext()
   const [pullDistance, setPullDistance] = useState(0)
@@ -21,6 +28,9 @@ export function usePullToRefresh() {
   }, [])
 
   useEffect(() => {
+    // Only activate in PWA standalone mode — regular browsers have their own refresh
+    if (!isStandalone()) return
+
     const onTouchStart = (e: TouchEvent) => {
       if (isRefreshing) return
       if (window.scrollY > 0) return


### PR DESCRIPTION
## Summary
- Gates `usePullToRefresh` touch listeners behind a standalone PWA check (`display-mode: standalone` / `navigator.standalone`)
- Regular browsers have their own refresh button and native pull-to-refresh — no need for our custom gesture there
- Prevents the custom PTR indicator from showing in normal browser sessions

## Test plan
- [x] `npm run type-check` passes
- [ ] Regular browser: pull down at top of page — no custom indicator, native behavior preserved
- [ ] PWA standalone: pull down at top — custom PTR fires as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)