### PR TITLE
fix: remove overlapping group avatars on Dashboard BalanceCard

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -88,10 +88,10 @@ export function BalanceCard({ balance, currency = 'EUR', onClick, groupMembers }
             </div>
           </div>
           {groupMembers && groupMembers.length > 1 && (
-            <div className="flex items-center mt-2">
+            <div className="flex items-center gap-1 mt-2">
               {groupMembers.slice(0, 4).map((member, i) => (
-                <div key={i} className={i > 0 ? '-ml-2' : ''} style={{ zIndex: groupMembers.length - i }}>
-                  <ParticipantAvatar participant={member} size="sm" className="ring-2 ring-background" />
+                <div key={i}>
+                  <ParticipantAvatar participant={member} size="sm" />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Group member avatars on Dashboard BalanceCard used negative margin overlap (`-ml-2`) with `ring-2 ring-background`, causing white ring circles to visibly shine through each other (especially with photo avatars)
- Replaced with `gap-1` side-by-side layout — no overlap, no ring, no shine-through

## Test plan
- [ ] Visual check on Dashboard: group avatar rows display cleanly without ring artifacts
- [ ] Individual (non-group) cards unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)