### PR TITLE
fix: scan flow sheet vanishing + preserve child status — closes #494, #495

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -107,7 +107,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
     setSupportsContacts('contacts' in navigator && typeof (navigator as any).contacts?.select === 'function')
   }, [])
 
-  const addPerson = async (personName: string, personEmail: string | null, personUserId?: string | null) => {
+  const addPerson = async (personName: string, personEmail: string | null, personUserId?: string | null, isAdult?: boolean) => {
     const emailLower = personEmail?.trim().toLowerCase() ?? null
     if (emailLower) {
       const duplicate = participants.some(p => p.email?.toLowerCase() === emailLower)
@@ -117,7 +117,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
     const input = {
       trip_id: tripId,
       name: personName.trim(),
-      is_adult: true,
+      is_adult: isAdult ?? true,
       email: emailLower || null,
       ...(personUserId ? { user_id: personUserId } : {}),
     }
@@ -138,7 +138,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
   }
 
   const handleAddRecent = async (contact: TripContact) => {
-    await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id)
+    await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id, contact.is_adult)
   }
 
   const handleAddFromContacts = async () => {
@@ -237,6 +237,9 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
                     }`}
                   >
                     <span className="font-medium truncate">{displayName}</span>
+                    {!contact.is_adult && (
+                      <span className="text-[10px] text-muted-foreground border border-border rounded px-1 py-0.5 shrink-0">Child</span>
+                    )}
                     {contact.email && (
                       <span className="text-xs text-muted-foreground truncate ml-auto mr-2">
                         {contact.email}

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -324,7 +324,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
     const input = {
       trip_id: currentTrip.id,
       name: personName,
-      is_adult: true,
+      is_adult: contact.is_adult ?? true,
       email: emailLower || null,
       ...(contact.user_id ? { user_id: contact.user_id } : {}),
     }
@@ -385,9 +385,15 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
           <span className="font-medium text-foreground truncate">
             {participant.name}
           </span>
-          <Badge variant={participant.is_adult ? 'soft' : 'outline'}>
-            {participant.is_adult ? 'Adult' : 'Child'}
-          </Badge>
+          <button
+            type="button"
+            onClick={() => updateParticipant(participant.id, { is_adult: !participant.is_adult })}
+            title={`Click to change to ${participant.is_adult ? 'Child' : 'Adult'}`}
+          >
+            <Badge variant={participant.is_adult ? 'soft' : 'outline'} className="cursor-pointer hover:opacity-80 transition-opacity">
+              {participant.is_adult ? 'Adult' : 'Child'}
+            </Badge>
+          </button>
           {participant.user_id && (
             <span title="Account linked" className="shrink-0">
               <UserCheck size={12} className="text-positive" />
@@ -575,6 +581,9 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                         }`}
                       >
                         <span className="font-medium truncate">{displayName}</span>
+                        {!contact.is_adult && (
+                          <span className="text-[10px] text-muted-foreground border border-border rounded px-1 py-0.5 shrink-0">Child</span>
+                        )}
                         {contact.email && (
                           <span className="text-xs text-muted-foreground truncate ml-auto mr-2">
                             {contact.email}

--- a/src/hooks/useTripContacts.ts
+++ b/src/hooks/useTripContacts.ts
@@ -10,6 +10,7 @@ export interface TripContact {
   email: string | null
   user_id: string | null
   display_name: string | null
+  is_adult: boolean
   lastSeenAt: string
 }
 
@@ -57,7 +58,7 @@ export function useTripContacts(currentTripId: string | undefined) {
         const { data, error } = await withTimeout(
           supabase
             .from('participants')
-            .select('name, email, user_id, trip_id')
+            .select('name, email, user_id, trip_id, is_adult')
             .in('trip_id', otherTripIds)
             .limit(200)
             .abortSignal(controller.signal),
@@ -139,6 +140,7 @@ export function useTripContacts(currentTripId: string | undefined) {
               email: bestEmail,
               user_id: p.user_id ?? null,
               display_name,
+              is_adult: isNewer ? (p.is_adult ?? true) : (existing?.is_adult ?? true),
               lastSeenAt: isNewer ? lastSeenAt : existing!.lastSeenAt,
             })
           }

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -32,6 +32,11 @@ export function ConditionalHomePage() {
       return
     }
 
+    // Don't redirect while a sheet/dialog is open (e.g. QuickScanCreateFlow).
+    // Creating a trip with today's date would otherwise trigger an immediate
+    // redirect that unmounts the sheet mid-flow.
+    if (document.querySelector('[data-radix-dialog-overlay]')) return
+
     // Only auto-redirect for authenticated users. For unauthenticated users,
     // TripContext fetches ALL trips and localStorage includes shared-link trips,
     // so there's no reliable way to distinguish "my trip" from "visited via link".


### PR DESCRIPTION
## Summary
- **Sheet vanishing bug (#494)**: `QuickScanCreateFlow` creates a trip with today's date, which updates `TripContext.trips`. `ConditionalHomePage` detects the new active trip and redirects to `/t/:code/quick`, unmounting the sheet mid-flow. Fix: skip redirect when any Radix sheet/dialog overlay is open (same guard pattern as `usePullToRefresh`).
- **Child→adult conversion (#495)**: Recent contacts from other trips were always added as adults (`is_adult: true` hardcoded). Now `TripContact` includes `is_adult` from the source trip and passes it through when adding.
- **Child label**: "Child" indicator shown next to child contacts in recent contacts lists (both Quick and Full mode).
- **Adult/Child toggle**: Badge in `ParticipantsSetup` is now clickable to toggle between Adult/Child.

Closes #494, closes #495

## Test plan
- [ ] Open scan flow on mobile home page → add participants from recent list → sheet stays open (doesn't vanish)
- [ ] Add a contact who was a child in another trip → they're added as Child (not Adult)
- [ ] Recent contacts list shows "Child" label next to child contacts
- [ ] Tap Adult/Child badge on Manage page → toggles correctly
- [ ] `npm run type-check` passes clean
- [ ] All 173 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)