### PR TITLE
fix: remove duplicate demo link + gate bank details to payers — closes #479

### DIFF
--- a/src/components/OnboardingPrompts.tsx
+++ b/src/components/OnboardingPrompts.tsx
@@ -8,7 +8,11 @@ import { Button } from '@/components/ui/button'
 const LOGIN_DISMISS_KEY = 'spl1t:dismiss-login-prompt'
 const BANK_DETAILS_DISMISS_KEY = 'spl1t:dismiss-bank-details'
 
-export function OnboardingPrompts() {
+interface OnboardingPromptsProps {
+  hasPaidExpense?: boolean
+}
+
+export function OnboardingPrompts({ hasPaidExpense = false }: OnboardingPromptsProps) {
   const { user, userProfile, loading } = useAuth()
   const [loginDismissed, setLoginDismissed] = useState(
     () => localStorage.getItem(LOGIN_DISMISS_KEY) === 'true'
@@ -51,7 +55,7 @@ export function OnboardingPrompts() {
 
   // Bank details prompt for authenticated users without bank details
   const hasBankDetails = userProfile?.bank_account_holder || userProfile?.bank_iban
-  if (user && !hasBankDetails && !bankDetailsDismissed) {
+  if (user && !hasBankDetails && !bankDetailsDismissed && hasPaidExpense) {
     return (
       <>
         <div className="mb-6 p-4 rounded-lg border border-border bg-accent/30 flex items-start justify-between gap-3">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -333,7 +333,7 @@ export function HomePage() {
           <InstallGuide variant="banner" onDismiss={dismissInstall} />
         )}
 
-        <OnboardingPrompts />
+        <OnboardingPrompts hasPaidExpense={tripBalances.some(tb => tb.myBalance && tb.myBalance.totalPaid > 0)} />
 
         {/* Scan CTA — authenticated users only */}
         {isAuthenticated && (
@@ -355,19 +355,6 @@ export function HomePage() {
             </div>
             <ChevronRight size={18} className="opacity-70" />
           </button>
-        )}
-
-        {/* Demo link — authenticated users with no trips */}
-        {isAuthenticated && !loading && visibleTrips.length === 0 && (
-          <div className="text-center -mt-3 mb-6">
-            <button
-              onClick={() => navigate(`/t/${DEMO_TRIP_CODE}`)}
-              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <Sparkles size={14} />
-              Try a demo
-            </button>
-          </div>
         )}
 
         {/* Action Buttons — unauthenticated only (authenticated uses sheet + scan CTA) */}


### PR DESCRIPTION
## Summary
- Remove standalone "Try a demo" link below Scan CTA — the empty state card already has one, so authenticated users with no trips were seeing it twice
- Bank details prompt (`OnboardingPrompts`) now only appears when the user has paid for at least one expense across any trip, not immediately on sign-up

## Test plan
- [ ] `npm run type-check` passes
- [ ] Auth user with no trips: one "Try a demo" link (inside empty state card only)
- [ ] Unauth user: one "Try a demo" link (inside empty state card)
- [ ] Auth user with no paid expenses: no bank details banner
- [ ] Auth user who has paid an expense: bank details banner appears (if not already set/dismissed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)