### PR TITLE
fix: allow any authenticated user to edit receipt mapping

### DIFF
--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -384,7 +384,7 @@ export function ExpensesPage() {
           open={!!viewingReceiptTask}
           onOpenChange={open => { if (!open) setViewingReceiptTask(null) }}
           task={viewingReceiptTask}
-          canReprocess={!!user && viewingReceiptTask.created_by === user.id}
+          canReprocess={!!user}
           onReprocess={() => handleReprocessReceipt(viewingReceiptTask)}
         />
       )}


### PR DESCRIPTION
## Summary
- Removes `created_by === user.id` restriction on "Edit mapping" button
- Any authenticated user can now re-edit receipt mappings, matching the app's access model

## Test plan
- [ ] Authenticated user who didn't scan the receipt sees "Edit mapping" button
- [ ] Clicking "Edit mapping" opens the review sheet correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)