### PR TITLE
feat: improve contact chips with avatars, full names & email

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -223,7 +223,7 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
             className="flex items-center gap-2 text-sm font-medium text-muted-foreground w-full"
           >
             <Users size={14} />
-            <span>People you've traveled with</span>
+            <span>Recent companions</span>
             <ChevronRight
               size={14}
               className={`transition-transform ${recentExpanded ? 'rotate-90' : ''}`}
@@ -234,7 +234,6 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
               {contacts.slice(0, 20).map((contact, i) => {
                 const added = isAdded(contact)
                 const displayName = contact.display_name ?? contact.name
-                const firstName = displayName.split(' ')[0]
                 const initials = displayName.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase()
                 const isChild = contact.is_adult === false
                 const tooltip = displayName + (contact.email ? ` (${contact.email})` : '')
@@ -246,19 +245,28 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
                     disabled={added}
                     title={tooltip}
                     aria-label={added ? `${displayName} already added` : `Add ${displayName}`}
-                    className={`inline-flex items-center gap-1.5 pl-1 pr-2 py-1 rounded-full border text-sm transition-colors ${
+                    className={`inline-flex items-center gap-1.5 pl-1 pr-2 py-1.5 rounded-full border text-sm transition-colors ${
                       added
                         ? 'bg-primary/10 border-primary/20 text-primary/60 cursor-default'
                         : 'border-border hover:bg-accent/50 text-foreground'
                     }`}
                   >
-                    <span className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium shrink-0 ${
-                      isChild ? 'bg-amber-100 text-amber-700' : 'bg-primary/10 text-primary'
-                    }`}>
-                      {initials}
-                    </span>
-                    <span className="truncate max-w-[100px]">
-                      {firstName}{isChild ? ' (child)' : ''}
+                    {contact.avatar_url ? (
+                      <img src={contact.avatar_url} alt="" className="w-7 h-7 rounded-full object-cover shrink-0" />
+                    ) : (
+                      <span className={`w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-medium shrink-0 ${
+                        isChild ? 'bg-amber-100 text-amber-700' : 'bg-primary/10 text-primary'
+                      }`}>
+                        {initials}
+                      </span>
+                    )}
+                    <span className="flex flex-col items-start min-w-0">
+                      <span className="truncate max-w-[140px] leading-tight">
+                        {displayName}{isChild ? ' (child)' : ''}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground truncate max-w-[140px] min-h-[14px] leading-tight">
+                        {contact.email ?? ''}
+                      </span>
                     </span>
                     {added ? <Check size={12} className="shrink-0" /> : <Plus size={12} className="shrink-0 text-muted-foreground" />}
                   </button>

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -647,7 +647,7 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                 className="flex items-center gap-2 text-sm font-medium text-muted-foreground w-full"
               >
                 <Users size={14} />
-                <span>People you've traveled with</span>
+                <span>Recent companions</span>
                 <ChevronRight
                   size={14}
                   className={`transition-transform ${recentExpanded ? 'rotate-90' : ''}`}
@@ -658,7 +658,6 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                   {contacts.slice(0, 20).map((contact, i) => {
                     const added = isRecentAdded(contact)
                     const displayName = contact.display_name ?? contact.name
-                    const firstName = displayName.split(' ')[0]
                     const initials = displayName.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase()
                     const isChild = contact.is_adult === false
                     const tooltip = displayName + (contact.email ? ` (${contact.email})` : '')
@@ -670,19 +669,28 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                         disabled={added}
                         title={tooltip}
                         aria-label={added ? `${displayName} already added` : `Add ${displayName}`}
-                        className={`inline-flex items-center gap-1.5 pl-1 pr-2 py-1 rounded-full border text-sm transition-colors ${
+                        className={`inline-flex items-center gap-1.5 pl-1 pr-2 py-1.5 rounded-full border text-sm transition-colors ${
                           added
                             ? 'bg-primary/10 border-primary/20 text-primary/60 cursor-default'
                             : 'border-border hover:bg-accent/50 text-foreground'
                         }`}
                       >
-                        <span className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium shrink-0 ${
-                          isChild ? 'bg-amber-100 text-amber-700' : 'bg-primary/10 text-primary'
-                        }`}>
-                          {initials}
-                        </span>
-                        <span className="truncate max-w-[100px]">
-                          {firstName}{isChild ? ' (child)' : ''}
+                        {contact.avatar_url ? (
+                          <img src={contact.avatar_url} alt="" className="w-7 h-7 rounded-full object-cover shrink-0" />
+                        ) : (
+                          <span className={`w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-medium shrink-0 ${
+                            isChild ? 'bg-amber-100 text-amber-700' : 'bg-primary/10 text-primary'
+                          }`}>
+                            {initials}
+                          </span>
+                        )}
+                        <span className="flex flex-col items-start min-w-0">
+                          <span className="truncate max-w-[140px] leading-tight">
+                            {displayName}{isChild ? ' (child)' : ''}
+                          </span>
+                          <span className="text-[10px] text-muted-foreground truncate max-w-[140px] min-h-[14px] leading-tight">
+                            {contact.email ?? ''}
+                          </span>
                         </span>
                         {added ? <Check size={12} className="shrink-0" /> : <Plus size={12} className="shrink-0 text-muted-foreground" />}
                       </button>

--- a/src/hooks/useTripContacts.ts
+++ b/src/hooks/useTripContacts.ts
@@ -11,6 +11,7 @@ export interface TripContact {
   user_id: string | null
   display_name: string | null
   nickname: string | null
+  avatar_url: string | null
   is_adult: boolean
   lastSeenAt: string
 }
@@ -90,13 +91,13 @@ export function useTripContacts(currentTripId: string | undefined) {
         const userIds = [...new Set(
           filtered.filter((p: any) => p.user_id).map((p: any) => p.user_id as string)
         )]
-        const profileMap = new Map<string, { displayName: string | null; email: string | null }>()
+        const profileMap = new Map<string, { displayName: string | null; email: string | null; avatarUrl: string | null }>()
         if (userIds.length > 0) {
           try {
             const { data: profiles } = await withTimeout<{ data: any[]; error: any }>(
               (supabase as any)
                 .from('user_profiles')
-                .select('id, display_name, email')
+                .select('id, display_name, email, avatar_url')
                 .in('id', userIds)
                 .abortSignal(controller.signal),
               15000,
@@ -107,6 +108,7 @@ export function useTripContacts(currentTripId: string | undefined) {
                 profileMap.set(p.id, {
                   displayName: p.display_name ?? null,
                   email: p.email ?? null,
+                  avatarUrl: p.avatar_url ?? null,
                 })
               }
             }
@@ -136,12 +138,14 @@ export function useTripContacts(currentTripId: string | undefined) {
           const hasNewDisplayName = display_name && !existing?.display_name
           if (isNewer || hasNewDisplayName) {
             const bestEmail = p.email ?? profile?.email ?? existing?.email ?? null
+            const bestAvatar = profile?.avatarUrl ?? existing?.avatar_url ?? null
             seen.set(key, {
               name: p.name,
               email: bestEmail,
               user_id: p.user_id ?? null,
               display_name,
               nickname: p.nickname ?? existing?.nickname ?? null,
+              avatar_url: bestAvatar,
               is_adult: isNewer ? (p.is_adult ?? true) : (existing?.is_adult ?? true),
               lastSeenAt: isNewer ? lastSeenAt : existing!.lastSeenAt,
             })
@@ -166,6 +170,9 @@ export function useTripContacts(currentTripId: string | undefined) {
             }
             if (removeEntry.display_name && !keepEntry.display_name) {
               keepEntry.display_name = removeEntry.display_name
+            }
+            if (removeEntry.avatar_url && !keepEntry.avatar_url) {
+              keepEntry.avatar_url = removeEntry.avatar_url
             }
             seen.delete(removeKey)
             emailToKey.set(emailLower, keepKey)


### PR DESCRIPTION
## Summary
- Add `avatar_url` to `TripContact` type — fetched from `user_profiles` and merged through the dedup pipeline
- Two-line pill layout in both `QuickParticipantPicker` and `ParticipantsSetup`: full display name on line 1, email on line 2 (fixed height even when empty)
- Show Google profile photos (`w-7 h-7 rounded-full`) for linked accounts; initials circle fallback for others
- Rename disclosure header from "People you've traveled with" to "Recent companions"

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 173/173 passing
- [ ] Visual: contacts with Google accounts show profile photos in pills
- [ ] Visual: all pills same height (with or without email)
- [ ] Visual: full names visible, pills wrap naturally on mobile (375px)
- [ ] Tooltip still shows full name + email on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)