### PR TITLE
fix: auto-populate participant email on "This is me" linking

### DIFF
--- a/src/components/LinkParticipantDialog.tsx
+++ b/src/components/LinkParticipantDialog.tsx
@@ -32,7 +32,7 @@ export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDial
 
   const handleLink = async (participantId: string) => {
     setLinking(true)
-    const success = await linkUserToParticipant(participantId, user.id)
+    const success = await linkUserToParticipant(participantId, user.id, user.email ?? undefined)
     setLinking(false)
 
     if (success) {

--- a/src/contexts/ParticipantContext.tsx
+++ b/src/contexts/ParticipantContext.tsx
@@ -19,7 +19,7 @@ interface ParticipantContextType {
   deleteParticipant: (id: string) => Promise<boolean>
   refreshParticipants: () => Promise<void>
   getAdultParticipants: () => Participant[]
-  linkUserToParticipant: (participantId: string, userId: string) => Promise<boolean>
+  linkUserToParticipant: (participantId: string, userId: string, userEmail?: string) => Promise<boolean>
   unlinkUserFromParticipant: (participantId: string) => Promise<boolean>
 }
 
@@ -169,15 +169,23 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
   }
 
   // Link a user to a participant ("This is me")
-  const linkUserToParticipant = async (participantId: string, userId: string): Promise<boolean> => {
+  const linkUserToParticipant = async (participantId: string, userId: string, userEmail?: string): Promise<boolean> => {
     try {
       setError(null)
+
+      // Backfill email if participant doesn't have one
+      const existing = participants.find(p => p.id === participantId)
+      const backfillEmail = userEmail && !existing?.email
+
+      const updatePayload = backfillEmail
+        ? { user_id: userId, email: userEmail }
+        : { user_id: userId }
 
       const controller = new AbortController()
       const { error: linkError } = await withTimeout<any>(
         (supabase as any)
           .from('participants')
-          .update({ user_id: userId })
+          .update(updatePayload)
           .eq('id', participantId)
           .abortSignal(controller.signal),
         15000,
@@ -188,7 +196,9 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       if (linkError) throw linkError
 
       setParticipants(prev =>
-        prev.map(p => (p.id === participantId ? { ...p, user_id: userId } : p))
+        prev.map(p => (p.id === participantId
+          ? { ...p, user_id: userId, ...(backfillEmail ? { email: userEmail } : {}) }
+          : p))
       )
 
       return true


### PR DESCRIPTION
## Summary
- When a user links themselves to a participant via "This is me", the participant's email is now auto-populated from the auth session if the participant has no email set
- Prevents the need for manual email entry to enable invite/reminder features
- Existing emails are never overwritten

## Test plan
- [ ] `npm run type-check` passes clean
- [ ] All 173 unit tests pass
- [ ] Manual: link to a participant with no email → email populated from auth session
- [ ] Manual: link to a participant with existing email → email NOT overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)