### PR TITLE
feat: sync participant name/email from Google on link

### DIFF
--- a/src/components/LinkParticipantDialog.tsx
+++ b/src/components/LinkParticipantDialog.tsx
@@ -19,7 +19,7 @@ interface LinkParticipantDialogProps {
 }
 
 export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDialogProps) {
-  const { user } = useAuth()
+  const { user, userProfile } = useAuth()
   const { participants, linkUserToParticipant } = useParticipantContext()
   const { isLinked } = useMyParticipant()
   const [open, setOpen] = useState(false)
@@ -32,7 +32,7 @@ export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDial
 
   const handleLink = async (participantId: string) => {
     setLinking(true)
-    const success = await linkUserToParticipant(participantId, user.id, user.email ?? undefined)
+    const success = await linkUserToParticipant(participantId, user.id, user.email ?? undefined, userProfile?.display_name ?? undefined)
     setLinking(false)
 
     if (success) {

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -410,15 +410,17 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
           >
             <Users size={15} className={participant.wallet_group ? 'text-accent' : 'text-muted-foreground'} />
           </Button>
-          <Button
-            onClick={() => handleStartEditEmail(participant)}
-            variant="ghost"
-            size="sm"
-            className="h-8 w-8 p-0"
-            title={participant.email ? `Email: ${participant.email}` : 'Add email'}
-          >
-            <Mail size={15} className={participant.email ? 'text-accent' : 'text-muted-foreground'} />
-          </Button>
+          {!participant.user_id && (
+            <Button
+              onClick={() => handleStartEditEmail(participant)}
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              title={participant.email ? `Email: ${participant.email}` : 'Add email'}
+            >
+              <Mail size={15} className={participant.email ? 'text-accent' : 'text-muted-foreground'} />
+            </Button>
+          )}
           {participant.email && user && (
             <Button
               onClick={() => handleSendInvite(participant)}
@@ -479,7 +481,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
       )}
 
       {/* Inline email editor */}
-      {editingEmailId === participant.id && (
+      {editingEmailId === participant.id && !participant.user_id && (
         <div className="mt-2 flex gap-2">
           <Input
             type="email"
@@ -523,13 +525,20 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
 
       {/* Show email if set and not editing */}
       {participant.email && editingEmailId !== participant.id && (
-        <button
-          onClick={() => handleStartEditEmail(participant)}
-          className="mt-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <Pencil size={11} />
-          {participant.email}
-        </button>
+        participant.user_id ? (
+          <span className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <Mail size={11} />
+            {participant.email}
+          </span>
+        ) : (
+          <button
+            onClick={() => handleStartEditEmail(participant)}
+            className="mt-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <Pencil size={11} />
+            {participant.email}
+          </button>
+        )
       )}
     </motion.div>
   )

--- a/src/contexts/ParticipantContext.tsx
+++ b/src/contexts/ParticipantContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { createContext, useContext, useState, useEffect, useRef, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import {
   Participant,
@@ -6,6 +6,7 @@ import {
   UpdateParticipantInput,
 } from '@/types/participant'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useAuth } from '@/contexts/AuthContext'
 import { withTimeout } from '@/lib/fetchWithTimeout'
 import { useAbortController } from '@/hooks/useAbortController'
 
@@ -19,7 +20,7 @@ interface ParticipantContextType {
   deleteParticipant: (id: string) => Promise<boolean>
   refreshParticipants: () => Promise<void>
   getAdultParticipants: () => Participant[]
-  linkUserToParticipant: (participantId: string, userId: string, userEmail?: string) => Promise<boolean>
+  linkUserToParticipant: (participantId: string, userId: string, userEmail?: string, displayName?: string) => Promise<boolean>
   unlinkUserFromParticipant: (participantId: string) => Promise<boolean>
 }
 
@@ -32,6 +33,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null)
 
   const { currentTrip, tripCode } = useCurrentTrip()
+  const { user, userProfile } = useAuth()
   const { newSignal, cancel } = useAbortController()
 
   const clearError = () => setError(null)
@@ -169,17 +171,13 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
   }
 
   // Link a user to a participant ("This is me")
-  const linkUserToParticipant = async (participantId: string, userId: string, userEmail?: string): Promise<boolean> => {
+  const linkUserToParticipant = async (participantId: string, userId: string, userEmail?: string, displayName?: string): Promise<boolean> => {
     try {
       setError(null)
 
-      // Backfill email if participant doesn't have one
-      const existing = participants.find(p => p.id === participantId)
-      const backfillEmail = userEmail && !existing?.email
-
-      const updatePayload = backfillEmail
-        ? { user_id: userId, email: userEmail }
-        : { user_id: userId }
+      const updatePayload: Record<string, unknown> = { user_id: userId }
+      if (userEmail) updatePayload.email = userEmail
+      if (displayName) updatePayload.name = displayName
 
       const controller = new AbortController()
       const { error: linkError } = await withTimeout<any>(
@@ -197,8 +195,9 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
 
       setParticipants(prev =>
         prev.map(p => (p.id === participantId
-          ? { ...p, user_id: userId, ...(backfillEmail ? { email: userEmail } : {}) }
+          ? { ...p, user_id: userId, ...(userEmail ? { email: userEmail } : {}), ...(displayName ? { name: displayName } : {}) }
           : p))
+          .sort((a, b) => a.name.localeCompare(b.name))
       )
 
       return true
@@ -261,6 +260,30 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
     }
     return cancel
   }, [tripCode, currentTrip?.id])
+
+  // Background sync: keep linked participant's name/email in sync with Google profile
+  const bgSyncDoneRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!user || !userProfile?.display_name || participants.length === 0) return
+
+    const myParticipant = participants.find(p => p.user_id === user.id)
+    if (!myParticipant) return
+
+    const nameStale = myParticipant.name !== userProfile.display_name
+    const emailStale = user.email && myParticipant.email !== user.email
+
+    if (!nameStale && !emailStale) return
+
+    // Prevent re-firing for the same participant while update is in flight
+    const syncKey = `${myParticipant.id}:${userProfile.display_name}:${user.email}`
+    if (bgSyncDoneRef.current === syncKey) return
+    bgSyncDoneRef.current = syncKey
+
+    updateParticipant(myParticipant.id, {
+      ...(nameStale ? { name: userProfile.display_name } : {}),
+      ...(emailStale ? { email: user.email! } : {}),
+    })
+  }, [participants, userProfile?.display_name, user?.email])
 
   const value: ParticipantContextType = {
     participants,

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -130,11 +130,16 @@ export function JoinPage() {
       setLinkError(null)
 
       try {
-        // Link auth user to participant
+        // Link auth user to participant — sync name from Google profile
+        const displayName = user!.user_metadata?.full_name || user!.user_metadata?.name || null
         const { error: linkError } = await withTimeout<any>(
           (supabase as any)
             .from('participants')
-            .update({ user_id: user!.id, email: user!.email || null })
+            .update({
+              user_id: user!.id,
+              email: user!.email || null,
+              ...(displayName ? { name: displayName } : {}),
+            })
             .eq('id', invitation!.participant_id),
           15000,
           'Linking account timed out. Please check your connection and try again.'


### PR DESCRIPTION
## Summary
- When a user clicks "This is me" or accepts an invitation, their Google display name and email now overwrite the participant record (previously only email was conditionally backfilled)
- Background sync `useEffect` in `ParticipantContext` silently updates stale name/email on each trip load — catches old trips, Google name changes, and JoinPage timing races
- Email editing is locked (button hidden, display read-only) for linked participants in `ParticipantsSetup`
- JoinPage uses `user_metadata.full_name` directly (available immediately from auth session) to avoid async `userProfile` timing issues

## Test plan
- [ ] Sign in → create trip → add participant "K" → click "This is me" → verify name changes to Google display name and email is set
- [ ] Try to click the email edit button on a linked participant → should be hidden
- [ ] Linked participant email displays as read-only text (mail icon, no pencil)
- [ ] On an old trip where you're already linked with a stale name → reload → name + email auto-sync
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (172/173, 1 pre-existing flaky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)