### PR TITLE
fix: toggle recent companions and manual add form

### DIFF
--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -279,116 +279,120 @@ export function QuickParticipantPicker({ tripId }: QuickParticipantPickerProps) 
         </div>
       )}
 
-      {/* Section B: Device contacts */}
-      {supportsContacts && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-            <Smartphone size={14} />
-            Contacts
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-2"
-            onClick={handleAddFromContacts}
-          >
-            <Smartphone size={14} />
-            Add from Contacts
-          </Button>
-        </div>
-      )}
-
-      {/* Section C: Add manually */}
-      <div className="space-y-2">
-        <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-          <UserPlus size={14} />
-          Add manually
-        </div>
-        <form onSubmit={handleManualAdd} className="space-y-2">
-          <div className="flex gap-2">
-            <div className="relative flex-1">
-              <Input
-                ref={nameInputRef}
-                placeholder="Name"
-                value={name}
-                onChange={e => handleNameChange(e.target.value)}
-                onKeyDown={handleNameKeyDown}
-                autoComplete="off"
-                role="combobox"
-                aria-expanded={showDropdown}
-                aria-autocomplete="list"
-                aria-controls="quick-contact-suggestions"
-              />
-              {showDropdown && (
-                <div
-                  ref={dropdownRef}
-                  id="quick-contact-suggestions"
-                  role="listbox"
-                  className="absolute top-full left-0 right-0 z-50 bg-popover border border-border rounded-md shadow-md mt-1 max-h-[200px] overflow-y-auto"
-                >
-                  {filteredContacts.map((contact, i) => (
-                    <button
-                      key={`${contact.email ?? contact.name}-${i}`}
-                      type="button"
-                      role="option"
-                      aria-selected={i === activeIndex}
-                      className={`w-full text-left px-3 py-2 transition-colors ${
-                        i === activeIndex ? 'bg-accent/50' : 'hover:bg-accent/30'
-                      }`}
-                      onMouseDown={(e) => {
-                        e.preventDefault()
-                        handleSelectContact(contact)
-                      }}
-                    >
-                      <div className="font-medium text-sm">
-                        {contact.display_name ?? contact.name}
-                      </div>
-                      {contact.email && (
-                        <div className="text-xs text-muted-foreground">{contact.email}</div>
-                      )}
-                      {contact.user_id && (
-                        <div className="text-xs text-primary">✓ Has Spl1t account</div>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              )}
+      {!recentExpanded && (
+        <>
+          {/* Section B: Device contacts */}
+          {supportsContacts && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                <Smartphone size={14} />
+                Contacts
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={handleAddFromContacts}
+              >
+                <Smartphone size={14} />
+                Add from Contacts
+              </Button>
             </div>
-            <Button type="submit" size="sm" disabled={adding || !name.trim()}>
-              {adding ? '…' : 'Add'}
-            </Button>
-          </div>
-          <div>
-            <Label className="sr-only" htmlFor="picker-email">Email (optional)</Label>
-            <Input
-              ref={emailInputRef}
-              id="picker-email"
-              type="email"
-              inputMode="email"
-              placeholder="Email (optional)"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              autoComplete="section-participant email"
-            />
-            <p className="text-xs text-muted-foreground mt-1">
-              Add now or let them link themselves via the trip link
-            </p>
-          </div>
-          {error && (
-            <p className="text-xs text-destructive">{error}</p>
           )}
-        </form>
-      </div>
 
-      {/* Dismiss error */}
-      {error && (
-        <button
-          onClick={() => setError(null)}
-          className="text-xs text-muted-foreground flex items-center gap-1"
-        >
-          <X size={10} />
-          Dismiss
-        </button>
+          {/* Section C: Add manually */}
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <UserPlus size={14} />
+              Add manually
+            </div>
+            <form onSubmit={handleManualAdd} className="space-y-2">
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    ref={nameInputRef}
+                    placeholder="Name"
+                    value={name}
+                    onChange={e => handleNameChange(e.target.value)}
+                    onKeyDown={handleNameKeyDown}
+                    autoComplete="off"
+                    role="combobox"
+                    aria-expanded={showDropdown}
+                    aria-autocomplete="list"
+                    aria-controls="quick-contact-suggestions"
+                  />
+                  {showDropdown && (
+                    <div
+                      ref={dropdownRef}
+                      id="quick-contact-suggestions"
+                      role="listbox"
+                      className="absolute top-full left-0 right-0 z-50 bg-popover border border-border rounded-md shadow-md mt-1 max-h-[200px] overflow-y-auto"
+                    >
+                      {filteredContacts.map((contact, i) => (
+                        <button
+                          key={`${contact.email ?? contact.name}-${i}`}
+                          type="button"
+                          role="option"
+                          aria-selected={i === activeIndex}
+                          className={`w-full text-left px-3 py-2 transition-colors ${
+                            i === activeIndex ? 'bg-accent/50' : 'hover:bg-accent/30'
+                          }`}
+                          onMouseDown={(e) => {
+                            e.preventDefault()
+                            handleSelectContact(contact)
+                          }}
+                        >
+                          <div className="font-medium text-sm">
+                            {contact.display_name ?? contact.name}
+                          </div>
+                          {contact.email && (
+                            <div className="text-xs text-muted-foreground">{contact.email}</div>
+                          )}
+                          {contact.user_id && (
+                            <div className="text-xs text-primary">✓ Has Spl1t account</div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <Button type="submit" size="sm" disabled={adding || !name.trim()}>
+                  {adding ? '…' : 'Add'}
+                </Button>
+              </div>
+              <div>
+                <Label className="sr-only" htmlFor="picker-email">Email (optional)</Label>
+                <Input
+                  ref={emailInputRef}
+                  id="picker-email"
+                  type="email"
+                  inputMode="email"
+                  placeholder="Email (optional)"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  autoComplete="section-participant email"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Add now or let them link themselves via the trip link
+                </p>
+              </div>
+              {error && (
+                <p className="text-xs text-destructive">{error}</p>
+              )}
+            </form>
+          </div>
+
+          {/* Dismiss error */}
+          {error && (
+            <button
+              onClick={() => setError(null)}
+              className="text-xs text-muted-foreground flex items-center gap-1"
+            >
+              <X size={10} />
+              Dismiss
+            </button>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -703,121 +703,125 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
             </div>
           )}
 
-          {error && (
-            <p className="mb-3 text-sm text-destructive">{error}</p>
-          )}
-          <form onSubmit={handleAdd} className="space-y-4">
-            <div className="space-y-2 relative">
-              <Label htmlFor="name">Participant Name</Label>
-              <Input
-                ref={nameInputRef}
-                type="text"
-                id="name"
-                value={name}
-                onChange={(e) => handleNameChange(e.target.value)}
-                onKeyDown={handleNameKeyDown}
-                placeholder="e.g., John Doe"
-                required
-                disabled={adding}
-                autoComplete="off"
-                role="combobox"
-                aria-expanded={showDropdown}
-                aria-autocomplete="list"
-                aria-controls="contact-suggestions"
-              />
-              {showDropdown && (
-                <div
-                  ref={dropdownRef}
-                  id="contact-suggestions"
-                  role="listbox"
-                  className="absolute top-full left-0 right-0 z-50 bg-popover border border-border rounded-md shadow-md mt-1 max-h-[200px] overflow-y-auto"
-                >
-                  {filteredContacts.map((contact, i) => (
-                    <button
-                      key={`${contact.email ?? contact.name}-${i}`}
-                      type="button"
-                      role="option"
-                      aria-selected={i === activeIndex}
-                      className={`w-full text-left px-3 py-2 transition-colors ${
-                        i === activeIndex ? 'bg-accent/50' : 'hover:bg-accent/30'
-                      }`}
-                      onMouseDown={(e) => {
-                        e.preventDefault() // Prevent input blur
-                        handleSelectContact(contact)
-                      }}
-                    >
-                      <div className="font-medium text-sm">
-                        {contact.display_name ?? contact.name}
-                      </div>
-                      {contact.email && (
-                        <div className="text-xs text-muted-foreground">{contact.email}</div>
-                      )}
-                      {contact.user_id && (
-                        <div className="text-xs text-primary">✓ Has Spl1t account</div>
-                      )}
-                    </button>
-                  ))}
-                </div>
+          {!recentExpanded && (
+            <>
+              {error && (
+                <p className="mb-3 text-sm text-destructive">{error}</p>
               )}
-            </div>
+              <form onSubmit={handleAdd} className="space-y-4">
+                <div className="space-y-2 relative">
+                  <Label htmlFor="name">Participant Name</Label>
+                  <Input
+                    ref={nameInputRef}
+                    type="text"
+                    id="name"
+                    value={name}
+                    onChange={(e) => handleNameChange(e.target.value)}
+                    onKeyDown={handleNameKeyDown}
+                    placeholder="e.g., John Doe"
+                    required
+                    disabled={adding}
+                    autoComplete="off"
+                    role="combobox"
+                    aria-expanded={showDropdown}
+                    aria-autocomplete="list"
+                    aria-controls="contact-suggestions"
+                  />
+                  {showDropdown && (
+                    <div
+                      ref={dropdownRef}
+                      id="contact-suggestions"
+                      role="listbox"
+                      className="absolute top-full left-0 right-0 z-50 bg-popover border border-border rounded-md shadow-md mt-1 max-h-[200px] overflow-y-auto"
+                    >
+                      {filteredContacts.map((contact, i) => (
+                        <button
+                          key={`${contact.email ?? contact.name}-${i}`}
+                          type="button"
+                          role="option"
+                          aria-selected={i === activeIndex}
+                          className={`w-full text-left px-3 py-2 transition-colors ${
+                            i === activeIndex ? 'bg-accent/50' : 'hover:bg-accent/30'
+                          }`}
+                          onMouseDown={(e) => {
+                            e.preventDefault() // Prevent input blur
+                            handleSelectContact(contact)
+                          }}
+                        >
+                          <div className="font-medium text-sm">
+                            {contact.display_name ?? contact.name}
+                          </div>
+                          {contact.email && (
+                            <div className="text-xs text-muted-foreground">{contact.email}</div>
+                          )}
+                          {contact.user_id && (
+                            <div className="text-xs text-primary">✓ Has Spl1t account</div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional)</span></Label>
-              <Input
-                ref={emailInputRef}
-                type="email"
-                inputMode="email"
-                id="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="e.g., john@example.com"
-                disabled={adding}
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Add now or let them link themselves via the trip link
-              </p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email <span className="text-muted-foreground font-normal">(optional)</span></Label>
+                  <Input
+                    ref={emailInputRef}
+                    type="email"
+                    inputMode="email"
+                    id="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="e.g., john@example.com"
+                    disabled={adding}
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Add now or let them link themselves via the trip link
+                  </p>
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="walletGroup">Shared Wallet <span className="text-muted-foreground font-normal">(optional — group people who share costs)</span></Label>
-              <Input
-                type="text"
-                id="walletGroup"
-                value={walletGroup}
-                onChange={(e) => setWalletGroup(e.target.value)}
-                placeholder="e.g., The Smiths"
-                disabled={adding}
-                list="wallet-groups"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                People in the same group settle as a unit — e.g. a couple or parents with kids.
-              </p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="walletGroup">Shared Wallet <span className="text-muted-foreground font-normal">(optional — group people who share costs)</span></Label>
+                  <Input
+                    type="text"
+                    id="walletGroup"
+                    value={walletGroup}
+                    onChange={(e) => setWalletGroup(e.target.value)}
+                    placeholder="e.g., The Smiths"
+                    disabled={adding}
+                    list="wallet-groups"
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    People in the same group settle as a unit — e.g. a couple or parents with kids.
+                  </p>
+                </div>
 
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="isAdult"
-                checked={isAdult}
-                onCheckedChange={(checked) => setIsAdult(checked as boolean)}
-                disabled={adding}
-              />
-              <label
-                htmlFor="isAdult"
-                className="text-sm text-foreground cursor-pointer"
-              >
-                Adult (can pay for expenses)
-              </label>
-            </div>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="isAdult"
+                    checked={isAdult}
+                    onCheckedChange={(checked) => setIsAdult(checked as boolean)}
+                    disabled={adding}
+                  />
+                  <label
+                    htmlFor="isAdult"
+                    className="text-sm text-foreground cursor-pointer"
+                  >
+                    Adult (can pay for expenses)
+                  </label>
+                </div>
 
-            <Button
-              type="submit"
-              disabled={adding || !name.trim()}
-              className="w-full"
-            >
-              <UserPlus size={16} className="mr-2" />
-              {adding ? 'Adding...' : 'Add Participant'}
-            </Button>
-          </form>
+                <Button
+                  type="submit"
+                  disabled={adding || !name.trim()}
+                  className="w-full"
+                >
+                  <UserPlus size={16} className="mr-2" />
+                  {adding ? 'Adding...' : 'Add Participant'}
+                </Button>
+              </form>
+            </>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- Expanding "Recent companions" now hides the manual add form, reducing page noise
- Collapsing it (default) restores the form fields
- Applied to both `ParticipantsSetup` (Full mode) and `QuickParticipantPicker` (Quick mode)

## Test plan
- [ ] Default view shows form fields with "Recent companions" collapsed
- [ ] Expanding "Recent companions" shows chip grid, hides form
- [ ] Collapsing "Recent companions" restores form
- [ ] `npm run type-check` clean, 173 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)