### PR TITLE
feat: responsive receipt viewer with edit mapping support

### DIFF
--- a/src/components/receipts/PendingReceiptBanner.tsx
+++ b/src/components/receipts/PendingReceiptBanner.tsx
@@ -10,6 +10,7 @@ export interface ReceiptReviewData {
   currency: string
   imagePath: string | null
   category: string | null
+  existingExpenseId?: string
 }
 
 interface PendingReceiptBannerProps {

--- a/src/components/receipts/ReceiptDetailsSheet.tsx
+++ b/src/components/receipts/ReceiptDetailsSheet.tsx
@@ -1,19 +1,25 @@
 import { useState, useEffect } from 'react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { ScanLine, ChevronDown, ChevronUp, Image, X } from 'lucide-react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ScanLine, ChevronDown, ChevronUp, Image, X, Pencil } from 'lucide-react'
 import { ReceiptTask } from '@/types/receipt'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/lib/logger'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 
 interface ReceiptDetailsSheetProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   task: ReceiptTask
+  canReprocess?: boolean
+  onReprocess?: () => void
 }
 
-export function ReceiptDetailsSheet({ open, onOpenChange, task }: ReceiptDetailsSheetProps) {
+export function ReceiptDetailsSheet({ open, onOpenChange, task, canReprocess, onReprocess }: ReceiptDetailsSheetProps) {
   const items = task.extracted_items ?? []
   const currency = task.extracted_currency ?? '—'
+  const isMobile = useMediaQuery('(max-width: 767px)')
 
   const [receiptImageUrl, setReceiptImageUrl] = useState<string | null>(null)
   const [showThumbnail, setShowThumbnail] = useState(false)
@@ -36,84 +42,126 @@ export function ReceiptDetailsSheet({ open, onOpenChange, task }: ReceiptDetails
       })
   }, [open, task.receipt_image_path])
 
-  return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="bottom"
-        hideClose
-        className="flex flex-col p-0 rounded-t-2xl"
-        style={{ height: '75dvh' }}
+  const onClose = () => onOpenChange(false)
+
+  const header = (
+    <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+      <div className="w-8" />
+      <SheetTitle className="text-base font-semibold flex items-center gap-2 min-w-0">
+        <ScanLine size={18} className="shrink-0" />
+        <span className="truncate">
+          Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
+        </span>
+      </SheetTitle>
+      <button
+        onClick={onClose}
+        aria-label="Close"
+        className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
       >
-        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-          <div className="w-8" />
-          <SheetTitle className="text-base font-semibold flex items-center gap-2 min-w-0">
-            <ScanLine size={18} className="shrink-0" />
-            <span className="truncate">
-              Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
-            </span>
-          </SheetTitle>
-          <button
-            onClick={() => onOpenChange(false)}
-            aria-label="Close"
-            className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-          >
-            <X className="w-4 h-4 text-muted-foreground" />
-          </button>
-        </div>
+        <X className="w-4 h-4 text-muted-foreground" />
+      </button>
+    </div>
+  )
 
-        <div className="flex-1 overflow-y-auto overscroll-contain">
-          <div className="px-4 py-3 space-y-3">
-            {/* Receipt image thumbnail (collapsible) */}
-            {receiptImageUrl && (
-              <div className="border border-border rounded-lg overflow-hidden">
-                <button
-                  className="flex items-center justify-between w-full px-3 py-2 text-sm font-medium text-foreground"
-                  onClick={() => setShowThumbnail(v => !v)}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <Image size={14} />
-                    Receipt photo
-                  </span>
-                  {showThumbnail ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-                </button>
-                {showThumbnail && (
-                  <img
-                    src={receiptImageUrl}
-                    alt="Receipt"
-                    className="w-full max-h-64 object-contain bg-muted"
-                  />
-                )}
-              </div>
-            )}
-
-            {items.length === 0 ? (
-              <p className="text-sm text-muted-foreground text-center py-6">No items extracted.</p>
-            ) : (
-              <div className="space-y-1">
-                <div className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs font-medium text-muted-foreground pb-1 border-b border-border">
-                  <span>Item</span>
-                  <span className="text-center">Qty</span>
-                  <span className="text-right">Price</span>
-                </div>
-                {items.map((item, i) => (
-                  <div key={i} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-sm py-1.5 border-b border-border/50 last:border-0">
-                    <span className="break-words min-w-0">{item.name}</span>
-                    <span className="text-center text-muted-foreground">{item.qty}</span>
-                    <span className="text-right tabular-nums whitespace-nowrap">{currency} {item.price.toFixed(2)}</span>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {task.extracted_total != null && (
-              <div className="flex items-center justify-between font-semibold text-sm border-t border-border pt-2">
-                <span>Total</span>
-                <span className="tabular-nums">{currency} {task.extracted_total.toFixed(2)}</span>
-              </div>
+  const body = (
+    <div className="flex-1 overflow-y-auto overscroll-contain">
+      <div className="px-4 py-3 space-y-3">
+        {/* Receipt image thumbnail (collapsible) */}
+        {receiptImageUrl && (
+          <div className="border border-border rounded-lg overflow-hidden">
+            <button
+              className="flex items-center justify-between w-full px-3 py-2 text-sm font-medium text-foreground"
+              onClick={() => setShowThumbnail(v => !v)}
+            >
+              <span className="flex items-center gap-1.5">
+                <Image size={14} />
+                Receipt photo
+              </span>
+              {showThumbnail ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+            </button>
+            {showThumbnail && (
+              <img
+                src={receiptImageUrl}
+                alt="Receipt"
+                className="w-full max-h-64 object-contain bg-muted"
+              />
             )}
           </div>
-        </div>
-      </SheetContent>
-    </Sheet>
+        )}
+
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-6">No items extracted.</p>
+        ) : (
+          <div className="space-y-1">
+            <div className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs font-medium text-muted-foreground pb-1 border-b border-border">
+              <span>Item</span>
+              <span className="text-center">Qty</span>
+              <span className="text-right">Price</span>
+            </div>
+            {items.map((item, i) => (
+              <div key={i} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-sm py-1.5 border-b border-border/50 last:border-0">
+                <span className="break-words min-w-0">{item.name}</span>
+                <span className="text-center text-muted-foreground">{item.qty}</span>
+                <span className="text-right tabular-nums whitespace-nowrap">{currency} {item.price.toFixed(2)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {task.extracted_total != null && (
+          <div className="flex items-center justify-between font-semibold text-sm border-t border-border pt-2">
+            <span>Total</span>
+            <span className="tabular-nums">{currency} {task.extracted_total.toFixed(2)}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  const footer = canReprocess && onReprocess ? (
+    <div className="shrink-0 px-4 py-3 border-t border-border bg-background">
+      <Button
+        onClick={onReprocess}
+        variant="outline"
+        className="w-full gap-2"
+      >
+        <Pencil size={16} />
+        Edit mapping
+      </Button>
+    </div>
+  ) : null
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="bottom"
+          hideClose
+          className="flex flex-col p-0 rounded-t-2xl"
+          style={{ height: '75dvh' }}
+        >
+          {header}
+          {body}
+          {footer}
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        hideClose
+        className="flex flex-col max-w-2xl max-h-[85vh] p-0 gap-0"
+        aria-describedby={undefined}
+      >
+        <DialogTitle className="sr-only">
+          Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
+        </DialogTitle>
+        {header}
+        {body}
+        {footer}
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -36,6 +36,7 @@ interface ReceiptReviewSheetProps {
   currency: string
   imagePath?: string | null
   extractedCategory?: string | null
+  existingExpenseId?: string
   onDone: () => void
 }
 
@@ -137,6 +138,7 @@ export function ReceiptReviewSheet({
   currency,
   imagePath,
   extractedCategory,
+  existingExpenseId,
   onDone,
 }: ReceiptReviewSheetProps) {
   const keyboard = useKeyboardHeight()
@@ -144,7 +146,7 @@ export function ReceiptReviewSheet({
   useScrollIntoView(contentRef, { enabled: keyboard.isVisible, offset: 20 })
   const { currentTrip } = useCurrentTrip()
   const { participants, getAdultParticipants } = useParticipantContext()
-  const { createExpense } = useExpenseContext()
+  const { createExpense, updateExpense } = useExpenseContext()
   const { completeReceiptTask, error: receiptError, clearError: clearReceiptError } = useReceiptContext()
   const { updateTrip } = useTripContext()
   const { user } = useAuth()
@@ -334,27 +336,41 @@ export function ReceiptReviewSheet({
         ? `Receipt: ${merchantName.trim()}`
         : 'Receipt'
 
-      const expense = await createExpense({
-        trip_id: currentTrip.id,
-        description,
-        amount: totalAmount,
-        currency: activeCurrency,
-        paid_by: paidBy,
-        distribution,
-        category,
-        expense_date: new Date().toISOString().split('T')[0],
-      })
+      let expenseId: string
 
-      if (!expense) {
-        toast({ title: 'Failed to create expense', variant: 'destructive' })
-        setSubmitting(false)
-        return
+      if (existingExpenseId) {
+        await updateExpense(existingExpenseId, {
+          description,
+          amount: totalAmount,
+          currency: activeCurrency,
+          paid_by: paidBy,
+          distribution,
+          category,
+        })
+        expenseId = existingExpenseId
+      } else {
+        const expense = await createExpense({
+          trip_id: currentTrip.id,
+          description,
+          amount: totalAmount,
+          currency: activeCurrency,
+          paid_by: paidBy,
+          distribution,
+          category,
+          expense_date: new Date().toISOString().split('T')[0],
+        })
+        if (!expense) {
+          toast({ title: 'Failed to create expense', variant: 'destructive' })
+          setSubmitting(false)
+          return
+        }
+        expenseId = expense.id
       }
 
-      await completeReceiptTask(taskId, expense.id)
+      await completeReceiptTask(taskId, expenseId)
 
       toast({
-        title: 'Receipt added',
+        title: existingExpenseId ? 'Receipt updated' : 'Receipt added',
         description: `${description} — ${activeCurrency} ${totalAmount.toFixed(2)}`,
       })
 
@@ -592,10 +608,10 @@ export function ReceiptReviewSheet({
             {submitting ? (
               <>
                 <Loader2 size={16} className="animate-spin" />
-                Adding expense...
+                {existingExpenseId ? 'Updating expense...' : 'Adding expense...'}
               </>
             ) : (
-              `Add Expense — ${activeCurrency} ${totalExpense.toFixed(2)}`
+              `${existingExpenseId ? 'Update' : 'Add'} Expense — ${activeCurrency} ${totalExpense.toFixed(2)}`
             )}
           </Button>
           {!canSubmit && totalFloat > 0 && unassignedItems.length > 0 && (

--- a/src/contexts/ReceiptContext.tsx
+++ b/src/contexts/ReceiptContext.tsx
@@ -16,6 +16,7 @@ interface ReceiptContextType {
   createReceiptTask: (tripId: string, imagePath?: string) => Promise<ReceiptTask>
   updateReceiptTask: (id: string, updates: ReceiptTaskUpdate) => Promise<boolean>
   completeReceiptTask: (id: string, expenseId: string) => Promise<boolean>
+  reopenReceiptTask: (id: string) => Promise<boolean>
   dismissReceiptTask: (id: string) => Promise<boolean>
   refreshPendingReceipts: () => Promise<void>
 }
@@ -33,6 +34,7 @@ export type ReceiptTaskUpdate = Partial<Pick<ReceiptTask,
   | 'mapped_items'
   | 'error_message'
   | 'receipt_image_path'
+  | 'expense_id'
 >>
 
 const ReceiptContext = createContext<ReceiptContextType | undefined>(undefined)
@@ -215,6 +217,41 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  const reopenReceiptTask = async (id: string): Promise<boolean> => {
+    try {
+      const controller = new AbortController()
+      const { error: updateError } = await withTimeout(
+        supabase
+          .from('receipt_tasks')
+          .update({
+            status: 'review',
+            expense_id: null,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', id)
+          .abortSignal(controller.signal),
+        15000,
+        'Reopening receipt task timed out.',
+        controller
+      )
+
+      if (updateError) {
+        const message = updateError.message || 'Failed to reopen receipt task'
+        setError(message)
+        logger.error('Failed to reopen receipt task', { error: updateError.message })
+        return false
+      }
+
+      fetchPendingReceipts()
+      return true
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to reopen receipt task'
+      setError(message)
+      logger.error('Unhandled error reopening receipt task', { error: String(err) })
+      return false
+    }
+  }
+
   const dismissReceiptTask = async (id: string): Promise<boolean> => {
     const imagePath = pendingReceipts.find(r => r.id === id)?.receipt_image_path ?? null
     try {
@@ -267,6 +304,7 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
         createReceiptTask,
         updateReceiptTask,
         completeReceiptTask,
+        reopenReceiptTask,
         dismissReceiptTask,
         refreshPendingReceipts: fetchPendingReceipts,
       }}

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -9,6 +9,7 @@ import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
 import { useReceiptContext } from '@/contexts/ReceiptContext'
+import { useAuth } from '@/contexts/AuthContext'
 import { calculateBalances, convertToBaseCurrency } from '@/services/balanceCalculator'
 import { exportExpensesToExcel } from '@/services/excelExport'
 import { ExpenseWizard } from '@/components/expenses/ExpenseWizard'
@@ -44,7 +45,8 @@ export function ExpensesPage() {
   const { expenses, loading, error, createExpense, updateExpense, deleteExpense, refreshExpenses } = useExpenseContext()
   const { participants } = useParticipantContext()
   const { settlements } = useSettlementContext()
-  const { pendingReceipts, receiptByExpenseId, dismissReceiptTask } = useReceiptContext()
+  const { pendingReceipts, receiptByExpenseId, dismissReceiptTask, reopenReceiptTask } = useReceiptContext()
+  const { user } = useAuth()
   const { toast } = useToast()
 
   const handleRefresh = useCallback(() => refreshExpenses(), [refreshExpenses])
@@ -93,6 +95,25 @@ export function ExpensesPage() {
     ).balances
 
     exportExpensesToExcel(currentTrip, expenses, participants, balances, settlements)
+  }
+
+  const handleReprocessReceipt = async (task: ReceiptTask) => {
+    const success = await reopenReceiptTask(task.id)
+    if (!success) {
+      toast({ title: 'Failed to reopen receipt', variant: 'destructive' })
+      return
+    }
+    setViewingReceiptTask(null)
+    setReceiptReviewData({
+      taskId: task.id,
+      merchant: task.extracted_merchant,
+      items: task.extracted_items ?? [],
+      total: task.extracted_total,
+      currency: task.extracted_currency ?? currentTrip?.default_currency ?? 'EUR',
+      imagePath: task.receipt_image_path ?? null,
+      category: task.extracted_category ?? null,
+      existingExpenseId: task.expense_id ?? undefined,
+    })
   }
 
   const hasActiveFilters = searchQuery !== '' || selectedCategory !== 'all' || selectedPaidBy !== 'all'
@@ -352,6 +373,7 @@ export function ExpensesPage() {
           currency={receiptReviewData.currency}
           imagePath={receiptReviewData.imagePath}
           extractedCategory={receiptReviewData.category}
+          existingExpenseId={receiptReviewData.existingExpenseId}
           onDone={() => setReceiptReviewData(null)}
         />
       )}
@@ -362,6 +384,8 @@ export function ExpensesPage() {
           open={!!viewingReceiptTask}
           onOpenChange={open => { if (!open) setViewingReceiptTask(null) }}
           task={viewingReceiptTask}
+          canReprocess={!!user && viewingReceiptTask.created_by === user.id}
+          onReprocess={() => handleReprocessReceipt(viewingReceiptTask)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- **Responsive receipt viewer**: Desktop uses centered `Dialog` (`max-w-2xl`), mobile keeps bottom `Sheet` at `75dvh` — matching the ExpenseWizard pattern
- **Edit mapping button**: Receipt creators can re-open the interactive review screen to fix item-to-participant assignments on completed receipts; the same expense row is updated in place
- **`reopenReceiptTask`**: New ReceiptContext method that resets receipt status to `review` and clears `expense_id`

## Test plan
- [ ] Desktop: receipt viewer opens as centered dialog (not full-width sheet)
- [ ] Mobile: receipt viewer still opens as bottom sheet at 75dvh
- [ ] "Edit mapping" button visible only for authenticated receipt creator
- [ ] Clicking "Edit mapping" closes details → opens review sheet with pre-filled data
- [ ] After re-mapping and submitting: same expense updated in place (not duplicated)
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (173 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)