### PR TITLE
fix: make Dashboard BalanceCard tiles equal height in grid

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -59,9 +59,9 @@ export function BalanceCard({ balance, currency = 'EUR', onClick, groupMembers }
   } : {}
 
   return (
-    <CardWrapper {...cardProps}>
+    <CardWrapper {...cardProps} className="h-full">
       <Card
-        className={`p-4 border ${status.borderClass} ${status.bgClass} ${
+        className={`h-full p-4 border ${status.borderClass} ${status.bgClass} ${
           onClick ? 'cursor-pointer hover:shadow-md' : ''
         } transition-all`}
         onClick={onClick}


### PR DESCRIPTION
## Summary
- Add `h-full` to BalanceCard wrapper and Card so tiles stretch to fill the full CSS Grid cell height
- Ensures tiles in the same row align evenly regardless of content differences (settlements, group avatars, etc.)

## Test plan
- [ ] Open Dashboard with multiple participants/groups having different settlement amounts
- [ ] Verify tiles in the same grid row are equal height on desktop (2-col layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)