### PR TITLE
fix: prevent receipt edit flow from detaching receipt on close

### DIFF
--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -45,7 +45,7 @@ export function ExpensesPage() {
   const { expenses, loading, error, createExpense, updateExpense, deleteExpense, refreshExpenses } = useExpenseContext()
   const { participants } = useParticipantContext()
   const { settlements } = useSettlementContext()
-  const { pendingReceipts, receiptByExpenseId, dismissReceiptTask, reopenReceiptTask } = useReceiptContext()
+  const { pendingReceipts, receiptByExpenseId, dismissReceiptTask } = useReceiptContext()
   const { user } = useAuth()
   const { toast } = useToast()
 
@@ -97,12 +97,7 @@ export function ExpensesPage() {
     exportExpensesToExcel(currentTrip, expenses, participants, balances, settlements)
   }
 
-  const handleReprocessReceipt = async (task: ReceiptTask) => {
-    const success = await reopenReceiptTask(task.id)
-    if (!success) {
-      toast({ title: 'Failed to reopen receipt', variant: 'destructive' })
-      return
-    }
+  const handleReprocessReceipt = (task: ReceiptTask) => {
     setViewingReceiptTask(null)
     setReceiptReviewData({
       taskId: task.id,


### PR DESCRIPTION
## Summary
- Remove the eager `reopenReceiptTask()` call from `handleReprocessReceipt` in `ExpensesPage.tsx` which set `expense_id: null` in the DB before the review sheet opened
- If the user closed the edit sheet without saving, the receipt was permanently orphaned — appearing as unreviewed and creating a duplicate expense on re-submit
- Now the receipt stays attached while editing; closing without saving is a no-op

Closes #530

## Test plan
- [ ] Scan receipt → map items → submit → click edit mapping → close (X) → receipt should still be attached, no "unreviewed receipt" banner
- [ ] Scan receipt → map items → submit → click edit mapping → change mapping → "Update Expense" → expense updates correctly
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — 175 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)