### PR TITLE
feat: smart receipt section in payment reminder emails

### DIFF
--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -177,7 +177,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
     try {
       const organiserName = userProfile?.display_name || user.email?.split('@')[0] || 'Organiser'
 
-      // Collect receipt data for expenses paid by the creditor (max 3)
+      // Collect receipt data for expenses paid by the creditor
       const entityMap = buildEntityMap(participants, trackingMode)
       const creditorParticipantIds = new Set(
         participants
@@ -188,6 +188,9 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
         .filter(p => (entityMap.participantToEntityId.get(p.id) ?? p.id) === tx.fromId)
         .map(p => p.id)
 
+      // Count all expenses paid by the creditor to decide receipt vs summary
+      const creditorExpenseCount = expenses.filter(e => creditorParticipantIds.has(e.paid_by)).length
+
       const receipts: Array<{
         merchant: string | null
         items: Array<{ name: string; price: number; qty: number }> | null
@@ -197,20 +200,23 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
         mapped_items: Array<{ item_index: number; participant_ids: string[] }> | null
         debtor_participant_ids: string[]
       }> = []
-      for (const expense of expenses) {
-        if (receipts.length >= 3) break
-        if (!creditorParticipantIds.has(expense.paid_by)) continue
-        const receipt = receiptByExpenseId[expense.id]
-        if (receipt) {
-          receipts.push({
-            merchant: receipt.extracted_merchant,
-            items: receipt.extracted_items,
-            confirmed_total: receipt.confirmed_total,
-            tip_amount: receipt.tip_amount,
-            currency: receipt.extracted_currency ?? currentTrip.default_currency,
-            mapped_items: receipt.mapped_items,
-            debtor_participant_ids: debtorParticipantIds,
-          })
+
+      // Only collect receipt details when creditor has 3 or fewer expenses
+      if (creditorExpenseCount <= 3) {
+        for (const expense of expenses) {
+          if (!creditorParticipantIds.has(expense.paid_by)) continue
+          const receipt = receiptByExpenseId[expense.id]
+          if (receipt) {
+            receipts.push({
+              merchant: receipt.extracted_merchant,
+              items: receipt.extracted_items,
+              confirmed_total: receipt.confirmed_total,
+              tip_amount: receipt.tip_amount,
+              currency: receipt.extracted_currency ?? currentTrip.default_currency,
+              mapped_items: receipt.mapped_items,
+              debtor_participant_ids: debtorParticipantIds,
+            })
+          }
         }
       }
 
@@ -230,6 +236,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
               pay_to_name: tx.toName,
               organiser_name: organiserName,
               ...(receipts.length > 0 && { receipts }),
+              ...(creditorExpenseCount > 3 && { expense_count: creditorExpenseCount }),
             },
           })
         )

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -209,6 +209,10 @@ export function SettlementsPage() {
     const debtorParticipantIds = participants
       .filter(p => (entityMap.participantToEntityId.get(p.id) ?? p.id) === transaction.fromId)
       .map(p => p.id)
+
+    // Count all expenses paid by the creditor to decide receipt vs summary
+    const creditorExpenseCount = expenses.filter(e => creditorParticipantIds.has(e.paid_by)).length
+
     const receipts: Array<{
       merchant: string | null
       items: Array<{ name: string; price: number; qty: number }> | null
@@ -218,20 +222,23 @@ export function SettlementsPage() {
       mapped_items: Array<{ item_index: number; participant_ids: string[] }> | null
       debtor_participant_ids: string[]
     }> = []
-    for (const expense of expenses) {
-      if (receipts.length >= 3) break
-      if (!creditorParticipantIds.has(expense.paid_by)) continue
-      const receipt = receiptByExpenseId[expense.id]
-      if (receipt) {
-        receipts.push({
-          merchant: receipt.extracted_merchant,
-          items: receipt.extracted_items,
-          confirmed_total: receipt.confirmed_total,
-          tip_amount: receipt.tip_amount,
-          currency: receipt.extracted_currency ?? currentTrip.default_currency,
-          mapped_items: receipt.mapped_items,
-          debtor_participant_ids: debtorParticipantIds,
-        })
+
+    // Only collect receipt details when creditor has 3 or fewer expenses
+    if (creditorExpenseCount <= 3) {
+      for (const expense of expenses) {
+        if (!creditorParticipantIds.has(expense.paid_by)) continue
+        const receipt = receiptByExpenseId[expense.id]
+        if (receipt) {
+          receipts.push({
+            merchant: receipt.extracted_merchant,
+            items: receipt.extracted_items,
+            confirmed_total: receipt.confirmed_total,
+            tip_amount: receipt.tip_amount,
+            currency: receipt.extracted_currency ?? currentTrip.default_currency,
+            mapped_items: receipt.mapped_items,
+            debtor_participant_ids: debtorParticipantIds,
+          })
+        }
       }
     }
 
@@ -251,6 +258,7 @@ export function SettlementsPage() {
             pay_to_name: transaction.toName,
             organiser_name: organiserName,
             ...(receipts.length > 0 && { receipts }),
+            ...(creditorExpenseCount > 3 && { expense_count: creditorExpenseCount }),
           },
         })
       )

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -132,6 +132,7 @@ type SendEmailBody =
       pay_to_name: string
       organiser_name: string
       receipts?: ReceiptEmailData[]
+      expense_count?: number
     }
   | {
       type: 'issue_report'
@@ -256,10 +257,13 @@ function paymentReminderEmailHtml(params: {
   tripUrl: string
   settlementsUrl: string
   receipts?: ReceiptEmailData[]
+  expenseCount?: number
 }): string {
-  const { recipientName, organiserName, tripName, formattedAmount, payToName, tripUrl, settlementsUrl, receipts } = params
+  const { recipientName, organiserName, tripName, formattedAmount, payToName, tripUrl, settlementsUrl, receipts, expenseCount } = params
   const hasReceipts = receipts && receipts.length > 0
-  const receiptSection = hasReceipts ? `
+  let receiptSection = ''
+  if (hasReceipts) {
+    receiptSection = `
               <!-- Receipt tables -->
               <div style="margin-bottom:24px;">
                 <p style="margin:0 0 12px;color:${BRAND.textMuted};font-size:14px;font-weight:600;">What you're splitting:</p>
@@ -267,7 +271,18 @@ function paymentReminderEmailHtml(params: {
                 <p style="margin:8px 0 0;color:${BRAND.textMuted};font-size:12px;text-align:center;font-style:italic;">
                   Full receipt photo available in the Spl1t app.
                 </p>
-              </div>` : ''
+              </div>`
+  } else if (expenseCount && expenseCount > 0) {
+    receiptSection = `
+              <!-- Expense count summary -->
+              <div style="margin-bottom:24px;border:1px solid ${BRAND.border};border-radius:8px;overflow:hidden;">
+                <div style="background:${BRAND.background};padding:12px 16px;">
+                  <p style="margin:0 0 4px;color:${BRAND.textMuted};font-size:14px;font-weight:600;">What you're splitting:</p>
+                  <p style="margin:0;color:${BRAND.textPrimary};font-size:14px;">Based on ${expenseCount} expenses from ${escapeHtml(tripName)}.</p>
+                  <p style="margin:6px 0 0;color:${BRAND.textMuted};font-size:13px;"><a href="${settlementsUrl}" style="color:${BRAND.coral};text-decoration:none;">Open the app</a> to see the full breakdown.</p>
+                </div>
+              </div>`
+  }
 
   const bodyContent = `
               <h2 style="margin:0 0 8px;color:${BRAND.textPrimary};font-size:20px;font-weight:600;">Hi ${escapeHtml(recipientName)}!</h2>
@@ -427,6 +442,7 @@ Deno.serve(async (req) => {
         tripUrl,
         settlementsUrl,
         receipts: body.receipts,
+        expenseCount: body.expense_count,
       })
       toEmail = body.recipient_email
       toName = body.recipient_name


### PR DESCRIPTION
## Summary
- Payment reminder emails now count how many expenses the creditor paid for
- If 3 or fewer: include receipt detail tables as before
- If more than 3: skip receipt tables and show a "Based on N expenses" summary with a link to the app
- Prevents misleading partial receipt data in trips with many expenses (e.g. 91 expenses showing only 3 random receipts)

## Test plan
- [ ] `npm run type-check` — clean
- [ ] `npm test` — 173 tests pass, no regressions
- [ ] `supabase functions deploy send-email`
- [ ] Manual: trip with <= 3 creditor expenses → email shows receipt tables (unchanged)
- [ ] Manual: trip with > 3 creditor expenses → email shows "Based on N expenses" summary, no receipt tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)