### PR TITLE
fix: await receipt image path update to prevent race condition

### DIFF
--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -188,9 +188,9 @@ export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowP
         }),
       ])
 
-      // Write image path to task row (non-blocking)
+      // Write image path to task row — must complete before refreshPendingReceipts
       if (uploadResult.status === 'fulfilled' && !uploadResult.value.error) {
-        supabase.from('receipt_tasks').update({ receipt_image_path: uploadPath }).eq('id', task.id)
+        await supabase.from('receipt_tasks').update({ receipt_image_path: uploadPath }).eq('id', task.id)
       } else {
         const errMsg =
           uploadResult.status === 'rejected'


### PR DESCRIPTION
## Summary
- In `QuickScanCreateFlow`, the DB update setting `receipt_image_path` was fire-and-forget (not awaited)
- `refreshPendingReceipts()` ran immediately after and fetched the row before the update completed, so `receipt_image_path` stayed `null`
- The "Receipt photo" section in `ReceiptDetailsSheet` never rendered because the path was missing
- Fix: add `await` to the update (matching `ReceiptCaptureSheet` which already had it)

Closes #538

## Test plan
- [ ] Scan receipt via scan-to-create flow → after processing, open expense → click receipt icon → "Receipt photo" section should be visible
- [ ] `npm run type-check` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)