### PR TITLE
fix: restore payer and item assignments when editing receipt mapping

### DIFF
--- a/src/components/receipts/PendingReceiptBanner.tsx
+++ b/src/components/receipts/PendingReceiptBanner.tsx
@@ -1,6 +1,6 @@
 import { ScanLine } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { ReceiptTask, ExtractedItem } from '@/types/receipt'
+import { ReceiptTask, ExtractedItem, MappedItem } from '@/types/receipt'
 
 export interface ReceiptReviewData {
   taskId: string
@@ -11,6 +11,7 @@ export interface ReceiptReviewData {
   imagePath: string | null
   category: string | null
   existingExpenseId?: string
+  mappedItems?: MappedItem[] | null
 }
 
 interface PendingReceiptBannerProps {

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -24,7 +24,7 @@ import { useTripContext } from '@/contexts/TripContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { useToast } from '@/hooks/use-toast'
-import { ExtractedItem } from '@/types/receipt'
+import { ExtractedItem, MappedItem } from '@/types/receipt'
 import { IndividualsDistribution, ExpenseCategory } from '@/types/expense'
 import { Participant } from '@/types/participant'
 
@@ -39,6 +39,7 @@ interface ReceiptReviewSheetProps {
   imagePath?: string | null
   extractedCategory?: string | null
   existingExpenseId?: string
+  mappedItems?: MappedItem[] | null
   onDone: () => void
 }
 
@@ -141,6 +142,7 @@ export function ReceiptReviewSheet({
   imagePath,
   extractedCategory,
   existingExpenseId,
+  mappedItems,
   onDone,
 }: ReceiptReviewSheetProps) {
   const isMobile = useMediaQuery('(max-width: 767px)')
@@ -149,7 +151,7 @@ export function ReceiptReviewSheet({
   useScrollIntoView(contentRef, { enabled: keyboard.isVisible, offset: 20 })
   const { currentTrip } = useCurrentTrip()
   const { participants, getAdultParticipants } = useParticipantContext()
-  const { createExpense, updateExpense } = useExpenseContext()
+  const { createExpense, updateExpense, getExpenseById } = useExpenseContext()
   const { completeReceiptTask, error: receiptError, clearError: clearReceiptError } = useReceiptContext()
   const { updateTrip } = useTripContext()
   const { user } = useAuth()
@@ -206,19 +208,34 @@ export function ReceiptReviewSheet({
 
     const defaultPayerId = adultParticipants.find(p => p.user_id === user?.id)?.id ?? adultParticipants[0]?.id ?? ''
 
+    // When editing an existing expense, restore payer and category from it
+    const existingExpense = existingExpenseId ? getExpenseById(existingExpenseId) : undefined
+
+    // Build a map of item_index → participant_ids from saved mapped_items
+    const mappedItemsByIndex = new Map<number, Set<string>>()
+    if (mappedItems) {
+      for (const mi of mappedItems) {
+        mappedItemsByIndex.set(mi.item_index, new Set(mi.participant_ids))
+      }
+    }
+
     setEditableItems(
-      initialItems.map(item => ({
+      initialItems.map((item, index) => ({
         name: item.name,
         price: item.price.toFixed(2),
         qty: item.qty,
-        assignedIds: new Set<string>(),
+        assignedIds: mappedItemsByIndex.get(index) ?? new Set<string>(),
       }))
     )
     setConfirmedTotal(extractedTotal != null ? extractedTotal.toFixed(2) : '')
     setTipAmount('0')
-    setPaidBy(defaultPayerId)
+    setPaidBy(existingExpense?.paid_by ?? defaultPayerId)
     setMerchantName(merchant ?? '')
-    setCategory(validCategories.includes(extractedCategory as ExpenseCategory) ? extractedCategory as ExpenseCategory : 'Food')
+    setCategory(
+      existingExpense?.category && validCategories.includes(existingExpense.category)
+        ? existingExpense.category
+        : validCategories.includes(extractedCategory as ExpenseCategory) ? extractedCategory as ExpenseCategory : 'Food'
+    )
     setActiveCurrency(currency)
     setExchangeRate('')
     setShowAllItems(true)
@@ -370,7 +387,15 @@ export function ReceiptReviewSheet({
         expenseId = expense.id
       }
 
-      await completeReceiptTask(taskId, expenseId)
+      // Save item-to-participant mappings so they can be restored on "Edit mapping"
+      const mappedItemsToSave: MappedItem[] = editableItems
+        .map((item, index) => ({
+          item_index: index,
+          participant_ids: Array.from(item.assignedIds),
+        }))
+        .filter(mi => mi.participant_ids.length > 0)
+
+      await completeReceiptTask(taskId, expenseId, mappedItemsToSave)
 
       toast({
         title: existingExpenseId ? 'Receipt updated' : 'Receipt added',

--- a/src/contexts/ReceiptContext.tsx
+++ b/src/contexts/ReceiptContext.tsx
@@ -15,7 +15,7 @@ interface ReceiptContextType {
   clearError: () => void
   createReceiptTask: (tripId: string, imagePath?: string) => Promise<ReceiptTask>
   updateReceiptTask: (id: string, updates: ReceiptTaskUpdate) => Promise<boolean>
-  completeReceiptTask: (id: string, expenseId: string) => Promise<boolean>
+  completeReceiptTask: (id: string, expenseId: string, mappedItems?: MappedItem[]) => Promise<boolean>
   reopenReceiptTask: (id: string) => Promise<boolean>
   dismissReceiptTask: (id: string) => Promise<boolean>
   refreshPendingReceipts: () => Promise<void>
@@ -180,7 +180,7 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const completeReceiptTask = async (id: string, expenseId: string): Promise<boolean> => {
+  const completeReceiptTask = async (id: string, expenseId: string, mappedItems?: MappedItem[]): Promise<boolean> => {
     try {
       const completeController = new AbortController()
       const { error: updateError } = await withTimeout(
@@ -189,8 +189,9 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
           .update({
             status: 'complete',
             expense_id: expenseId,
+            ...(mappedItems ? { mapped_items: mappedItems } : {}),
             updated_at: new Date().toISOString(),
-          })
+          } as Record<string, unknown>)
           .eq('id', id)
           .abortSignal(completeController.signal),
         15000,

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -113,6 +113,7 @@ export function ExpensesPage() {
       imagePath: task.receipt_image_path ?? null,
       category: task.extracted_category ?? null,
       existingExpenseId: task.expense_id ?? undefined,
+      mappedItems: task.mapped_items,
     })
   }
 
@@ -374,6 +375,7 @@ export function ExpensesPage() {
           imagePath={receiptReviewData.imagePath}
           extractedCategory={receiptReviewData.category}
           existingExpenseId={receiptReviewData.existingExpenseId}
+          mappedItems={receiptReviewData.mappedItems}
           onDone={() => setReceiptReviewData(null)}
         />
       )}


### PR DESCRIPTION
## Summary
- When clicking "Edit mapping" on a completed receipt, the payer now restores from the existing expense instead of resetting to the current auth user
- Item assignments (participant chips) restore from saved `mapped_items` instead of starting empty
- `mapped_items` are now persisted to the DB on receipt completion so they survive reopen/edit cycles

## Test plan
- [ ] Complete a receipt with item assignments → click receipt → "Edit mapping" → verify payer and assignments are pre-populated
- [ ] Test new receipt flow still works (no existing expense = current defaults)
- [ ] Test old receipts (completed before this fix, `mapped_items` is null) — assignments start empty (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)