### PR TITLE
feat: multi-email choice for wallet group payment reminders

### DIFF
--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -15,8 +15,8 @@ interface SettlementPlanProps {
   onRecordSettlement?: (transaction: SettlementTransaction) => void
   bankDetailsMap?: Record<string, BankDetails>
   linkedParticipantIds?: Set<string>
-  fromEmailMap?: Record<string, string>
-  onRemind?: (transaction: SettlementTransaction, fromEmail: string) => Promise<void>
+  fromEmailMap?: Record<string, { name: string; email: string }[]>
+  onRemind?: (transaction: SettlementTransaction, emails: string[]) => Promise<void>
   avatarMap?: Record<string, string | null>
 }
 
@@ -66,8 +66,8 @@ export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap, linke
             onRecord={onRecordSettlement ? () => onRecordSettlement(transaction) : undefined}
             bankDetails={bankDetailsMap?.[transaction.toId]}
             linkedParticipantIds={linkedParticipantIds}
-            fromEmail={fromEmailMap?.[transaction.fromId]}
-            onRemind={onRemind ? (email) => onRemind(transaction, email) : undefined}
+            fromEmails={fromEmailMap?.[transaction.fromId]}
+            onRemind={onRemind ? (emails) => onRemind(transaction, emails) : undefined}
             avatarMap={avatarMap}
           />
         ))}
@@ -83,8 +83,8 @@ interface SettlementTransactionCardProps {
   onRecord?: () => void
   bankDetails?: BankDetails
   linkedParticipantIds?: Set<string>
-  fromEmail?: string
-  onRemind?: (fromEmail: string) => Promise<void>
+  fromEmails?: { name: string; email: string }[]
+  onRemind?: (emails: string[]) => Promise<void>
   avatarMap?: Record<string, string | null>
 }
 
@@ -95,13 +95,14 @@ function SettlementTransactionCard({
   onRecord,
   bankDetails,
   linkedParticipantIds,
-  fromEmail,
+  fromEmails,
   onRemind,
   avatarMap,
 }: SettlementTransactionCardProps) {
   const [confirmingRemind, setConfirmingRemind] = useState(false)
   const [sending, setSending] = useState(false)
   const [remindResult, setRemindResult] = useState<'sent' | 'error' | null>(null)
+  const [checkedEmails, setCheckedEmails] = useState<Record<string, boolean>>({})
 
   const formattedAmount = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -109,11 +110,15 @@ function SettlementTransactionCard({
   }).format(transaction.amount)
 
   const handleSendReminder = async () => {
-    if (!onRemind || !fromEmail) return
+    if (!onRemind || !fromEmails || fromEmails.length === 0) return
+    const selectedEmails = fromEmails.length === 1
+      ? [fromEmails[0].email]
+      : fromEmails.filter(e => checkedEmails[e.email] !== false).map(e => e.email)
+    if (selectedEmails.length === 0) return
     setSending(true)
     setRemindResult(null)
     try {
-      await onRemind(fromEmail)
+      await onRemind(selectedEmails)
       setRemindResult('sent')
       setConfirmingRemind(false)
     } catch {
@@ -170,18 +175,34 @@ function SettlementTransactionCard({
           )}
 
           {/* Remind confirmation inline */}
-          {confirmingRemind && fromEmail && (
+          {confirmingRemind && fromEmails && fromEmails.length > 0 && (
             <div className="mt-3 p-3 rounded-lg bg-accent/10 border border-accent/20 space-y-2">
               <p className="text-sm text-foreground">
                 Send payment reminder to <strong>{transaction.fromName}</strong>?
               </p>
-              <p className="text-xs text-muted-foreground">{fromEmail}</p>
+              {fromEmails.length === 1 ? (
+                <p className="text-xs text-muted-foreground">{fromEmails[0].email}</p>
+              ) : (
+                <div className="space-y-1.5">
+                  {fromEmails.map(({ name, email }) => (
+                    <label key={email} className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={checkedEmails[email] !== false}
+                        onChange={(e) => setCheckedEmails(prev => ({ ...prev, [email]: e.target.checked }))}
+                        className="accent-primary"
+                      />
+                      <span>{name} — {email}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
               <div className="flex gap-2">
                 <Button
                   size="sm"
                   className="h-7 text-xs"
                   onClick={handleSendReminder}
-                  disabled={sending}
+                  disabled={sending || (fromEmails.length > 1 && fromEmails.every(e => checkedEmails[e.email] === false))}
                 >
                   {sending ? 'Sending…' : 'Send'}
                 </Button>
@@ -223,9 +244,18 @@ function SettlementTransactionCard({
               Record
             </Button>
           )}
-          {fromEmail && onRemind && !confirmingRemind && (
+          {fromEmails && fromEmails.length > 0 && onRemind && !confirmingRemind && (
             <Button
-              onClick={() => { setConfirmingRemind(true); setRemindResult(null) }}
+              onClick={() => {
+                setConfirmingRemind(true)
+                setRemindResult(null)
+                // Initialize all emails as checked
+                if (fromEmails.length > 1) {
+                  const init: Record<string, boolean> = {}
+                  for (const e of fromEmails) init[e.email] = true
+                  setCheckedEmails(init)
+                }
+              }}
               size="sm"
               variant="outline"
               title={`Send payment reminder to ${transaction.fromName}`}

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -50,19 +50,21 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
   const [confirmingRemindIdx, setConfirmingRemindIdx] = useState<number | null>(null)
   const [sendingRemind, setSendingRemind] = useState(false)
   const [remindResults, setRemindResults] = useState<Record<number, 'sent' | 'error'>>({})
+  const [checkedEmails, setCheckedEmails] = useState<Record<string, boolean>>({})
   const isSubmittingRef = useRef(false)
   const keyboard = useKeyboardHeight()
   const isMobile = useMediaQuery('(max-width: 767px)')
 
-  // Build email map: entity ID → email
+  // Build email map: entity ID → emails (multiple adults in wallet_group)
   const fromEmailMap = useMemo(() => {
     if (!currentTrip) return {}
     const entityMap = buildEntityMap(participants, currentTrip.tracking_mode)
-    const map: Record<string, string> = {}
+    const map: Record<string, { name: string; email: string }[]> = {}
     for (const p of participants) {
-      if (!p.email) continue
+      if (!p.email || p.is_adult === false) continue
       const entityId = entityMap.participantToEntityId.get(p.id) ?? p.id
-      map[entityId] = p.email
+      if (!map[entityId]) map[entityId] = []
+      map[entityId].push({ name: p.name, email: p.email })
     }
     return map
   }, [participants, currentTrip])
@@ -162,15 +164,20 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
 
   const handleRemind = async (tx: SettlementTransaction, idx: number) => {
     if (!currentTrip || !user) return
-    const fromEmail = fromEmailMap[tx.fromId]
-    if (!fromEmail) return
+    const fromEmails = fromEmailMap[tx.fromId]
+    if (!fromEmails || fromEmails.length === 0) return
+
+    // Determine which emails to send to
+    const selectedEmails = fromEmails.length === 1
+      ? [fromEmails[0].email]
+      : fromEmails.filter(e => checkedEmails[e.email] !== false).map(e => e.email)
+    if (selectedEmails.length === 0) return
 
     setSendingRemind(true)
     try {
       const organiserName = userProfile?.display_name || user.email?.split('@')[0] || 'Organiser'
 
       // Collect receipt data for expenses paid by the creditor (max 3)
-      // Entity IDs are participant IDs — find all members of the same wallet_group
       const entityMap = buildEntityMap(participants, trackingMode)
       const creditorParticipantIds = new Set(
         participants
@@ -207,22 +214,29 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
         }
       }
 
-      const { error } = await supabase.functions.invoke('send-email', {
-        body: {
-          type: 'payment_reminder',
-          trip_id: currentTrip.id,
-          trip_name: currentTrip.name,
-          trip_code: currentTrip.trip_code,
-          recipient_name: tx.fromName,
-          recipient_email: fromEmail,
-          amount: tx.amount,
-          currency: currentTrip.default_currency,
-          pay_to_name: tx.toName,
-          organiser_name: organiserName,
-          ...(receipts.length > 0 && { receipts }),
-        },
-      })
-      if (error) throw new Error(String(error))
+      // Send one email per selected recipient
+      const results = await Promise.allSettled(
+        selectedEmails.map(email =>
+          supabase.functions.invoke('send-email', {
+            body: {
+              type: 'payment_reminder',
+              trip_id: currentTrip.id,
+              trip_name: currentTrip.name,
+              trip_code: currentTrip.trip_code,
+              recipient_name: tx.fromName,
+              recipient_email: email,
+              amount: tx.amount,
+              currency: currentTrip.default_currency,
+              pay_to_name: tx.toName,
+              organiser_name: organiserName,
+              ...(receipts.length > 0 && { receipts }),
+            },
+          })
+        )
+      )
+
+      const failures = results.filter(r => r.status === 'rejected' || (r.status === 'fulfilled' && r.value.error))
+      if (failures.length === selectedEmails.length) throw new Error('All reminders failed')
 
       setRemindResults(prev => ({ ...prev, [idx]: 'sent' }))
       setConfirmingRemindIdx(null)
@@ -282,6 +296,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
       setPrefill(null)
       setConfirmingRemindIdx(null)
       setRemindResults({})
+      setCheckedEmails({})
     }
     onOpenChange(isOpen)
   }
@@ -355,8 +370,8 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
               </p>
               {myTransactions.map((tx, i) => {
                 const iOwe = tx.fromId === myEntityId
-                const fromEmail = !iOwe ? fromEmailMap[tx.fromId] : undefined
-                const canRemind = !iOwe && !!fromEmail
+                const fromEmails = !iOwe ? fromEmailMap[tx.fromId] : undefined
+                const canRemind = !iOwe && !!fromEmails && fromEmails.length > 0
                 const isConfirmingRemind = confirmingRemindIdx === i
                 const remindResult = remindResults[i]
                 return (
@@ -423,18 +438,34 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                       })()}
 
                       {/* Inline remind confirm */}
-                      {isConfirmingRemind && fromEmail && (
+                      {isConfirmingRemind && fromEmails && fromEmails.length > 0 && (
                         <div className="mt-3 p-3 rounded-lg bg-accent/10 border border-accent/20 space-y-2">
                           <p className="text-sm text-foreground">
                             Send payment reminder to <strong>{tx.fromName}</strong>?
                           </p>
-                          <p className="text-xs text-muted-foreground">{fromEmail}</p>
+                          {fromEmails.length === 1 ? (
+                            <p className="text-xs text-muted-foreground">{fromEmails[0].email}</p>
+                          ) : (
+                            <div className="space-y-1.5">
+                              {fromEmails.map(({ name, email }) => (
+                                <label key={email} className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+                                  <input
+                                    type="checkbox"
+                                    checked={checkedEmails[email] !== false}
+                                    onChange={(e) => setCheckedEmails(prev => ({ ...prev, [email]: e.target.checked }))}
+                                    className="accent-primary"
+                                  />
+                                  <span>{name} — {email}</span>
+                                </label>
+                              ))}
+                            </div>
+                          )}
                           <div className="flex gap-2">
                             <Button
                               size="sm"
                               className="h-7 text-xs"
                               onClick={() => handleRemind(tx, i)}
-                              disabled={sendingRemind}
+                              disabled={sendingRemind || (fromEmails.length > 1 && fromEmails.every(e => checkedEmails[e.email] === false))}
                             >
                               {sendingRemind ? 'Sending…' : 'Send'}
                             </Button>
@@ -475,7 +506,16 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                         <Button
                           size="sm"
                           variant="outline"
-                          onClick={() => { setConfirmingRemindIdx(i); setRemindResults(prev => { const n = { ...prev }; delete n[i]; return n }) }}
+                          onClick={() => {
+                            setConfirmingRemindIdx(i)
+                            setRemindResults(prev => { const n = { ...prev }; delete n[i]; return n })
+                            // Initialize all emails as checked
+                            if (fromEmails && fromEmails.length > 1) {
+                              const init: Record<string, boolean> = {}
+                              for (const e of fromEmails) init[e.email] = true
+                              setCheckedEmails(init)
+                            }
+                          }}
                           title={`Send payment reminder to ${tx.fromName}`}
                         >
                           <Bell size={14} className="mr-1" />

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -63,15 +63,16 @@ export function SettlementsPage() {
     return map
   }, [participants])
 
-  // Build a map of entity ID → email for the "from" side of transactions
+  // Build a map of entity ID → emails for the "from" side of transactions
   const fromEmailMap = useMemo(() => {
     if (!currentTrip) return {}
     const entityMap = buildEntityMap(participants, currentTrip.tracking_mode)
-    const map: Record<string, string> = {}
+    const map: Record<string, { name: string; email: string }[]> = {}
     for (const p of participants) {
-      if (!p.email) continue
+      if (!p.email || p.is_adult === false) continue
       const entityId = entityMap.participantToEntityId.get(p.id) ?? p.id
-      map[entityId] = p.email
+      if (!map[entityId]) map[entityId] = []
+      map[entityId].push({ name: p.name, email: p.email })
     }
     return map
   }, [participants, currentTrip])
@@ -193,7 +194,7 @@ export function SettlementsPage() {
     setPrefilledNote(undefined)
   }
 
-  const handleRemind = async (transaction: SettlementTransaction, fromEmail: string): Promise<void> => {
+  const handleRemind = async (transaction: SettlementTransaction, emails: string[]): Promise<void> => {
     if (!currentTrip || !user) return
     const organiserName = userProfile?.display_name || user.email?.split('@')[0] || 'Organiser'
 
@@ -234,24 +235,33 @@ export function SettlementsPage() {
       }
     }
 
-    const { error } = await supabase.functions.invoke('send-email', {
-      body: {
-        type: 'payment_reminder',
-        trip_id: currentTrip.id,
-        trip_name: currentTrip.name,
-        trip_code: currentTrip.trip_code,
-        recipient_name: transaction.fromName,
-        recipient_email: fromEmail,
-        amount: transaction.amount,
-        currency: currentTrip.default_currency,
-        pay_to_name: transaction.toName,
-        organiser_name: organiserName,
-        ...(receipts.length > 0 && { receipts }),
-      },
-    })
-    if (error) {
-      logger.error('Failed to send payment reminder', { error: String(error) })
-      throw new Error('Failed to send reminder')
+    // Send one email per selected recipient
+    const results = await Promise.allSettled(
+      emails.map(email =>
+        supabase.functions.invoke('send-email', {
+          body: {
+            type: 'payment_reminder',
+            trip_id: currentTrip.id,
+            trip_name: currentTrip.name,
+            trip_code: currentTrip.trip_code,
+            recipient_name: transaction.fromName,
+            recipient_email: email,
+            amount: transaction.amount,
+            currency: currentTrip.default_currency,
+            pay_to_name: transaction.toName,
+            organiser_name: organiserName,
+            ...(receipts.length > 0 && { receipts }),
+          },
+        })
+      )
+    )
+
+    const failures = results.filter(r => r.status === 'rejected' || (r.status === 'fulfilled' && r.value.error))
+    if (failures.length > 0) {
+      logger.error('Failed to send payment reminder(s)', { failureCount: failures.length, totalCount: emails.length })
+      if (failures.length === emails.length) {
+        throw new Error('Failed to send reminder')
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- When a wallet group (e.g. "Lammuka Eliased") has multiple adults with email addresses, the remind flow now shows checkboxes to choose which member(s) to send the reminder to
- Single-email entities show the same UI as before (no checkbox, just the email)
- `fromEmailMap` changed from `Record<string, string>` to `Record<string, { name: string; email: string }[]>` in both SettlementsPage and QuickSettlementSheet
- `handleRemind` now accepts `emails: string[]` and uses `Promise.allSettled` to send one email per selected recipient
- Children (`is_adult === false`) are excluded from the email list

## Test plan
- [ ] Trip with wallet group where 2 adults have emails → remind shows both with checkboxes, all pre-checked
- [ ] Solo participant with email → remind shows single email, no checkbox (same as today)
- [ ] Uncheck one email, send → only checked email receives reminder
- [ ] Uncheck all emails → Send button is disabled
- [ ] Full mode (SettlementsPage) and Quick mode (QuickSettlementSheet) both work
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — 173 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)