### PR TITLE
feat: show gross settlement amounts on BalanceCard

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -22,9 +22,8 @@ export function BalanceCard({ balance, currency = 'EUR', onClick, groupMembers }
   }).format(value)
   const formattedPaid = fmt(balance.totalPaid)
   const formattedShare = fmt(balance.totalShare)
-  const formattedSettled = balance.totalSettled !== 0
-    ? `${fmt(Math.abs(balance.totalSettled))} ${balance.totalSettled > 0 ? 'sent' : 'received'}`
-    : '—'
+  const hasSent = balance.totalSettledSent > 0
+  const hasReceived = balance.totalSettledReceived > 0
 
   const getBalanceStatus = () => {
     if (balance.balance > 0.01) {
@@ -111,7 +110,14 @@ export function BalanceCard({ balance, currency = 'EUR', onClick, groupMembers }
           </div>
           <div className="flex justify-between text-muted-foreground">
             <span>Settled:</span>
-            <span className="font-medium text-foreground tabular-nums">{formattedSettled}</span>
+            <span className="font-medium text-foreground tabular-nums text-right">
+              {!hasSent && !hasReceived ? '—' : (
+                <>
+                  {hasReceived && <span className="block">{fmt(balance.totalSettledReceived)} received</span>}
+                  {hasSent && <span className="block">{fmt(balance.totalSettledSent)} sent</span>}
+                </>
+              )}
+            </span>
           </div>
         </div>
 

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -298,8 +298,51 @@ describe('calculateBalances', () => {
 
     expect(aliceBalance.balance).toBeCloseTo(0, 2)
     expect(aliceBalance.totalSettled).toBe(-50) // received 50
+    expect(aliceBalance.totalSettledSent).toBe(0)
+    expect(aliceBalance.totalSettledReceived).toBe(50)
     expect(bobBalance.balance).toBeCloseTo(0, 2)
     expect(bobBalance.totalSettled).toBe(50) // sent 50
+    expect(bobBalance.totalSettledSent).toBe(50)
+    expect(bobBalance.totalSettledReceived).toBe(0)
+  })
+
+  it('tracks gross settlement amounts when bidirectional', () => {
+    const expense = buildExpense({
+      amount: 100,
+      paid_by: 'p1',
+      distribution: { type: 'individuals', participants: ['p1', 'p2'] },
+    })
+    const settlements = [
+      buildSettlement({
+        id: 's1',
+        from_participant_id: 'p2',
+        to_participant_id: 'p1',
+        amount: 80,
+        currency: 'EUR',
+      }),
+      buildSettlement({
+        id: 's2',
+        from_participant_id: 'p1',
+        to_participant_id: 'p2',
+        amount: 20,
+        currency: 'EUR',
+      }),
+    ]
+    const result = calculateBalances(
+      [expense], participants, 'individuals', settlements
+    )
+    const aliceBalance = result.balances.find(b => b.id === 'p1')!
+    const bobBalance = result.balances.find(b => b.id === 'p2')!
+
+    // Alice: net settled = -80 (received) + 20 (sent) = -60
+    expect(aliceBalance.totalSettled).toBe(-60)
+    expect(aliceBalance.totalSettledSent).toBe(20)
+    expect(aliceBalance.totalSettledReceived).toBe(80)
+
+    // Bob: net settled = 80 (sent) - 20 (received) = 60
+    expect(bobBalance.totalSettled).toBe(60)
+    expect(bobBalance.totalSettledSent).toBe(80)
+    expect(bobBalance.totalSettledReceived).toBe(20)
   })
 
   it('sorts by balance descending', () => {
@@ -396,7 +439,7 @@ describe('calculateBalances', () => {
 // ─── getBalanceForEntity ──────────────────────────────────────────
 describe('getBalanceForEntity', () => {
   const balances = [
-    { id: 'p1', name: 'Alice', totalPaid: 100, totalShare: 50, totalSettled: 0, balance: 50, isFamily: false },
+    { id: 'p1', name: 'Alice', totalPaid: 100, totalShare: 50, totalSettled: 0, totalSettledSent: 0, totalSettledReceived: 0, balance: 50, isFamily: false },
   ]
 
   it('returns balance when entity is found', () => {

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -9,6 +9,8 @@ export interface ParticipantBalance {
   totalPaid: number
   totalShare: number
   totalSettled: number
+  totalSettledSent: number
+  totalSettledReceived: number
   balance: number
   isFamily: boolean
 }
@@ -197,6 +199,8 @@ export function calculateBalances(
       totalPaid: 0,
       totalShare: 0,
       totalSettled: 0,
+      totalSettledSent: 0,
+      totalSettledReceived: 0,
       balance: 0,
       isFamily: entity.isFamily,
     })
@@ -241,12 +245,16 @@ export function calculateBalances(
     const convertedAmount = convertToBaseCurrency(settlement.amount, settlement.currency, defaultCurrency, exchangeRates)
 
     if (fromEntityId && balances.has(fromEntityId)) {
-      balances.get(fromEntityId)!.balance += convertedAmount
-      balances.get(fromEntityId)!.totalSettled += convertedAmount
+      const fromBalance = balances.get(fromEntityId)!
+      fromBalance.balance += convertedAmount
+      fromBalance.totalSettled += convertedAmount
+      fromBalance.totalSettledSent += convertedAmount
     }
     if (toEntityId && balances.has(toEntityId)) {
-      balances.get(toEntityId)!.balance -= convertedAmount
-      balances.get(toEntityId)!.totalSettled -= convertedAmount
+      const toBalance = balances.get(toEntityId)!
+      toBalance.balance -= convertedAmount
+      toBalance.totalSettled -= convertedAmount
+      toBalance.totalSettledReceived += convertedAmount
     }
   }
 
@@ -404,6 +412,8 @@ export function calculateWithinGroupBalances(
       totalPaid: a.totalPaid,
       totalShare: a.totalShare,
       totalSettled: 0,
+      totalSettledSent: 0,
+      totalSettledReceived: 0,
       balance: a.balance,
       isFamily: false,
     })).sort((a, b) => b.balance - a.balance)
@@ -416,6 +426,8 @@ export function calculateWithinGroupBalances(
     totalPaid: m.totalPaid,
     totalShare: m.totalShare,
     totalSettled: 0,
+    totalSettledSent: 0,
+    totalSettledReceived: 0,
     balance: m.balance,
     isFamily: false,
   }))

--- a/src/services/settlementOptimizer.test.ts
+++ b/src/services/settlementOptimizer.test.ts
@@ -10,7 +10,7 @@ import {
 import type { ParticipantBalance } from './balanceCalculator'
 
 function balance(id: string, name: string, bal: number): ParticipantBalance {
-  return { id, name, totalPaid: 0, totalShare: 0, totalSettled: 0, balance: bal, isFamily: false }
+  return { id, name, totalPaid: 0, totalShare: 0, totalSettled: 0, totalSettledSent: 0, totalSettledReceived: 0, balance: bal, isFamily: false }
 }
 
 // ─── calculateOptimalSettlement ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Display sent and received settlement amounts separately on BalanceCard instead of a single net value
- Adds `totalSettledSent` and `totalSettledReceived` fields to `ParticipantBalance` interface
- When both directions exist (e.g. received €481.50, sent €150.78), shows two lines instead of net €330.72

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — all balance calculator and settlement optimizer tests pass (174 total, 1 pre-existing flaky unrelated)
- [ ] Visual check on production Thai trip dashboard — Tiirikud should show both amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)