### PR TITLE
fix: exclude intra-family settlements from BalanceCard gross amounts

### DIFF
--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -345,6 +345,33 @@ describe('calculateBalances', () => {
     expect(bobBalance.totalSettledReceived).toBe(20)
   })
 
+  it('excludes intra-family settlements from gross amounts', () => {
+    const famP1 = buildParticipant({ id: 'fp1', name: 'FamAlice', wallet_group: 'Smith', is_adult: true })
+    const famP2 = buildParticipant({ id: 'fp2', name: 'FamBob', wallet_group: 'Smith', is_adult: true })
+    const solo = buildParticipant({ id: 'sp1', name: 'Carol' })
+    const expense = buildExpense({
+      amount: 90,
+      paid_by: 'fp1',
+      distribution: { type: 'individuals', participants: ['fp1', 'fp2', 'sp1'] },
+    })
+    // Intra-family settlement: both map to same entity
+    const intraSettlement = buildSettlement({
+      id: 's-intra',
+      from_participant_id: 'fp2',
+      to_participant_id: 'fp1',
+      amount: 25,
+      currency: 'EUR',
+    })
+    const result = calculateBalances(
+      [expense], [famP1, famP2, solo], 'individuals', [intraSettlement]
+    )
+    // Entity ID for the Smith group is 'fp1' (FamAlice, first adult alphabetically)
+    const smithBalance = result.balances.find(b => b.id === 'fp1')!
+    expect(smithBalance.totalSettled).toBe(0)
+    expect(smithBalance.totalSettledSent).toBe(0)
+    expect(smithBalance.totalSettledReceived).toBe(0)
+  })
+
   it('sorts by balance descending', () => {
     const expense = buildExpense({
       amount: 100,

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -242,6 +242,7 @@ export function calculateBalances(
   for (const settlement of settlements) {
     const fromEntityId = participantToEntityId.get(settlement.from_participant_id)
     const toEntityId = participantToEntityId.get(settlement.to_participant_id)
+    if (fromEntityId === toEntityId) continue
     const convertedAmount = convertToBaseCurrency(settlement.amount, settlement.currency, defaultCurrency, exchangeRates)
 
     if (fromEntityId && balances.has(fromEntityId)) {


### PR DESCRIPTION
## Summary
- Intra-family settlements (where both participants map to the same wallet group entity) were inflating `totalSettledSent` / `totalSettledReceived` on the group-level BalanceCard, showing misleading large amounts
- Added `if (fromEntityId === toEntityId) continue` guard in the settlement loop — skips intra-family settlements entirely (they net to zero anyway)
- Added test case verifying all three settlement counters are `0` for intra-family settlements

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — all 47 balance calculator tests pass (including new test)
- [ ] Visual check: wallet group entities (e.g. Kivinugise Eliased) should show only external settlement amounts on BalanceCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)