### PR TITLE
fix: prevent scan-to-create sheet from closing prematurely

### DIFF
--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -24,7 +24,7 @@ export function usePullToRefresh() {
   const pullingRef = useRef(false)
 
   const isSheetOpen = useCallback(() => {
-    return !!document.querySelector('[data-radix-dialog-overlay]')
+    return !!document.querySelector('[role="dialog"][data-state="open"]')
   }, [])
 
   useEffect(() => {

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -35,7 +35,7 @@ export function ConditionalHomePage() {
     // Don't redirect while a sheet/dialog is open (e.g. QuickScanCreateFlow).
     // Creating a trip with today's date would otherwise trigger an immediate
     // redirect that unmounts the sheet mid-flow.
-    if (document.querySelector('[data-radix-dialog-overlay]')) return
+    if (document.querySelector('[role="dialog"][data-state="open"]')) return
 
     // Only auto-redirect for authenticated users. For unauthenticated users,
     // TripContext fetches ALL trips and localStorage includes shared-link trips,


### PR DESCRIPTION
## Summary
- Replace broken `[data-radix-dialog-overlay]` selector with `[role="dialog"][data-state="open"]` in `ConditionalHomePage` and `usePullToRefresh` — Radix Dialog v1.1.15 doesn't render `data-radix-dialog-overlay`, so the open-sheet guard was always returning null
- Fixes scan-to-create flow on home page where `ConditionalHomePage` redirects to quick view mid-scan, unmounting the sheet
- Also fixes `usePullToRefresh` sheet-open detection (same broken selector)

## Test plan
- [ ] Open home page on mobile → tap scan CTA → take photo → "Scan & Create Group" → loading screen stays visible during processing → participant picker appears after receipt is processed
- [ ] Pull-to-refresh skips when a sheet/dialog is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)