### PR TITLE
fix: restyle settlement step badges and force initials for wallet groups

### DIFF
--- a/src/components/ParticipantAvatar.tsx
+++ b/src/components/ParticipantAvatar.tsx
@@ -3,6 +3,7 @@ import type { Participant } from '@/types/participant'
 interface ParticipantAvatarProps {
   participant: Pick<Participant, 'name' | 'avatar_url'>
   size?: 'sm' | 'md'
+  forceInitials?: boolean
 }
 
 const sizes = {
@@ -10,7 +11,7 @@ const sizes = {
   md: 'w-8 h-8 text-xs',
 }
 
-export function ParticipantAvatar({ participant, size = 'md' }: ParticipantAvatarProps) {
+export function ParticipantAvatar({ participant, size = 'md', forceInitials }: ParticipantAvatarProps) {
   const sizeClass = sizes[size]
 
   const initials = participant.name
@@ -20,7 +21,7 @@ export function ParticipantAvatar({ participant, size = 'md' }: ParticipantAvata
     .toUpperCase()
     .slice(0, 2)
 
-  if (participant.avatar_url) {
+  if (participant.avatar_url && !forceInitials) {
     return (
       <img
         src={participant.avatar_url}

--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -129,16 +129,13 @@ function SettlementTransactionCard({
         <div className="flex-1 min-w-0">
           {/* Step Number */}
           <div className="flex items-center mb-2">
-            <span className="flex items-center justify-center w-6 h-6 bg-accent text-accent-foreground text-xs font-bold rounded-full mr-2">
-              {index}
-            </span>
-            <span className="text-xs text-muted-foreground">Step {index}</span>
+            <span className="text-xs font-medium text-muted-foreground">Step {index}</span>
           </div>
 
           {/* Transaction Details */}
           <div className="flex items-center gap-2 text-sm flex-wrap">
             <div className="flex items-center gap-1.5">
-              <ParticipantAvatar participant={{ name: transaction.fromName, avatar_url: avatarMap?.[transaction.fromId] ?? null }} size="sm" />
+              <ParticipantAvatar participant={{ name: transaction.fromName, avatar_url: avatarMap?.[transaction.fromId] ?? null }} size="sm" forceInitials={transaction.fromIsFamily} />
               <span className="font-medium text-foreground">
                 {transaction.fromName}
               </span>
@@ -147,7 +144,7 @@ function SettlementTransactionCard({
             <span className="text-muted-foreground flex-shrink-0">→</span>
 
             <div className="flex items-center gap-1.5">
-              <ParticipantAvatar participant={{ name: transaction.toName, avatar_url: avatarMap?.[transaction.toId] ?? null }} size="sm" />
+              <ParticipantAvatar participant={{ name: transaction.toName, avatar_url: avatarMap?.[transaction.toId] ?? null }} size="sm" forceInitials={transaction.toIsFamily} />
               <span className="font-medium text-foreground">
                 {transaction.toName}
               </span>

--- a/src/services/settlementOptimizer.test.ts
+++ b/src/services/settlementOptimizer.test.ts
@@ -100,6 +100,8 @@ describe('formatSettlementTransaction', () => {
       toId: 'a',
       toName: 'Alice',
       amount: 50,
+      fromIsFamily: false,
+      toIsFamily: false,
     }
     const formatted = formatSettlementTransaction(tx, 'EUR')
     expect(formatted).toContain('Bob')

--- a/src/services/settlementOptimizer.ts
+++ b/src/services/settlementOptimizer.ts
@@ -6,6 +6,8 @@ export interface SettlementTransaction {
   toId: string
   toName: string
   amount: number
+  fromIsFamily: boolean
+  toIsFamily: boolean
 }
 
 export interface OptimalSettlementPlan {
@@ -70,6 +72,8 @@ export function calculateOptimalSettlement(
       toId: creditor.id,
       toName: creditor.name,
       amount: Math.round(transactionAmount * 100) / 100, // Round to 2 decimals
+      fromIsFamily: debtor.isFamily,
+      toIsFamily: creditor.isFamily,
     })
 
     // Update balances


### PR DESCRIPTION
## Summary
- Step badges on the settlement plan are now plain "Step N" text labels instead of circles that looked identical to participant avatars
- Wallet group entities always show initials instead of one member's Google avatar (via new `forceInitials` prop on `ParticipantAvatar`)
- `SettlementTransaction` now carries `fromIsFamily`/`toIsFamily` flags from the balance calculator

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — all 173 tests pass
- [ ] Visual: step labels are plain text, no circle
- [ ] Visual: wallet group settlements show initials, not a member's photo
- [ ] Visual: individual participants with Google avatars still show their photo

🤖 Generated with [Claude Code](https://claude.com/claude-code)