### PR TITLE
docs: update CLAUDE.md and PLAN.md with PRs #491–#541

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Family Trip Cost Splitter — A mobile-first web application for splitting costs
 - Auth: Supabase Auth (Google OAuth supported)
 - Observability: Grafana Cloud (Loki logs + OTLP metrics) via `log-proxy` Edge Function
 - Deployment: Cloudflare Pages
-- Tests: Vitest + Testing Library (173 tests)
+- Tests: Vitest + Testing Library (175 tests)
 
 ---
 
@@ -59,7 +59,7 @@ git branch -d fix/description
 
 ### Core tables (migrations 001–006, updated by family refactor migrations 029–032)
 - `trips` — trip metadata, tracking_mode (`individuals` | `families`), trip_code (URL slug), created_by
-- `participants` — individuals with optional `wallet_group TEXT` for shared-wallet grouping; `user_id` links to auth user ("This is me")
+- `participants` — individuals with optional `wallet_group TEXT` for shared-wallet grouping; `user_id` links to auth user ("This is me"); `nickname TEXT` preserves short name when "This is me" overwrites with full Google name
 - `expenses` — expense records with JSONB `distribution` field
 - `settlements` — payment transfers between participants/families
 - `meals` — meal planning (breakfast/lunch/dinner per day)
@@ -74,8 +74,9 @@ git branch -d fix/description
 - `enable_activities BOOLEAN` — feature toggle (migration 018)
 - `default_split_all BOOLEAN DEFAULT true` — auto-select all participants when adding expense
 
-### RLS policies (migration 026, updated 033)
+### RLS policies (migration 026, updated 033, 036)
 - `trips`: SELECT open, INSERT auth-only, UPDATE/DELETE creator-only. Migration 033 added admin UUID delete policy.
+- `receipt_tasks`: SELECT open to all users (migration 036, matches trips table access model)
 - Other tables: standard auth-based policies
 
 ### Newer tables
@@ -188,6 +189,9 @@ Participants can be grouped via `wallet_group TEXT` on the `participants` table.
 /t/:tripCode/manage        → ManageTripPage (Layout)
 /create-trip               → TripsPage (Layout)
 /admin/all-trips           → AdminAllTripsPage (Layout)
+/join/:token               → JoinPage (invitation acceptance)
+/remind/:tripCode          → RemindPage (payment reminder landing)
+/trip-not-found/:tripCode  → TripNotFoundPage
 ```
 
 All trip-scoped routes are wrapped in `TripRouteGuard`. Full-mode routes render inside `Layout`; quick routes inside `QuickLayout`. The home page (`/`) renders inside `Layout`.
@@ -329,7 +333,7 @@ Stays are managed separately in `StayContext`. Activities in `ActivityContext`.
 
 ### User–Participant Link
 
-`participants.user_id` links a Supabase auth user to their participant record ("This is me"). One user per trip (enforced by unique index). Use `useMyParticipant()` hook to get the current user's participant. Use `useMyTripBalances()` to get the user's balance across all their trips (used on the unified home page). `linkUserToParticipant` also backfills the participant's `email` from the auth session if the participant has no email set (existing emails are never overwritten).
+`participants.user_id` links a Supabase auth user to their participant record ("This is me"). One user per trip (enforced by unique index). Use `useMyParticipant()` hook to get the current user's participant. Use `useMyTripBalances()` to get the user's balance across all their trips (used on the unified home page). `linkUserToParticipant` syncs `name` and `email` from the Google profile, saves the original short name as `nickname`, and backfills `email` if not set (existing emails are never overwritten).
 
 ### Contact Autocomplete (`useTripContacts`)
 
@@ -484,7 +488,7 @@ iOS Safari ignores `manifest.start_url` and saves whatever URL was in the addres
 ## Testing
 
 ### Unit Tests
-Vitest + Testing Library. Run with `npm test`. 173 tests covering contexts, hooks, and key pages. Test files co-located with source (`*.test.tsx`). Use factories in `src/test/factories.ts` to build test data.
+Vitest + Testing Library. Run with `npm test`. 175 tests covering contexts, hooks, and key pages. Test files co-located with source (`*.test.tsx`). Use factories in `src/test/factories.ts` to build test data.
 
 ### E2E Smoke Tests (Playwright)
 26 automated tests: 13 routes × 2 viewports (mobile 375×812, desktop 1280×720). Supabase fully mocked via `page.route()`. Run with `npm run test:e2e` or `npm run test:e2e:ui`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 # PLAN.md — Spl1t Feature Planning Document
 
 > **Living document.** Update at the start and end of every session.
-> Last updated: 2026-03-01 (Phases 1–7 ✅; family refactor Phases 1–4 ✅ COMPLETE; PWA ✅; pull-to-refresh ✅; invite UX simplified ✅; email header branding ✅; issue report email ✅; scan flow sheet fix ✅; contact is_adult ✅; iOS scroll lock fix ✅)
+> Last updated: 2026-03-01 (Phases 1–7 ✅; family refactor Phases 1–4 ✅ COMPLETE; PWA ✅; pull-to-refresh ✅; invite UX simplified ✅; email header branding ✅; issue report email ✅; scan flow sheet fix ✅; contact is_adult ✅; iOS scroll lock fix ✅; nicknames + avatars ✅; receipt viewer ✅; scan-create fix ✅; dialog selector fix ✅)
 
 ---
 
@@ -781,6 +781,22 @@ Replace ad-hoc loading/error patterns with the shared components from 7a.
 | 2026-03-01 | Email header branding | PR #484: replaced coral background email header with white header + logo image (`logo.png` at 40×40) + dark wordmark, matching marketing page nav bar. |
 | 2026-03-01 | Docs + README | PRs #487, #488: Updated CLAUDE.md/PLAN.md with PR #484. Overhauled README.md and added v1.1.0 release notes. |
 | 2026-03-01 | Stale chunk detection | PR #489 (closes #483): ErrorBoundary detects stale chunk errors (`'text/html' is not a valid JavaScript MIME type'` and 3 other variants) from post-deploy cache mismatches. Auto-reloads once (sessionStorage guard); if still broken, shows friendly "New version available" card instead of generic error. |
+| 2026-03-01 | Email header iterations | PRs #491, #496, #500, #501: Iterated email header layout — side-by-side logo + wordmark, larger logo, cropped logo, left-aligned final design. Added issue report notification email type to `send-email` edge function. |
+| 2026-03-01 | Scan flow fix + child status | PR #498: Fixed scan flow sheet vanishing when creating trip with today's date (ConditionalHomePage redirect guard using `[data-radix-dialog-overlay]`). Also preserved `is_adult` child status from contacts when adding participants. |
+| 2026-03-01 | Google profile sync | PRs #502, #503: `linkUserToParticipant` ("This is me") now syncs participant name + email from Google profile. Migration 034: one-time backfill of all linked participants' names/emails from `auth.users` metadata. |
+| 2026-03-01 | Payment reminder landing | PR #504: New `/remind/:tripCode` route — branded standalone landing page for payment reminders (replaces direct settlements link in emails). Matches JoinPage pattern with trip gradient header + CTAs. |
+| 2026-03-01 | Nicknames + avatars | PRs #505, #506, #507: Migration 035 adds `nickname TEXT` to participants — preserves short name when "This is me" overwrites with full Google name. `ParticipantAvatar` component shows Google avatars. `getShortName()` utility for consistent short name display. Nickname carried over from previous trips via `useTripContacts`. "aka" label + pencil edit icon in participant lists. |
+| 2026-03-01 | Contact UI redesign | PRs #508–#515: Redesigned recent contacts as compact chip grid with full names, avatars, and email. Stacked group member avatars on Dashboard BalanceCard (moved to second row). Distinguished child pills with Baby icon + dashed border. Settlement step badges restyled with forced initials for wallet groups. Recent companions + manual add form toggled as mutually exclusive. |
+| 2026-03-01 | Receipt access + viewer | PRs #516, #518, #520, #522, #523: Migration 036 opens `receipt_tasks` SELECT to all users + storage policy for receipt images. Responsive receipt viewer with edit mapping support (Dialog on desktop, Sheet on mobile). Any authenticated trip member can edit receipt mapping (not creator-only). Payer + item assignments restored correctly when editing. |
+| 2026-03-01 | Payment reminder emails | PRs #517, #519: Multi-email choice dialog for wallet group payment reminders (picks from group members' emails). Smart receipt section — shows expense count summary instead of full receipt tables when >3 creditor expenses. |
+| 2026-03-01 | Recent companions UX | PR #521: Expandable recent companions list with "Show more" toggle. |
+| 2026-03-01 | BalanceCard improvements | PRs #524, #525, #526, #527, #529: Gross settlement amounts on BalanceCard (with intra-family exclusion). Removed overlapping group avatars. Short names in ReceiptReviewSheet payer dropdown/chips. Equal-height BalanceCard tiles in 2-column dashboard grid. |
+| 2026-03-01 | iOS scroll lock fix | PR #532 (closes #528): New `useIOSScrollFix` hook — nudges `scrollTop` 1px from boundaries on `touchstart` to prevent iOS Safari scroll-lock bug with `overscroll-behavior: contain`. Applied to all 13 sheet scroll containers. No-op on non-iOS. |
+| 2026-03-01 | Scan-create sheet fix | PR #534: Fixed `[data-radix-dialog-overlay]` selector — Radix Dialog v1.1.15 doesn't render that attribute. Replaced with `[role="dialog"][data-state="open"]` in ConditionalHomePage + usePullToRefresh. |
+| 2026-03-01 | Receipt edit fix | PR #535: Prevent receipt edit flow from detaching receipt on close. |
+| 2026-03-01 | PWA sheet safe-area | PR #539 (closes #531): Added `pwa-safe-bottom` class to all bottom sheet sticky footers for iPhone home indicator padding in standalone PWA mode. |
+| 2026-03-01 | Receipt race condition | PR #540 (closes #538): Await receipt image path update to prevent race condition between upload and task row update. |
+| 2026-03-01 | Scan participant removal | PR #541 (closes #537): X button to remove participant chips + toggle checkmarks on recent contacts in QuickScanCreateFlow. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add 17 session log entries to PLAN.md covering all work merged today (PRs #491–#541)
- Add missing routes to CLAUDE.md: `/join/:token`, `/remind/:tripCode`, `/trip-not-found/:tripCode`
- Document `nickname` column on participants table and `receipt_tasks` open SELECT RLS (migrations 034–036)
- Update User–Participant Link section with Google profile sync behavior
- Update test count to 175

## Test plan
- [ ] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)