### PR TITLE
fix: carry over participant nickname from previous trips

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -27,6 +27,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
 
   // Autocomplete state
   const [suggestedUserId, setSuggestedUserId] = useState<string | null>(null)
+  const [suggestedNickname, setSuggestedNickname] = useState<string | null>(null)
   const [showDropdown, setShowDropdown] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
   const nameInputRef = useRef<HTMLInputElement>(null)
@@ -74,6 +75,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
     setName(contact.display_name ?? contact.name)
     setEmail(contact.email || '')
     setSuggestedUserId(contact.user_id)
+    setSuggestedNickname(contact.nickname)
     setShowDropdown(false)
     setActiveIndex(-1)
     setTimeout(() => emailInputRef.current?.focus(), 0)
@@ -82,6 +84,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
   const handleNameChange = useCallback((value: string) => {
     setName(value)
     setSuggestedUserId(null)
+    setSuggestedNickname(null)
   }, [])
 
   const handleNameKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -107,7 +110,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
     setSupportsContacts('contacts' in navigator && typeof (navigator as any).contacts?.select === 'function')
   }, [])
 
-  const addPerson = async (personName: string, personEmail: string | null, personUserId?: string | null, isAdult?: boolean) => {
+  const addPerson = async (personName: string, personEmail: string | null, personUserId?: string | null, isAdult?: boolean, personNickname?: string | null) => {
     const emailLower = personEmail?.trim().toLowerCase() ?? null
     if (emailLower) {
       const duplicate = participants.some(p => p.email?.toLowerCase() === emailLower)
@@ -119,6 +122,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
       name: personName.trim(),
       is_adult: isAdult ?? true,
       email: emailLower || null,
+      nickname: personNickname || null,
       ...(personUserId ? { user_id: personUserId } : {}),
     }
 
@@ -138,7 +142,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
   }
 
   const handleAddRecent = async (contact: TripContact) => {
-    await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id, contact.is_adult)
+    await addPerson(contact.display_name ?? contact.name, contact.email, contact.user_id, contact.is_adult, contact.nickname)
   }
 
   const handleAddFromContacts = async () => {
@@ -174,10 +178,11 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
 
     setAdding(true)
     try {
-      await addPerson(name.trim(), email.trim() || null, suggestedUserId)
+      await addPerson(name.trim(), email.trim() || null, suggestedUserId, undefined, suggestedNickname)
       setName('')
       setEmail('')
       setSuggestedUserId(null)
+      setSuggestedNickname(null)
     } finally {
       setAdding(false)
     }

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -99,6 +99,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
   // Autocomplete: contacts from past trips
   const { contacts } = useTripContacts(currentTrip?.id)
   const [suggestedUserId, setSuggestedUserId] = useState<string | null>(null)
+  const [suggestedNickname, setSuggestedNickname] = useState<string | null>(null)
   const [showDropdown, setShowDropdown] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -154,6 +155,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
     setName(contact.display_name ?? contact.name)
     setEmail(contact.email || '')
     setSuggestedUserId(contact.user_id)
+    setSuggestedNickname(contact.nickname)
     setShowDropdown(false)
     setActiveIndex(-1)
     // Focus email field so user can review/edit
@@ -162,8 +164,9 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
 
   const handleNameChange = useCallback((value: string) => {
     setName(value)
-    // Clear suggested user_id when user edits the name manually
+    // Clear suggested values when user edits the name manually
     setSuggestedUserId(null)
+    setSuggestedNickname(null)
   }, [])
 
   const handleNameKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -250,6 +253,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
         is_adult: isAdult,
         wallet_group: walletGroup.trim() || null,
         email: email.trim() || null,
+        nickname: suggestedNickname || null,
         ...(suggestedUserId ? { user_id: suggestedUserId } : {}),
       }
 
@@ -264,6 +268,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
       setName('')
       setEmail('')
       setSuggestedUserId(null)
+      setSuggestedNickname(null)
       // Keep walletGroup — likely adding more people to the same group
       setIsAdult(true)
     } finally {
@@ -346,6 +351,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
       name: personName,
       is_adult: contact.is_adult ?? true,
       email: emailLower || null,
+      nickname: contact.nickname || null,
       ...(contact.user_id ? { user_id: contact.user_id } : {}),
     }
 

--- a/src/hooks/useTripContacts.ts
+++ b/src/hooks/useTripContacts.ts
@@ -10,6 +10,7 @@ export interface TripContact {
   email: string | null
   user_id: string | null
   display_name: string | null
+  nickname: string | null
   is_adult: boolean
   lastSeenAt: string
 }
@@ -58,7 +59,7 @@ export function useTripContacts(currentTripId: string | undefined) {
         const { data, error } = await withTimeout(
           supabase
             .from('participants')
-            .select('name, email, user_id, trip_id, is_adult')
+            .select('name, email, user_id, trip_id, is_adult, nickname')
             .in('trip_id', otherTripIds)
             .limit(200)
             .abortSignal(controller.signal),
@@ -140,6 +141,7 @@ export function useTripContacts(currentTripId: string | undefined) {
               email: bestEmail,
               user_id: p.user_id ?? null,
               display_name,
+              nickname: p.nickname ?? existing?.nickname ?? null,
               is_adult: isNewer ? (p.is_adult ?? true) : (existing?.is_adult ?? true),
               lastSeenAt: isNewer ? lastSeenAt : existing!.lastSeenAt,
             })


### PR DESCRIPTION
## Summary
- `useTripContacts` now fetches `nickname` from participants and includes it in the `TripContact` interface
- Both `ParticipantsSetup` (Full mode) and `QuickParticipantPicker` (Quick mode) pass nickname through when:
  - Adding from "Recent" contacts list
  - Selecting from autocomplete dropdown and submitting the form

## Test plan
- [ ] Add a participant with a nickname in trip A
- [ ] Create trip B, add the same person from Recent contacts — nickname should be populated
- [ ] Same via autocomplete dropdown in the name field
- [ ] `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)