### PR TITLE
fix: simplify invite emails + add Recent contacts to ParticipantsSetup

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -1,37 +1,29 @@
 import { useState, useEffect, useMemo, useRef, useCallback, FormEvent } from 'react'
 import { Plus, UserPlus, X, Users, Smartphone, ChevronRight, Check } from 'lucide-react'
-import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useTripContacts, TripContact } from '@/hooks/useTripContacts'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { logger } from '@/lib/logger'
-import { withTimeout } from '@/lib/fetchWithTimeout'
 
 interface QuickParticipantPickerProps {
   tripId: string
-  tripCode: string
-  tripName: string
 }
 
-export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickParticipantPickerProps) {
-  const { user, userProfile } = useAuth()
+export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) {
   const { participants, createParticipant } = useParticipantContext()
   const { contacts } = useTripContacts(tripId)
 
   const [addedNames, setAddedNames] = useState<string[]>([])
   const [supportsContacts, setSupportsContacts] = useState(false)
   const [recentExpanded, setRecentExpanded] = useState(false)
-  const [sendInviteOnAdd, setSendInviteOnAdd] = useState(true)
 
   // Manual add form state
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [adding, setAdding] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [sendInvite, setSendInvite] = useState(true)
 
   // Autocomplete state
   const [suggestedUserId, setSuggestedUserId] = useState<string | null>(null)
@@ -115,44 +107,6 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
     setSupportsContacts('contacts' in navigator && typeof (navigator as any).contacts?.select === 'function')
   }, [])
 
-  const organiserName = userProfile?.display_name || user?.email?.split('@')[0] || 'Organiser'
-
-  const sendInvitation = async (participantId: string, participantEmail: string, participantName: string) => {
-    try {
-      const { data: inv, error: invError } = await withTimeout<any>(
-        (supabase as any)
-          .from('invitations')
-          .insert([{ trip_id: tripId, participant_id: participantId, inviter_id: user!.id }])
-          .select('id, token')
-          .single(),
-        15000,
-        'Creating invitation timed out.'
-      )
-
-      if (invError || !inv) {
-        logger.warn('Failed to create invitation row', { error: String(invError) })
-        return
-      }
-
-      supabase.functions.invoke('send-email', {
-        body: {
-          type: 'invitation',
-          invitation_id: inv.id,
-          trip_name: tripName,
-          trip_code: tripCode,
-          participant_name: participantName,
-          participant_email: participantEmail,
-          organiser_name: organiserName,
-          token: (inv as any).token,
-        },
-      }).then(({ error }) => {
-        if (error) logger.warn('send-email returned error', { error: String(error) })
-      })
-    } catch (err) {
-      logger.warn('sendInvitation: unhandled error', { error: String(err) })
-    }
-  }
-
   const addPerson = async (personName: string, personEmail: string | null, personUserId?: string | null) => {
     const emailLower = personEmail?.trim().toLowerCase() ?? null
     if (emailLower) {
@@ -184,10 +138,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
   }
 
   const handleAddRecent = async (contact: TripContact) => {
-    const newParticipant = await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id)
-    if (newParticipant?.email && user && sendInviteOnAdd) {
-      sendInvitation(newParticipant.id, newParticipant.email, newParticipant.name)
-    }
+    await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id)
   }
 
   const handleAddFromContacts = async () => {
@@ -198,10 +149,7 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
         const personName = contact.name?.[0] ?? ''
         const personEmail = contact.email?.[0] ?? null
         if (personName.trim()) {
-          const newParticipant = await addPerson(personName.trim(), personEmail)
-          if (newParticipant?.email && user && sendInviteOnAdd) {
-            sendInvitation(newParticipant.id, newParticipant.email, newParticipant.name)
-          }
+          await addPerson(personName.trim(), personEmail)
         }
       }
     } catch (err) {
@@ -226,14 +174,10 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
 
     setAdding(true)
     try {
-      const newParticipant = await addPerson(name.trim(), email.trim() || null, suggestedUserId)
-      if (newParticipant?.email && user && sendInvite) {
-        sendInvitation(newParticipant.id, newParticipant.email, newParticipant.name)
-      }
+      await addPerson(name.trim(), email.trim() || null, suggestedUserId)
       setName('')
       setEmail('')
       setSuggestedUserId(null)
-      setSendInvite(true)
     } finally {
       setAdding(false)
     }
@@ -280,17 +224,6 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
               className={`transition-transform ${recentExpanded ? 'rotate-90' : ''}`}
             />
           </button>
-          {user && (
-            <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
-              <input
-                type="checkbox"
-                checked={sendInviteOnAdd}
-                onChange={(e) => setSendInviteOnAdd(e.target.checked)}
-                className="rounded border-border"
-              />
-              Send invite emails when adding
-            </label>
-          )}
           {recentExpanded && (
             <div className="border border-border rounded-lg divide-y divide-border overflow-hidden">
               {contacts.slice(0, 20).map((contact, i) => {
@@ -421,17 +354,6 @@ export function QuickParticipantPicker({ tripId, tripCode, tripName }: QuickPart
               onChange={e => setEmail(e.target.value)}
               autoComplete="section-participant email"
             />
-            {email.trim() && (
-              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer mt-1">
-                <input
-                  type="checkbox"
-                  checked={sendInvite}
-                  onChange={(e) => setSendInvite(e.target.checked)}
-                  className="rounded border-border"
-                />
-                Send invite email
-              </label>
-            )}
             <p className="text-xs text-muted-foreground mt-1">
               Add now or let them link themselves via the trip link
             </p>

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -382,8 +382,6 @@ export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowP
               </p>
               <QuickParticipantPicker
                 tripId={createdTripId}
-                tripCode={createdTripCode}
-                tripName={createdTripName}
               />
               <Button variant="ghost" className="w-full text-muted-foreground" onClick={handleDone}>
                 Skip for now

--- a/src/components/setup/IndividualsSetup.tsx
+++ b/src/components/setup/IndividualsSetup.tsx
@@ -3,8 +3,6 @@ import { motion } from 'framer-motion'
 import { X, UserPlus, Mail, Pencil, Check, UserCheck } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
-import { useAuth } from '@/contexts/AuthContext'
-import { supabase } from '@/lib/supabase'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -13,78 +11,26 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { fadeInUp } from '@/lib/animations'
 import type { Participant } from '@/types/participant'
-import { logger } from '@/lib/logger'
 
 interface IndividualsSetupProps {
   onComplete?: () => void
   hasSetup?: boolean
 }
 
-async function sendInvitation(params: {
-  participantId: string
-  participantEmail: string
-  participantName: string
-  tripId: string
-  tripCode: string
-  tripName: string
-  organiserName: string
-  inviterId: string
-}) {
-  try {
-    // Create invitation row
-    const { data: inv, error: invError } = await supabase
-      .from('invitations')
-      .insert([{
-        trip_id: params.tripId,
-        participant_id: params.participantId,
-        inviter_id: params.inviterId,
-      }])
-      .select('id, token')
-      .single()
-
-    if (invError || !inv) {
-      logger.warn('Failed to create invitation row', { error: String(invError) })
-      return
-    }
-
-    // Fire-and-forget: send email
-    supabase.functions.invoke('send-email', {
-      body: {
-        type: 'invitation',
-        invitation_id: inv.id,
-        trip_name: params.tripName,
-        trip_code: params.tripCode,
-        participant_name: params.participantName,
-        participant_email: params.participantEmail,
-        organiser_name: params.organiserName,
-        token: inv.token,
-      },
-    }).then(({ error }) => {
-      if (error) logger.warn('send-email edge fn returned error', { error: String(error) })
-    })
-  } catch (err) {
-    logger.warn('sendInvitation: unhandled error', { error: String(err) })
-  }
-}
-
 export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup = false }: IndividualsSetupProps = {}) {
   const { currentTrip } = useCurrentTrip()
   const { participants, createParticipant, updateParticipant, deleteParticipant } = useParticipantContext()
-  const { user, userProfile } = useAuth()
 
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [isAdult, setIsAdult] = useState(true)
   const [adding, setAdding] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [sendInvite, setSendInvite] = useState(true)
 
   // Per-participant inline email editing
   const [editingEmailId, setEditingEmailId] = useState<string | null>(null)
   const [editEmailValue, setEditEmailValue] = useState('')
   const [savingEmailId, setSavingEmailId] = useState<string | null>(null)
-
-  const organiserName = userProfile?.display_name || user?.email?.split('@')[0] || 'Organiser'
 
   const handleAdd = async (e: FormEvent) => {
     e.preventDefault()
@@ -104,7 +50,7 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
 
     setAdding(true)
     try {
-      const newParticipant = await createParticipant({
+      await createParticipant({
         trip_id: currentTrip.id,
         name: name.trim(),
         is_adult: isAdult,
@@ -112,22 +58,7 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
       })
       setName('')
       setEmail('')
-      setSendInvite(true)
       setIsAdult(true)
-
-      // Send invitation if email provided and user opted in
-      if (newParticipant && email.trim() && user && sendInvite) {
-        sendInvitation({
-          participantId: newParticipant.id,
-          participantEmail: email.trim(),
-          participantName: newParticipant.name,
-          tripId: currentTrip.id,
-          tripCode: currentTrip.trip_code,
-          tripName: currentTrip.name,
-          organiserName,
-          inviterId: user.id,
-        })
-      }
     } finally {
       setAdding(false)
     }
@@ -157,23 +88,7 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
     }
     setError(null)
     setSavingEmailId(participant.id)
-    const hadEmail = !!participant.email
     await updateParticipant(participant.id, { email: newEmail })
-
-    // Send invitation if email is newly set
-    if (newEmail && !hadEmail && currentTrip && user) {
-      sendInvitation({
-        participantId: participant.id,
-        participantEmail: newEmail,
-        participantName: participant.name,
-        tripId: currentTrip.id,
-        tripCode: currentTrip.trip_code,
-        tripName: currentTrip.name,
-        organiserName,
-        inviterId: user.id,
-      })
-    }
-
     setSavingEmailId(null)
     setEditingEmailId(null)
     setEditEmailValue('')
@@ -219,17 +134,6 @@ export function IndividualsSetup({ onComplete: _onComplete, hasSetup: _hasSetup 
                 placeholder="e.g., john@example.com"
                 disabled={adding}
               />
-              {email.trim() && (
-                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={sendInvite}
-                    onChange={(e) => setSendInvite(e.target.checked)}
-                    className="rounded border-border"
-                  />
-                  Send invite email
-                </label>
-              )}
             </div>
 
             <div className="flex items-center space-x-2">

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect, useCallback, FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users } from 'lucide-react'
+import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users, ChevronRight, Plus, Send } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useAuth } from '@/contexts/AuthContext'
@@ -96,11 +96,18 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
   const [suggestedUserId, setSuggestedUserId] = useState<string | null>(null)
   const [showDropdown, setShowDropdown] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
-  const [sendInvite, setSendInvite] = useState(true)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const nameInputRef = useRef<HTMLInputElement>(null)
   const emailInputRef = useRef<HTMLInputElement>(null)
   const justSelectedRef = useRef(false)
+
+  // Recent contacts list
+  const [recentExpanded, setRecentExpanded] = useState(false)
+  const [addedNames, setAddedNames] = useState<string[]>([])
+
+  // Per-participant invite tracking
+  const [sentInviteIds, setSentInviteIds] = useState<Set<string>>(new Set())
+  const [sendingInviteId, setSendingInviteId] = useState<string | null>(null)
 
   // Filtered contacts based on current name input
   const filteredContacts = useMemo(() => {
@@ -252,23 +259,8 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
       setName('')
       setEmail('')
       setSuggestedUserId(null)
-      setSendInvite(true)
       // Keep walletGroup — likely adding more people to the same group
       setIsAdult(true)
-
-      // Send invitation if email provided and user opted in
-      if (newParticipant && email.trim() && user && sendInvite) {
-        sendInvitation({
-          participantId: newParticipant.id,
-          participantEmail: email.trim(),
-          participantName: newParticipant.name,
-          tripId: currentTrip.id,
-          tripCode: currentTrip.trip_code,
-          tripName: currentTrip.name,
-          organiserName,
-          inviterId: user.id,
-        })
-      }
     } finally {
       setAdding(false)
     }
@@ -298,23 +290,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
     }
     setError(null)
     setSavingEmailId(participant.id)
-    const hadEmail = !!participant.email
     await updateParticipant(participant.id, { email: newEmail })
-
-    // Send invitation if email is newly set
-    if (newEmail && !hadEmail && currentTrip && user) {
-      sendInvitation({
-        participantId: participant.id,
-        participantEmail: newEmail,
-        participantName: participant.name,
-        tripId: currentTrip.id,
-        tripCode: currentTrip.trip_code,
-        tripName: currentTrip.name,
-        organiserName,
-        inviterId: user.id,
-      })
-    }
-
     setSavingEmailId(null)
     setEditingEmailId(null)
     setEditEmailValue('')
@@ -333,6 +309,68 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
     setSavingGroupId(null)
     setEditingGroupId(null)
     setEditGroupValue('')
+  }
+
+  const handleAddRecent = async (contact: TripContact) => {
+    if (!currentTrip) return
+    const personName = contact.display_name ?? contact.name
+    const emailLower = contact.email?.trim().toLowerCase() ?? null
+
+    if (emailLower) {
+      const duplicate = participants.some(p => p.email?.toLowerCase() === emailLower)
+      if (duplicate) return
+    }
+
+    const input = {
+      trip_id: currentTrip.id,
+      name: personName,
+      is_adult: true,
+      email: emailLower || null,
+      ...(contact.user_id ? { user_id: contact.user_id } : {}),
+    }
+
+    let newParticipant = await createParticipant(input)
+
+    if (!newParticipant && contact.user_id) {
+      const { user_id: _, ...inputWithoutUserId } = input
+      newParticipant = await createParticipant(inputWithoutUserId)
+    }
+
+    if (newParticipant) {
+      setAddedNames(prev => [...prev, personName])
+    }
+  }
+
+  const isRecentAdded = (contact: TripContact) => {
+    const contactDisplayName = contact.display_name ?? contact.name
+    return addedNames.includes(contactDisplayName) ||
+      participants.some(p => (p.name === contact.name || p.name === contactDisplayName) && (
+        !contact.email || p.email?.toLowerCase() === contact.email?.toLowerCase()
+      ))
+  }
+
+  const handleSendInvite = async (participant: Participant) => {
+    if (!participant.email || !currentTrip || !user) return
+    setSendingInviteId(participant.id)
+    await sendInvitation({
+      participantId: participant.id,
+      participantEmail: participant.email,
+      participantName: participant.name,
+      tripId: currentTrip.id,
+      tripCode: currentTrip.trip_code,
+      tripName: currentTrip.name,
+      organiserName,
+      inviterId: user.id,
+    })
+    setSendingInviteId(null)
+    setSentInviteIds(prev => new Set(prev).add(participant.id))
+    setTimeout(() => {
+      setSentInviteIds(prev => {
+        const next = new Set(prev)
+        next.delete(participant.id)
+        return next
+      })
+    }, 2000)
   }
 
   const renderParticipantRow = (participant: Participant) => (
@@ -375,6 +413,22 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
           >
             <Mail size={15} className={participant.email ? 'text-accent' : 'text-muted-foreground'} />
           </Button>
+          {participant.email && user && (
+            <Button
+              onClick={() => handleSendInvite(participant)}
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              title="Send invite email"
+              disabled={sendingInviteId === participant.id || sentInviteIds.has(participant.id)}
+            >
+              {sentInviteIds.has(participant.id) ? (
+                <Check size={15} className="text-positive" />
+              ) : (
+                <Send size={15} className="text-muted-foreground" />
+              )}
+            </Button>
+          )}
           <Button
             onClick={() => handleDelete(participant.id)}
             variant="ghost"
@@ -493,6 +547,60 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
           <CardTitle>Add Participants</CardTitle>
         </CardHeader>
         <CardContent>
+          {/* Recent contacts from past trips */}
+          {contacts.length > 0 && (
+            <div className="mb-4 space-y-2">
+              <button
+                type="button"
+                onClick={() => setRecentExpanded(prev => !prev)}
+                className="flex items-center gap-2 text-sm font-medium text-muted-foreground w-full"
+              >
+                <Users size={14} />
+                <span>Recent ({contacts.slice(0, 20).length})</span>
+                <ChevronRight
+                  size={14}
+                  className={`transition-transform ${recentExpanded ? 'rotate-90' : ''}`}
+                />
+              </button>
+              {recentExpanded && (
+                <div className="border border-border rounded-lg divide-y divide-border overflow-hidden">
+                  {contacts.slice(0, 20).map((contact, i) => {
+                    const added = isRecentAdded(contact)
+                    const displayName = contact.display_name ?? contact.name
+                    return (
+                      <div
+                        key={i}
+                        className={`flex items-center gap-3 px-3 py-2 text-sm ${
+                          added ? 'opacity-50' : ''
+                        }`}
+                      >
+                        <span className="font-medium truncate">{displayName}</span>
+                        {contact.email && (
+                          <span className="text-xs text-muted-foreground truncate ml-auto mr-2">
+                            {contact.email}
+                          </span>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => !added && handleAddRecent(contact)}
+                          disabled={added}
+                          className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-colors ${
+                            added
+                              ? 'text-primary cursor-default'
+                              : 'hover:bg-accent/50 text-muted-foreground hover:text-foreground'
+                          }`}
+                          aria-label={added ? `${displayName} already added` : `Add ${displayName}`}
+                        >
+                          {added ? <Check size={14} /> : <Plus size={14} />}
+                        </button>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
           {error && (
             <p className="mb-3 text-sm text-destructive">{error}</p>
           )}
@@ -563,17 +671,6 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                 placeholder="e.g., john@example.com"
                 disabled={adding}
               />
-              {email.trim() && (
-                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={sendInvite}
-                    onChange={(e) => setSendInvite(e.target.checked)}
-                    className="rounded border-border"
-                  />
-                  Send invite email
-                </label>
-              )}
               <p className="text-xs text-muted-foreground mt-1">
                 Add now or let them link themselves via the trip link
               </p>


### PR DESCRIPTION
## Summary
- Remove invite email logic from the add-participant flow in QuickParticipantPicker, ParticipantsSetup, and IndividualsSetup (no more checkboxes, no auto-send on add or inline email edit)
- Add collapsible "Recent (N)" contacts list to ParticipantsSetup (same pattern as QuickParticipantPicker) for one-tap adding of past trip contacts
- Add per-participant "Send invite" button on the participant list (visible when participant has email + user is authenticated) with 2s sent indicator

## Test plan
- [x] `npm run type-check` passes clean
- [x] All 173 tests pass
- [ ] Manual: QuickParticipantPicker — no invite checkboxes visible, adding contacts works
- [ ] Manual: ParticipantsSetup (Manage page) — "Recent (N)" disclosure above form, tap to expand, tap + to add, ✓ for already-added
- [ ] Manual: ParticipantsSetup — no "Send invite email" checkbox on add form, no auto-send on inline email edit
- [ ] Manual: ParticipantsSetup — participant with email shows Send button → tap → sends invite → shows ✓ for 2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)