### PR TITLE
fix: detect stale chunk errors and auto-reload — closes #483

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,18 @@ import { AlertTriangle, Home, RefreshCw } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 
+const CHUNK_RELOAD_KEY = 'spl1t:chunk-reload'
+
+function isStaleChunkError(error: Error): boolean {
+  const msg = error.message
+  return (
+    msg.includes('is not a valid JavaScript MIME type') ||
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('Importing a module script failed') ||
+    msg.includes('error loading dynamically imported module')
+  )
+}
+
 interface Props {
   children: ReactNode
   fallback?: ReactNode
@@ -26,6 +38,17 @@ export class ErrorBoundary extends Component<Props, State> {
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo)
+
+    // Auto-reload once for stale chunk errors (new deploy invalidated cached JS)
+    if (isStaleChunkError(error)) {
+      const alreadyReloaded = sessionStorage.getItem(CHUNK_RELOAD_KEY)
+      if (!alreadyReloaded) {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, '1')
+        window.location.reload()
+        return
+      }
+    }
+
     import('@/lib/logger').then(({ logger }) => {
       logger.error('React ErrorBoundary caught error', {
         errorMessage: error.message,
@@ -49,6 +72,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   private handleRefresh = () => {
+    sessionStorage.removeItem(CHUNK_RELOAD_KEY)
     window.location.reload()
   }
 
@@ -58,7 +82,31 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback
       }
 
+      const staleChunk = this.state.error ? isStaleChunkError(this.state.error) : false
       const exhaustedRetries = this.state.resetCount >= 2
+
+      // Stale chunk: if auto-reload already happened, show targeted message
+      if (staleChunk) {
+        return (
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex flex-col items-center justify-center py-8 text-center">
+                <RefreshCw className="h-12 w-12 text-primary mb-4" />
+                <h3 className="text-lg font-semibold text-foreground mb-2">
+                  New version available
+                </h3>
+                <p className="text-sm text-muted-foreground mb-4 max-w-md">
+                  Spl1t has been updated. Please refresh to load the latest version.
+                </p>
+                <Button onClick={this.handleRefresh} variant="default">
+                  <RefreshCw size={16} className="mr-2" />
+                  Refresh page
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )
+      }
 
       return (
         <Card className="border-destructive/50">


### PR DESCRIPTION
## Summary
- After a new Cloudflare Pages deploy, cached HTML may reference old JS chunk filenames that no longer exist. The CDN returns the SPA fallback HTML, and the browser rejects it with `'text/html' is not a valid JavaScript MIME type`
- ErrorBoundary now detects stale chunk errors (4 message variants) and auto-reloads once (`sessionStorage` guard prevents infinite loops)
- If the auto-reload doesn't resolve it, shows a friendly "New version available — please refresh" card instead of the scary generic error boundary

## Test plan
- [ ] `npm run type-check` passes
- [ ] All 173 tests pass
- [ ] Manual: simulate stale chunk error → page auto-reloads once
- [ ] Manual: if error persists after reload → "New version available" card with Refresh button
- [ ] Manual: non-chunk errors → generic error boundary behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)