### PR TITLE
fix: add PWA safe-area padding to bottom sheet footers

### DIFF
--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -512,7 +512,7 @@ function MobileWizard({
         </div>
 
         {/* Sticky footer */}
-        <div className="px-6 py-4 border-t border-border shrink-0">
+        <div className="px-6 py-4 border-t border-border shrink-0 pwa-safe-bottom">
           <WizardNavigation
             currentStep={currentStep}
             totalSteps={totalSteps}

--- a/src/components/quick/QuickParticipantSetupSheet.tsx
+++ b/src/components/quick/QuickParticipantSetupSheet.tsx
@@ -51,7 +51,7 @@ export function QuickParticipantSetupSheet({ open, onOpenChange }: QuickParticip
         </div>
 
         {/* Sticky footer */}
-        <div className="shrink-0 px-4 py-3 border-t border-border bg-background">
+        <div className="shrink-0 px-4 py-3 border-t border-border bg-background pwa-safe-bottom">
           <Button className="w-full" onClick={() => onOpenChange(false)}>
             Done
           </Button>

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -397,7 +397,7 @@ export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowP
 
         {/* Sticky footer — participants step */}
         {step === 'participants' && (
-          <div className="shrink-0 px-4 py-3 border-t border-border bg-background">
+          <div className="shrink-0 px-4 py-3 border-t border-border bg-background pwa-safe-bottom">
             <Button className="w-full gap-1" onClick={handleDone}>
               Done
               <ChevronRight size={14} />

--- a/src/components/receipts/ReceiptDetailsSheet.tsx
+++ b/src/components/receipts/ReceiptDetailsSheet.tsx
@@ -121,7 +121,7 @@ export function ReceiptDetailsSheet({ open, onOpenChange, task, canReprocess, on
   )
 
   const footer = canReprocess && onReprocess ? (
-    <div className="shrink-0 px-4 py-3 border-t border-border bg-background">
+    <div className="shrink-0 px-4 py-3 border-t border-border bg-background pwa-safe-bottom">
       <Button
         onClick={onReprocess}
         variant="outline"

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -624,7 +624,7 @@ export function ReceiptReviewSheet({
   )
 
   const footer = (
-    <div className="shrink-0 px-4 py-3 border-t border-border bg-background">
+    <div className="shrink-0 px-4 py-3 border-t border-border bg-background pwa-safe-bottom">
       <Button
         onClick={handleSubmit}
         disabled={!canSubmit || submitting}


### PR DESCRIPTION
## Summary
- In PWA standalone mode on iPhone, the home indicator overlaps action buttons at the bottom of sheets (reported in #531 with screenshots)
- PR #460 added `pwa-safe-bottom` to Layout's bottom nav but missed bottom sheet sticky footers
- Add `pwa-safe-bottom` class to all 5 sheets with sticky footers: ReceiptReviewSheet, ReceiptDetailsSheet, ExpenseWizard (MobileWizard), QuickParticipantSetupSheet, QuickScanCreateFlow

Closes #531

## Test plan
- [ ] Open the app as PWA on iPhone — verify "Update Expense" button in ReceiptReviewSheet is fully visible above home indicator
- [ ] Verify "Edit mapping" button in ReceiptDetailsSheet is fully visible
- [ ] Verify expense wizard Next/Submit buttons are fully visible
- [ ] Verify regular browser (non-PWA) is unaffected
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — 175 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)