### PR TITLE
fix: vertically center contact chips without email

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -264,9 +264,11 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
                       <span className="truncate max-w-[140px] leading-tight">
                         {displayName}{isChild ? ' (child)' : ''}
                       </span>
-                      <span className="text-[10px] text-muted-foreground truncate max-w-[140px] min-h-[14px] leading-tight">
-                        {contact.email ?? ''}
-                      </span>
+                      {contact.email && (
+                        <span className="text-[10px] text-muted-foreground truncate max-w-[140px] leading-tight">
+                          {contact.email}
+                        </span>
+                      )}
                     </span>
                     {added ? <Check size={12} className="shrink-0" /> : <Plus size={12} className="shrink-0 text-muted-foreground" />}
                   </button>

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -688,9 +688,11 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                           <span className="truncate max-w-[140px] leading-tight">
                             {displayName}{isChild ? ' (child)' : ''}
                           </span>
-                          <span className="text-[10px] text-muted-foreground truncate max-w-[140px] min-h-[14px] leading-tight">
-                            {contact.email ?? ''}
-                          </span>
+                          {contact.email && (
+                            <span className="text-[10px] text-muted-foreground truncate max-w-[140px] leading-tight">
+                              {contact.email}
+                            </span>
+                          )}
                         </span>
                         {added ? <Check size={12} className="shrink-0" /> : <Plus size={12} className="shrink-0 text-muted-foreground" />}
                       </button>


### PR DESCRIPTION
## Summary
- Only render the email line when the contact actually has an email
- Name-only pills are now vertically centered instead of top-aligned with empty space below

## Test plan
- [x] `npm run type-check` — clean
- [ ] Visual: pills with email show two lines, pills without email show centered single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)