### PR TITLE
feat: stacked group member avatars on Dashboard BalanceCard

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -4,15 +4,16 @@ import { ParticipantBalance } from '@/services/balanceCalculator'
 import { formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
 import { Card } from '@/components/ui/card'
 import { ParticipantAvatar } from '@/components/ParticipantAvatar'
+import type { Participant } from '@/types/participant'
 
 interface BalanceCardProps {
   balance: ParticipantBalance
   currency?: string
   onClick?: () => void
-  avatarUrl?: string | null
+  groupMembers?: Array<Pick<Participant, 'name' | 'avatar_url'>>
 }
 
-export function BalanceCard({ balance, currency = 'EUR', onClick, avatarUrl }: BalanceCardProps) {
+export function BalanceCard({ balance, currency = 'EUR', onClick, groupMembers }: BalanceCardProps) {
   const balanceColorClass = getBalanceColorClass(balance.balance)
   const formattedBalance = formatBalance(balance.balance, currency)
   const fmt = (value: number) => new Intl.NumberFormat('en-US', {
@@ -69,7 +70,17 @@ export function BalanceCard({ balance, currency = 'EUR', onClick, avatarUrl }: B
         {/* Header */}
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-2 flex-1 min-w-0">
-            <ParticipantAvatar participant={{ name: balance.name, avatar_url: avatarUrl ?? null }} size="md" />
+            {groupMembers && groupMembers.length > 1 ? (
+              <div className="flex items-center shrink-0">
+                {groupMembers.slice(0, 4).map((member, i) => (
+                  <div key={i} className={i > 0 ? '-ml-2' : ''} style={{ zIndex: groupMembers.length - i }}>
+                    <ParticipantAvatar participant={member} size="sm" className="ring-2 ring-background" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <ParticipantAvatar participant={{ name: balance.name, avatar_url: groupMembers?.[0]?.avatar_url ?? null }} size="md" />
+            )}
             <h3 className="text-lg font-semibold text-foreground truncate">
               {balance.name}
             </h3>

--- a/src/components/ParticipantAvatar.tsx
+++ b/src/components/ParticipantAvatar.tsx
@@ -4,6 +4,7 @@ interface ParticipantAvatarProps {
   participant: Pick<Participant, 'name' | 'avatar_url'>
   size?: 'sm' | 'md'
   forceInitials?: boolean
+  className?: string
 }
 
 const sizes = {
@@ -11,7 +12,7 @@ const sizes = {
   md: 'w-8 h-8 text-xs',
 }
 
-export function ParticipantAvatar({ participant, size = 'md', forceInitials }: ParticipantAvatarProps) {
+export function ParticipantAvatar({ participant, size = 'md', forceInitials, className }: ParticipantAvatarProps) {
   const sizeClass = sizes[size]
 
   const initials = participant.name
@@ -26,14 +27,14 @@ export function ParticipantAvatar({ participant, size = 'md', forceInitials }: P
       <img
         src={participant.avatar_url}
         alt={participant.name}
-        className={`${sizeClass} rounded-full shrink-0 object-cover`}
+        className={`${sizeClass} rounded-full shrink-0 object-cover ${className ?? ''}`}
         referrerPolicy="no-referrer"
       />
     )
   }
 
   return (
-    <div className={`${sizeClass} rounded-full shrink-0 flex items-center justify-center font-medium bg-primary/10 text-primary`}>
+    <div className={`${sizeClass} rounded-full shrink-0 flex items-center justify-center font-medium bg-primary/10 text-primary ${className ?? ''}`}>
       {initials}
     </div>
   )

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState, useCallback } from 'react'
+import { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Lightbulb, Receipt, FileDown, Share2 } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -16,6 +16,7 @@ import { Link } from 'react-router-dom'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
 import { CostBreakdownDialog } from '@/components/CostBreakdownDialog'
 import { ParticipantBalance } from '@/services/balanceCalculator'
+import type { Participant } from '@/types/participant'
 
 // Lazy load chart components for better performance
 const ExpenseByCategoryChart = lazy(() => import('@/components/ExpenseByCategoryChart').then(m => ({ default: m.ExpenseByCategoryChart })))
@@ -78,6 +79,26 @@ export function DashboardPage() {
     ...b,
     balance: Math.round(b.balance * 100) / 100,
   }))
+
+  const groupMembersMap = useMemo(() => {
+    const map: Record<string, Array<Pick<Participant, 'name' | 'avatar_url'>>> = {}
+    for (const b of displayBalances) {
+      if (b.isFamily) {
+        const canonical = participants.find(p => p.id === b.id)
+        const groupName = canonical?.wallet_group
+        if (groupName) {
+          map[b.id] = participants
+            .filter(p => p.wallet_group === groupName)
+            .map(p => ({ name: p.name, avatar_url: p.avatar_url ?? null }))
+        }
+      }
+      if (!map[b.id]) {
+        const p = participants.find(pp => pp.id === b.id)
+        map[b.id] = [{ name: p?.name ?? b.name, avatar_url: p?.avatar_url ?? null }]
+      }
+    }
+    return map
+  }, [displayBalances, participants])
 
   const handleExportPDF = () => {
     exportTripSummaryToPDF(currentTrip, expenses, participants, balanceCalculation.balances)
@@ -199,7 +220,7 @@ export function DashboardPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {displayBalances.map(balance => (
-              <BalanceCard key={balance.id} balance={balance} currency={currentTrip.default_currency} onClick={() => setSelectedBalance(balance)} avatarUrl={participants.find(p => p.id === balance.id)?.avatar_url} />
+              <BalanceCard key={balance.id} balance={balance} currency={currentTrip.default_currency} onClick={() => setSelectedBalance(balance)} groupMembers={groupMembersMap[balance.id]} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Wallet group entities on the Dashboard now show **overlapping stacked avatars** of all group members instead of a single canonical participant's photo
- Solo participants continue to show a single avatar as before
- Added `className` pass-through to `ParticipantAvatar` for ring border support

## Test plan
- [ ] Dashboard: wallet group cards show overlapping member avatars (photos for Google accounts, initials for others)
- [ ] Dashboard: solo participant cards still show a single avatar
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (172/173, 1 pre-existing failure in myTripsStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)