### PR TITLE
style: left-align email header logo and wordmark

### DIFF
--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -65,19 +65,15 @@ function baseEmailHtml(params: {
         <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;background:${BRAND.white};border-radius:12px;border:1px solid ${BRAND.border};overflow:hidden;">
           <!-- Header — logo + wordmark -->
           <tr>
-            <td style="background:${BRAND.white};padding:16px 32px;text-align:center;border-bottom:1px solid ${BRAND.border};">
-              <table cellpadding="0" cellspacing="0" style="margin:0 auto;">
+            <td style="background:${BRAND.white};padding:16px 32px;border-bottom:1px solid ${BRAND.border};">
+              <table cellpadding="0" cellspacing="0">
                 <tr>
                   <td style="vertical-align:middle;padding-right:4px;">
                     <img src="https://split.xtian.me/logo-email.png" alt="Spl1t" width="30" height="30" style="display:block;" />
                   </td>
                   <td style="vertical-align:middle;">
                     <span style="font-size:24px;font-weight:700;color:${BRAND.textPrimary};letter-spacing:-0.5px;">Spl<span style="color:${BRAND.coral};">1</span>t</span>
-                  </td>
-                </tr>
-                <tr>
-                  <td colspan="2" style="text-align:center;padding-top:2px;">
-                    <span style="color:${BRAND.textMuted};font-size:12px;">${subtitle}</span>
+                    <div style="margin-top:2px;color:${BRAND.textMuted};font-size:12px;">${subtitle}</div>
                   </td>
                 </tr>
               </table>


### PR DESCRIPTION
## Summary
- Left-align logo + wordmark in email header (removed `text-align:center` and `margin:0 auto`)
- Move subtitle back inline under wordmark text for tighter grouping

## Test plan
- [x] Verified in Gmail — logo sits at left edge of header

🤖 Generated with [Claude Code](https://claude.com/claude-code)