### PR TITLE
feat: add participant nicknames + Google avatars

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -3,14 +3,16 @@ import { ArrowDownToLine, ArrowUpFromLine, CheckCircle2 } from 'lucide-react'
 import { ParticipantBalance } from '@/services/balanceCalculator'
 import { formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
 import { Card } from '@/components/ui/card'
+import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 
 interface BalanceCardProps {
   balance: ParticipantBalance
   currency?: string
   onClick?: () => void
+  avatarUrl?: string | null
 }
 
-export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardProps) {
+export function BalanceCard({ balance, currency = 'EUR', onClick, avatarUrl }: BalanceCardProps) {
   const balanceColorClass = getBalanceColorClass(balance.balance)
   const formattedBalance = formatBalance(balance.balance, currency)
   const fmt = (value: number) => new Intl.NumberFormat('en-US', {
@@ -66,8 +68,9 @@ export function BalanceCard({ balance, currency = 'EUR', onClick }: BalanceCardP
       >
         {/* Header */}
         <div className="flex items-start justify-between mb-3">
-          <div className="flex-1">
-            <h3 className="text-lg font-semibold text-foreground">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <ParticipantAvatar participant={{ name: balance.name, avatar_url: avatarUrl ?? null }} size="md" />
+            <h3 className="text-lg font-semibold text-foreground truncate">
               {balance.name}
             </h3>
           </div>

--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -6,6 +6,7 @@ import { ParticipantBalance, formatBalance, getBalanceColorClass, convertToBaseC
 import { Expense } from '@/types/expense'
 import { Participant } from '@/types/participant'
 import { Settlement } from '@/types/settlement'
+import { getShortName } from '@/lib/participantUtils'
 
 interface CostBreakdownDialogProps {
   open: boolean
@@ -107,7 +108,7 @@ export function CostBreakdownDialog({
 
   const participantNameMap = useMemo(() => {
     const map = new Map<string, string>()
-    participants.forEach(p => map.set(p.id, p.name))
+    participants.forEach(p => map.set(p.id, getShortName(p)))
     return map
   }, [participants])
 

--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -19,6 +19,7 @@ import { convertToBaseCurrency } from '@/services/balanceCalculator'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
+import { getShortName } from '@/lib/participantUtils'
 
 interface ExpenseCardProps {
   expense: Expense
@@ -52,14 +53,14 @@ export function ExpenseCard({ expense, onEdit, onDelete, onViewReceipt }: Expens
 
   const getPaidByName = () => {
     const participant = participants.find(p => p.id === expense.paid_by)
-    return participant?.name || 'Unknown'
+    return participant ? getShortName(participant) : 'Unknown'
   }
 
   const getDistributionText = () => {
     const dist = expense.distribution
     const ids = dist.type === 'individuals' ? dist.participants : []
     const names = ids
-      .map(id => participants.find(p => p.id === id)?.name)
+      .map(id => { const p = participants.find(pp => pp.id === id); return p ? getShortName(p) : null })
       .filter(Boolean)
     if (names.length === participants.length) {
       return 'Everyone'

--- a/src/components/ParticipantAvatar.tsx
+++ b/src/components/ParticipantAvatar.tsx
@@ -1,0 +1,39 @@
+import type { Participant } from '@/types/participant'
+
+interface ParticipantAvatarProps {
+  participant: Pick<Participant, 'name' | 'avatar_url'>
+  size?: 'sm' | 'md'
+}
+
+const sizes = {
+  sm: 'w-6 h-6 text-[10px]',
+  md: 'w-8 h-8 text-xs',
+}
+
+export function ParticipantAvatar({ participant, size = 'md' }: ParticipantAvatarProps) {
+  const sizeClass = sizes[size]
+
+  const initials = participant.name
+    .split(' ')
+    .map(n => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+
+  if (participant.avatar_url) {
+    return (
+      <img
+        src={participant.avatar_url}
+        alt={participant.name}
+        className={`${sizeClass} rounded-full shrink-0 object-cover`}
+        referrerPolicy="no-referrer"
+      />
+    )
+  }
+
+  return (
+    <div className={`${sizeClass} rounded-full shrink-0 flex items-center justify-center font-medium bg-primary/10 text-primary`}>
+      {initials}
+    </div>
+  )
+}

--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
+import { getShortName } from '@/lib/participantUtils'
 
 interface SettlementFormProps {
   onSubmit: (input: CreateSettlementInput) => Promise<void>
@@ -83,7 +84,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
     .filter(p => p.is_adult)
     .map(p => ({
       id: p.id,
-      name: p.name,
+      name: getShortName(p),
       groupName: p.wallet_group || null,
     }))
 

--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -3,6 +3,7 @@ import { PartyPopper, Lightbulb, Check, Bell, X } from 'lucide-react'
 import { OptimalSettlementPlan, SettlementTransaction } from '@/services/settlementOptimizer'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 
 export interface BankDetails {
   holder: string
@@ -16,9 +17,10 @@ interface SettlementPlanProps {
   linkedParticipantIds?: Set<string>
   fromEmailMap?: Record<string, string>
   onRemind?: (transaction: SettlementTransaction, fromEmail: string) => Promise<void>
+  avatarMap?: Record<string, string | null>
 }
 
-export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap, linkedParticipantIds, fromEmailMap, onRemind }: SettlementPlanProps) {
+export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap, linkedParticipantIds, fromEmailMap, onRemind, avatarMap }: SettlementPlanProps) {
   if (plan.transactions.length === 0) {
     return (
       <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
@@ -66,6 +68,7 @@ export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap, linke
             linkedParticipantIds={linkedParticipantIds}
             fromEmail={fromEmailMap?.[transaction.fromId]}
             onRemind={onRemind ? (email) => onRemind(transaction, email) : undefined}
+            avatarMap={avatarMap}
           />
         ))}
       </div>
@@ -82,6 +85,7 @@ interface SettlementTransactionCardProps {
   linkedParticipantIds?: Set<string>
   fromEmail?: string
   onRemind?: (fromEmail: string) => Promise<void>
+  avatarMap?: Record<string, string | null>
 }
 
 function SettlementTransactionCard({
@@ -93,6 +97,7 @@ function SettlementTransactionCard({
   linkedParticipantIds,
   fromEmail,
   onRemind,
+  avatarMap,
 }: SettlementTransactionCardProps) {
   const [confirmingRemind, setConfirmingRemind] = useState(false)
   const [sending, setSending] = useState(false)
@@ -132,7 +137,8 @@ function SettlementTransactionCard({
 
           {/* Transaction Details */}
           <div className="flex items-center gap-2 text-sm flex-wrap">
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1.5">
+              <ParticipantAvatar participant={{ name: transaction.fromName, avatar_url: avatarMap?.[transaction.fromId] ?? null }} size="sm" />
               <span className="font-medium text-foreground">
                 {transaction.fromName}
               </span>
@@ -140,7 +146,8 @@ function SettlementTransactionCard({
 
             <span className="text-muted-foreground flex-shrink-0">→</span>
 
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1.5">
+              <ParticipantAvatar participant={{ name: transaction.toName, avatar_url: avatarMap?.[transaction.toId] ?? null }} size="sm" />
               <span className="font-medium text-foreground">
                 {transaction.toName}
               </span>

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
+import { getShortName } from '@/lib/participantUtils'
 import { ExpenseSplitPreview } from './ExpenseSplitPreview'
 
 interface ExpenseFormProps {
@@ -434,7 +435,7 @@ export function ExpenseForm({
               <div className="flex-1">
                 <div className="flex items-center gap-2 text-sm font-medium text-foreground">
                   <Lightbulb size={16} className="text-accent" />
-                  <span><strong>{suggestedPayer.name}</strong> should pay next</span>
+                  <span><strong>{suggestedPayer.name.split(' ')[0]}</strong> should pay next</span>
                 </div>
                 <p className="text-xs text-muted-foreground mt-1">
                   Current balance:{' '}
@@ -458,7 +459,7 @@ export function ExpenseForm({
           <SelectContent>
             {adults.map(adult => (
               <SelectItem key={adult.id} value={adult.id}>
-                {adult.name}
+                {getShortName(adult)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -584,7 +585,7 @@ export function ExpenseForm({
                       htmlFor={`participant-${participant.id}`}
                       className="text-sm text-foreground cursor-pointer flex-1"
                     >
-                      {participant.name} {participant.is_adult ? '' : '(child)'}
+                      {getShortName(participant)} {participant.is_adult ? '' : '(child)'}
                     </label>
                     {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
                       <Input

--- a/src/components/expenses/ExpenseSplitPreview.tsx
+++ b/src/components/expenses/ExpenseSplitPreview.tsx
@@ -4,6 +4,7 @@ import { Participant } from '@/types/participant'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { User } from 'lucide-react'
+import { getShortName } from '@/lib/participantUtils'
 
 interface ExpenseSplitPreviewProps {
   amount: number
@@ -44,7 +45,7 @@ export function ExpenseSplitPreview({
           if (existing) {
             existing.memberIds.push(pid)
           } else {
-            entityMap.set(key, { name: p.wallet_group ?? p.name, memberIds: [pid] })
+            entityMap.set(key, { name: p.wallet_group ?? getShortName(p), memberIds: [pid] })
           }
         }
         const perEntity = amount / entityMap.size
@@ -53,7 +54,7 @@ export function ExpenseSplitPreview({
           for (const mid of entity.memberIds) {
             const p = participants.find(pp => pp.id === mid)
             if (p) {
-              entries.push({ id: mid, name: p.name, amount: perMember })
+              entries.push({ id: mid, name: getShortName(p), amount: perMember })
             }
           }
         }
@@ -66,7 +67,7 @@ export function ExpenseSplitPreview({
           if (participant) {
             entries.push({
               id: participantId,
-              name: participant.name,
+              name: getShortName(participant),
               amount: shareAmount,
             })
           }
@@ -79,7 +80,7 @@ export function ExpenseSplitPreview({
           const shareAmount = (amount * split.value) / 100
           entries.push({
             id: split.participantId,
-            name: participant.name,
+            name: getShortName(participant),
             amount: shareAmount,
           })
         }
@@ -90,7 +91,7 @@ export function ExpenseSplitPreview({
         if (participant) {
           entries.push({
             id: split.participantId,
-            name: participant.name,
+            name: getShortName(participant),
             amount: split.value,
           })
         }

--- a/src/components/expenses/wizard/WizardStep2.tsx
+++ b/src/components/expenses/wizard/WizardStep2.tsx
@@ -9,6 +9,8 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
+import { getShortName } from '@/lib/participantUtils'
+import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 
 interface SuggestedPayer {
   id: string
@@ -19,7 +21,9 @@ interface SuggestedPayer {
 interface Participant {
   id: string
   name: string
+  nickname?: string | null
   is_adult: boolean
+  avatar_url?: string | null
 }
 
 interface WizardStep2Props {
@@ -78,7 +82,7 @@ export function WizardStep2({
             <Lightbulb size={20} className="text-accent flex-shrink-0" />
             <div className="flex-1 min-w-0">
               <p className="font-medium text-foreground">
-                <strong>{suggestedPayer.name}</strong> should pay next
+                <strong>{suggestedPayer.name.split(' ')[0]}</strong> should pay next
               </p>
               <p className="text-sm text-muted-foreground mt-0.5">
                 Balance: {formatBalance(suggestedPayer.balance, currency)}
@@ -104,7 +108,10 @@ export function WizardStep2({
           <SelectContent>
             {adults.map((adult) => (
               <SelectItem key={adult.id} value={adult.id}>
-                {adult.name}
+                <span className="flex items-center gap-2">
+                  <ParticipantAvatar participant={adult} size="sm" />
+                  {getShortName(adult)}
+                </span>
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -5,12 +5,16 @@ import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { fadeInUp } from '@/lib/animations'
+import { getShortName } from '@/lib/participantUtils'
+import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 
 interface Participant {
   id: string
   name: string
+  nickname?: string | null
   is_adult: boolean
   wallet_group?: string | null
+  avatar_url?: string | null
 }
 
 interface WizardStep3Props {
@@ -192,11 +196,12 @@ export function WizardStep3({
                             />
                             <label
                               htmlFor={`participant-${participant.id}`}
-                              className="text-base text-foreground cursor-pointer flex-1"
+                              className="text-base text-foreground cursor-pointer flex-1 flex items-center gap-2"
                             >
-                              {participant.name}
+                              <ParticipantAvatar participant={participant} size="sm" />
+                              {getShortName(participant)}
                               {!participant.is_adult && (
-                                <span className="text-sm text-muted-foreground ml-2">
+                                <span className="text-sm text-muted-foreground">
                                   (child)
                                 </span>
                               )}

--- a/src/components/quick/QuickGroupMembersSheet.tsx
+++ b/src/components/quick/QuickGroupMembersSheet.tsx
@@ -5,6 +5,7 @@ import { ParticipantBalance, formatBalance, getBalanceColorClass, calculateWithi
 import { Participant } from '@/types/participant'
 import { Expense } from '@/types/expense'
 import { Settlement } from '@/types/settlement'
+import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 
 interface QuickGroupMembersSheetProps {
   open: boolean
@@ -92,8 +93,9 @@ export function QuickGroupMembersSheet({
                   className={`flex items-center justify-between px-6 py-3.5 gap-3 ${b.isFamily ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''}`}
                   onClick={b.isFamily ? () => toggleGroup(b.id) : undefined}
                 >
-                  {/* Left: name + badges */}
+                  {/* Left: avatar + name + badges */}
                   <div className="flex items-center gap-2 min-w-0">
+                    <ParticipantAvatar participant={{ name: b.name, avatar_url: participants.find(p => p.id === b.id)?.avatar_url ?? null }} size="sm" />
                     <span className="font-medium truncate">{b.name}</span>
                     {linked && (
                       <span title="Account linked">

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect, useCallback, FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users, ChevronRight, Plus, Send } from 'lucide-react'
+import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users, ChevronRight, Plus, Send, Type } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useAuth } from '@/contexts/AuthContext'
@@ -85,6 +85,11 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
   const [editingEmailId, setEditingEmailId] = useState<string | null>(null)
   const [editEmailValue, setEditEmailValue] = useState('')
   const [savingEmailId, setSavingEmailId] = useState<string | null>(null)
+
+  // Per-participant inline nickname editing
+  const [editingNicknameId, setEditingNicknameId] = useState<string | null>(null)
+  const [editNicknameValue, setEditNicknameValue] = useState('')
+  const [savingNicknameId, setSavingNicknameId] = useState<string | null>(null)
 
   // Per-participant inline wallet_group editing
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null)
@@ -296,6 +301,21 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
     setEditEmailValue('')
   }
 
+  const handleStartEditNickname = (participant: Participant) => {
+    setEditingNicknameId(participant.id)
+    setEditNicknameValue(participant.nickname || '')
+  }
+
+  const handleSaveNickname = async (participant: Participant) => {
+    setSavingNicknameId(participant.id)
+    await updateParticipant(participant.id, {
+      nickname: editNicknameValue.trim() || null,
+    })
+    setSavingNicknameId(null)
+    setEditingNicknameId(null)
+    setEditNicknameValue('')
+  }
+
   const handleStartEditGroup = (participant: Participant) => {
     setEditingGroupId(participant.id)
     setEditGroupValue(participant.wallet_group || '')
@@ -402,6 +422,15 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
           <Button
+            onClick={() => handleStartEditNickname(participant)}
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            title={participant.nickname ? `Nickname: ${participant.nickname}` : 'Set nickname'}
+          >
+            <Type size={15} className={participant.nickname ? 'text-accent' : 'text-muted-foreground'} />
+          </Button>
+          <Button
             onClick={() => handleStartEditGroup(participant)}
             variant="ghost"
             size="sm"
@@ -447,6 +476,37 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
           </Button>
         </div>
       </div>
+
+      {/* Inline nickname editor */}
+      {editingNicknameId === participant.id && (
+        <div className="mt-2 flex gap-2">
+          <Input
+            type="text"
+            value={editNicknameValue}
+            onChange={(e) => setEditNicknameValue(e.target.value)}
+            placeholder="Nickname (optional)"
+            className="h-8 text-sm flex-1"
+            disabled={savingNicknameId === participant.id}
+          />
+          <Button
+            onClick={() => handleSaveNickname(participant)}
+            size="sm"
+            className="h-8 px-3"
+            disabled={savingNicknameId === participant.id}
+          >
+            <Check size={14} />
+          </Button>
+          <Button
+            onClick={() => { setEditingNicknameId(null); setEditNicknameValue('') }}
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2"
+            disabled={savingNicknameId === participant.id}
+          >
+            <X size={14} />
+          </Button>
+        </div>
+      )}
 
       {/* Inline wallet_group editor */}
       {editingGroupId === participant.id && (
@@ -510,6 +570,17 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
             <X size={14} />
           </Button>
         </div>
+      )}
+
+      {/* Show nickname if set and not editing */}
+      {participant.nickname && editingNicknameId !== participant.id && (
+        <button
+          onClick={() => handleStartEditNickname(participant)}
+          className="mt-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <Type size={11} />
+          {participant.nickname}
+        </button>
       )}
 
       {/* Show wallet_group if set and not editing */}

--- a/src/contexts/ParticipantContext.tsx
+++ b/src/contexts/ParticipantContext.tsx
@@ -66,7 +66,23 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
 
       if (participantsError) throw participantsError
 
-      setParticipants((participantsData as Participant[]) || [])
+      // Enrich linked participants with avatar_url from user_profiles
+      const enriched = (participantsData as Participant[]) || []
+      const linkedUserIds = enriched.filter(p => p.user_id).map(p => p.user_id!)
+      if (linkedUserIds.length > 0) {
+        const { data: profiles } = await withTimeout<any>(
+          (supabase as any).from('user_profiles').select('id, avatar_url').in('id', linkedUserIds).abortSignal(signal),
+          15000, 'Loading profiles timed out.'
+        )
+        if (!signal.aborted && profiles) {
+          const avatarMap = new Map((profiles as { id: string; avatar_url: string | null }[]).map(p => [p.id, p.avatar_url]))
+          enriched.forEach(p => {
+            if (p.user_id) p.avatar_url = avatarMap.get(p.user_id) ?? null
+          })
+        }
+      }
+
+      setParticipants(enriched)
     } catch (err) {
       if (signal.aborted) return
       setError(err instanceof Error ? err.message : 'Failed to fetch data')
@@ -177,7 +193,14 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
 
       const updatePayload: Record<string, unknown> = { user_id: userId }
       if (userEmail) updatePayload.email = userEmail
-      if (displayName) updatePayload.name = displayName
+      if (displayName) {
+        updatePayload.name = displayName
+        // Preserve original name as nickname when overwriting with Google name
+        const existing = participants.find(p => p.id === participantId)
+        if (existing && !existing.nickname && existing.name !== displayName) {
+          updatePayload.nickname = existing.name
+        }
+      }
 
       const controller = new AbortController()
       const { error: linkError } = await withTimeout<any>(
@@ -194,10 +217,18 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       if (linkError) throw linkError
 
       setParticipants(prev =>
-        prev.map(p => (p.id === participantId
-          ? { ...p, user_id: userId, ...(userEmail ? { email: userEmail } : {}), ...(displayName ? { name: displayName } : {}) }
-          : p))
-          .sort((a, b) => a.name.localeCompare(b.name))
+        prev.map(p => {
+          if (p.id !== participantId) return p
+          const updates: Partial<Participant> = { user_id: userId }
+          if (userEmail) updates.email = userEmail
+          if (displayName) {
+            updates.name = displayName
+            if (!p.nickname && p.name !== displayName) {
+              updates.nickname = p.name
+            }
+          }
+          return { ...p, ...updates }
+        }).sort((a, b) => a.name.localeCompare(b.name))
       )
 
       return true
@@ -281,6 +312,9 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
 
     updateParticipant(myParticipant.id, {
       ...(nameStale ? { name: userProfile.display_name } : {}),
+      // Preserve original name as nickname when background sync overwrites name
+      ...(nameStale && !myParticipant.nickname && myParticipant.name !== userProfile.display_name
+        ? { nickname: myParticipant.name } : {}),
       ...(emailStale ? { email: user.email! } : {}),
     })
   }, [participants, userProfile?.display_name, user?.email])

--- a/src/lib/participantUtils.ts
+++ b/src/lib/participantUtils.ts
@@ -1,0 +1,6 @@
+import type { Participant } from '@/types/participant'
+
+export function getShortName(p: Pick<Participant, 'name' | 'nickname'>): string {
+  if (p.nickname) return p.nickname
+  return p.name.split(' ')[0]
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -199,7 +199,7 @@ export function DashboardPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {displayBalances.map(balance => (
-              <BalanceCard key={balance.id} balance={balance} currency={currentTrip.default_currency} onClick={() => setSelectedBalance(balance)} />
+              <BalanceCard key={balance.id} balance={balance} currency={currentTrip.default_currency} onClick={() => setSelectedBalance(balance)} avatarUrl={participants.find(p => p.id === balance.id)?.avatar_url} />
             ))}
           </div>
         )}

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -132,14 +132,21 @@ export function JoinPage() {
       try {
         // Link auth user to participant — sync name from Google profile
         const displayName = user!.user_metadata?.full_name || user!.user_metadata?.name || null
+        const updatePayload: Record<string, unknown> = {
+          user_id: user!.id,
+          email: user!.email || null,
+        }
+        if (displayName) {
+          updatePayload.name = displayName
+          // Preserve original name as nickname when overwriting with Google name
+          if (invitation!.participant_name !== displayName) {
+            updatePayload.nickname = invitation!.participant_name
+          }
+        }
         const { error: linkError } = await withTimeout<any>(
           (supabase as any)
             .from('participants')
-            .update({
-              user_id: user!.id,
-              email: user!.email || null,
-              ...(displayName ? { name: displayName } : {}),
-            })
+            .update(updatePayload)
             .eq('id', invitation!.participant_id),
           15000,
           'Linking account timed out. Please check your connection and try again.'

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -54,6 +54,15 @@ export function SettlementsPage() {
     }
   }
 
+  // Build a map of entity ID → avatar_url for settlement plan avatars
+  const avatarMap = useMemo(() => {
+    const map: Record<string, string | null> = {}
+    for (const p of participants) {
+      map[p.id] = p.avatar_url ?? null
+    }
+    return map
+  }, [participants])
+
   // Build a map of entity ID → email for the "from" side of transactions
   const fromEmailMap = useMemo(() => {
     if (!currentTrip) return {}
@@ -330,6 +339,7 @@ export function SettlementsPage() {
                 linkedParticipantIds={linkedParticipantIds}
                 fromEmailMap={fromEmailMap}
                 onRemind={user ? handleRemind : undefined}
+                avatarMap={avatarMap}
               />
             </CardContent>
           </Card>

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -1,6 +1,7 @@
 import { Expense } from '@/types/expense'
 import { Participant } from '@/types/participant'
 import { Settlement } from '@/types/settlement'
+import { getShortName } from '@/lib/participantUtils'
 
 export interface ParticipantBalance {
   id: string
@@ -73,7 +74,7 @@ export function buildEntityMap(
       walletGroups.set(p.wallet_group, group)
     } else {
       // Standalone participant (no wallet_group)
-      entities.push({ id: p.id, name: p.name, isFamily: false })
+      entities.push({ id: p.id, name: getShortName(p), isFamily: false })
       participantToEntityId.set(p.id, p.id)
     }
   }
@@ -358,7 +359,7 @@ export function calculateWithinGroupBalances(
   // Compute raw balances per member: balance = paid - share
   const rawBalances = groupMembers.map(m => ({
     id: m.id,
-    name: m.name,
+    name: getShortName(m),
     is_adult: m.is_adult,
     totalPaid: paid.get(m.id) || 0,
     totalShare: share.get(m.id) || 0,

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -3,9 +3,11 @@ export interface Participant {
   trip_id: string
   wallet_group?: string | null
   name: string
+  nickname?: string | null
   is_adult: boolean
   user_id?: string | null
   email?: string | null
+  avatar_url?: string | null // client-side enrichment from user_profiles, not a DB column
 }
 
 export interface CreateParticipantInput {
@@ -19,6 +21,7 @@ export interface CreateParticipantInput {
 
 export interface UpdateParticipantInput {
   name?: string
+  nickname?: string | null
   is_adult?: boolean
   wallet_group?: string | null
   email?: string | null

--- a/supabase/migrations/035_participant_nickname.sql
+++ b/supabase/migrations/035_participant_nickname.sql
@@ -1,0 +1,8 @@
+-- Add nickname column to participants
+ALTER TABLE participants ADD COLUMN IF NOT EXISTS nickname TEXT;
+
+-- Backfill: set nickname to first name for participants with multi-word names
+UPDATE participants
+SET nickname = split_part(name, ' ', 1)
+WHERE nickname IS NULL
+  AND name LIKE '% %';


### PR DESCRIPTION
## Summary

- Short names (nickname or first name) displayed throughout trip UI instead of full Google names
- When "This is me" syncs a Google name, original organizer-given name preserved as nickname
- Google avatars shown next to participant names in balance cards, settlement plan, expense wizard, and member sheets
- Inline nickname editing added to ParticipantsSetup
- Full names kept in formal contexts (participant setup list, contact picker, emails)

### New files
- `supabase/migrations/035_participant_nickname.sql` — `nickname TEXT` column + backfill
- `src/lib/participantUtils.ts` — `getShortName()` helper
- `src/components/ParticipantAvatar.tsx` — reusable avatar (img or initials)

### Modified files (20 total)
- `ParticipantContext` — fetch avatar_url from user_profiles, preserve nickname on link + background sync
- `JoinPage` — preserve nickname on invitation accept
- `balanceCalculator` — entity names use `getShortName()`
- 11 display components — short names + avatars
- `ParticipantsSetup` — inline nickname editing

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — 173/173 pass
- [ ] Apply migration `035` to Supabase
- [ ] Verify existing multi-word names get first name as nickname
- [ ] Add participant → "This is me" → confirm Google name overwrites, nickname preserved
- [ ] Balance cards, settlement plan, expense wizard show short names + avatars
- [ ] ParticipantsSetup: nickname editable inline via Type icon
- [ ] Full names still shown in ParticipantsSetup list

🤖 Generated with [Claude Code](https://claude.com/claude-code)