### PR TITLE
fix: backfill linked participant names from Google profiles

### DIFF
--- a/supabase/migrations/034_sync_linked_participant_names.sql
+++ b/supabase/migrations/034_sync_linked_participant_names.sql
@@ -1,0 +1,14 @@
+-- One-time backfill: sync linked participants' name + email from Google profiles
+-- Linked participants (user_id IS NOT NULL) should always reflect the user's
+-- Google display name and email. Prior to PR #502, only user_id was written
+-- on link — name and email were left as whatever the organiser originally entered.
+
+UPDATE participants p
+SET
+  name  = up.display_name,
+  email = au.email
+FROM user_profiles up
+JOIN auth.users au ON au.id = up.id
+WHERE p.user_id = up.id
+  AND (p.name IS DISTINCT FROM up.display_name
+       OR p.email IS DISTINCT FROM au.email);


### PR DESCRIPTION
## Summary
- One-time SQL migration (`034`) to sync all linked participants' `name` and `email` from `user_profiles.display_name` and `auth.users.email`
- Prior to PR #502, only `user_id` was written on "This is me" link — names stayed as whatever the organiser originally entered ("K", "Mom", etc.)
- Safe to re-run (no-op when already in sync via `IS DISTINCT FROM`)

## Test plan
- [ ] Apply migration: `supabase db push`
- [ ] Verify in Supabase Table Editor that linked participants now show Google display names and emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)