### PR TITLE
feat: optimize settlement algorithm with mode toggle — closes #545

### DIFF
--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -12,6 +12,7 @@ export interface BankDetails {
 
 interface SettlementPlanProps {
   plan: OptimalSettlementPlan
+  greedyPlan?: OptimalSettlementPlan
   onRecordSettlement?: (transaction: SettlementTransaction) => void
   bankDetailsMap?: Record<string, BankDetails>
   linkedParticipantIds?: Set<string>
@@ -20,7 +21,11 @@ interface SettlementPlanProps {
   avatarMap?: Record<string, string | null>
 }
 
-export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap, linkedParticipantIds, fromEmailMap, onRemind, avatarMap }: SettlementPlanProps) {
+export function SettlementPlan({ plan, greedyPlan, onRecordSettlement, bankDetailsMap, linkedParticipantIds, fromEmailMap, onRemind, avatarMap }: SettlementPlanProps) {
+  const [mode, setMode] = useState<'optimal' | 'greedy'>('optimal')
+  const showToggle = greedyPlan && greedyPlan.totalTransactions !== plan.totalTransactions
+  const activePlan = mode === 'greedy' && greedyPlan ? greedyPlan : plan
+
   if (plan.transactions.length === 0) {
     return (
       <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
@@ -38,30 +43,58 @@ export function SettlementPlan({ plan, onRecordSettlement, bankDetailsMap, linke
   return (
     <div className="space-y-3">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-foreground">
+      <div className="flex items-center justify-between mb-4 gap-3">
+        <h3 className="text-lg font-semibold text-foreground shrink-0">
           Settlement Plan
         </h3>
-        <span className="text-sm text-muted-foreground">
-          {plan.totalTransactions} {plan.totalTransactions === 1 ? 'transaction' : 'transactions'}
-        </span>
+        <div className="flex items-center gap-3">
+          {showToggle && (
+            <div className="flex rounded-full border border-border bg-muted/50 p-0.5 text-xs">
+              <button
+                onClick={() => setMode('optimal')}
+                className={`px-2.5 py-1 rounded-full transition-colors ${
+                  mode === 'optimal'
+                    ? 'bg-accent text-white font-medium shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Fewer
+              </button>
+              <button
+                onClick={() => setMode('greedy')}
+                className={`px-2.5 py-1 rounded-full transition-colors ${
+                  mode === 'greedy'
+                    ? 'bg-accent text-white font-medium shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Standard
+              </button>
+            </div>
+          )}
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {activePlan.totalTransactions} {activePlan.totalTransactions === 1 ? 'transaction' : 'transactions'}
+          </span>
+        </div>
       </div>
 
       {/* Info Box */}
       <div className="bg-accent/10 border border-accent/30 rounded-lg p-3 mb-4 flex items-start gap-2">
         <Lightbulb size={16} className="text-accent mt-0.5 flex-shrink-0" />
         <p className="text-sm text-foreground">
-          This is the optimal settlement plan with the minimum number of transactions needed to settle all balances.
+          {mode === 'optimal'
+            ? 'This plan uses the minimum number of transactions to settle all balances.'
+            : 'Standard settlement plan — each person settles with the largest counterparty first.'}
         </p>
       </div>
 
       {/* Transactions */}
       <div className="space-y-2">
-        {plan.transactions.map((transaction, index) => (
+        {activePlan.transactions.map((transaction, index) => (
           <SettlementTransactionCard
-            key={index}
+            key={`${mode}-${index}`}
             transaction={transaction}
-            currency={plan.currency}
+            currency={activePlan.currency}
             index={index + 1}
             onRecord={onRecordSettlement ? () => onRecordSettlement(transaction) : undefined}
             bankDetails={bankDetailsMap?.[transaction.toId]}

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -46,6 +46,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
 
   const scrollRef = useIOSScrollFix()
   const [view, setView] = useState<'suggestions' | 'form'>('suggestions')
+  const [settlementMode, setSettlementMode] = useState<'optimal' | 'greedy'>('optimal')
   const [prefill, setPrefill] = useState<Prefill | null>(null)
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
   const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
@@ -77,8 +78,8 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
   const defaultCurrency = currentTrip.default_currency || 'EUR'
   const exchangeRates = currentTrip.exchange_rates || {}
 
-  // Compute optimal settlement plan
-  const { myTransactions, allSettled, currency } = useMemo(() => {
+  // Compute both optimal and greedy settlement plans
+  const { myTransactions, myGreedyTransactions, allSettled, currency, showModeToggle } = useMemo(() => {
     const balanceCalc = calculateBalances(
       expenses,
       participants,
@@ -87,10 +88,11 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
       defaultCurrency,
       exchangeRates,
     )
-    const plan = calculateOptimalSettlement(balanceCalc.balances, defaultCurrency)
+    const optimalPlan = calculateOptimalSettlement(balanceCalc.balances, defaultCurrency, 'optimal')
+    const greedyPlan = calculateOptimalSettlement(balanceCalc.balances, defaultCurrency, 'greedy')
 
     if (!myParticipant) {
-      return { myTransactions: [], allSettled: plan.transactions.length === 0, currency: plan.currency }
+      return { myTransactions: [], myGreedyTransactions: [], allSettled: optimalPlan.transactions.length === 0, currency: optimalPlan.currency, showModeToggle: false }
     }
 
     // Determine which entity ID represents "me" via entity map
@@ -98,16 +100,23 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
     const myEntityId = entityMap.participantToEntityId.get(myParticipant.id) ?? myParticipant.id
 
     // Filter transactions involving me
-    const mine = plan.transactions.filter(
+    const myOptimal = optimalPlan.transactions.filter(
+      t => t.fromId === myEntityId || t.toId === myEntityId,
+    )
+    const myGreedy = greedyPlan.transactions.filter(
       t => t.fromId === myEntityId || t.toId === myEntityId,
     )
 
     return {
-      myTransactions: mine,
-      allSettled: plan.transactions.length === 0,
-      currency: plan.currency,
+      myTransactions: myOptimal,
+      myGreedyTransactions: myGreedy,
+      allSettled: optimalPlan.transactions.length === 0,
+      currency: optimalPlan.currency,
+      showModeToggle: myOptimal.length !== myGreedy.length,
     }
   }, [expenses, participants, settlements, trackingMode, defaultCurrency, exchangeRates, myParticipant])
+
+  const activeTransactions = settlementMode === 'greedy' ? myGreedyTransactions : myTransactions
 
   const myEntityId = useMemo(() => {
     if (!myParticipant) return null
@@ -117,11 +126,11 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
 
   const recipientKey = useMemo(() => {
     if (!myEntityId) return ''
-    return myTransactions
-      .filter(t => t.fromId === myEntityId)
-      .map(t => t.toId)
-      .join(',')
-  }, [myTransactions, myEntityId])
+    // Include recipients from both modes so bank details are fetched for either
+    const optimalRecipients = myTransactions.filter(t => t.fromId === myEntityId).map(t => t.toId)
+    const greedyRecipients = myGreedyTransactions.filter(t => t.fromId === myEntityId).map(t => t.toId)
+    return [...new Set([...optimalRecipients, ...greedyRecipients])].join(',')
+  }, [myTransactions, myGreedyTransactions, myEntityId])
 
   useEffect(() => {
     if (!user || !recipientKey) return
@@ -302,6 +311,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
     if (!isOpen) {
       // Reset state when closing
       setView('suggestions')
+      setSettlementMode('optimal')
       setPrefill(null)
       setConfirmingRemindIdx(null)
       setRemindResults({})
@@ -362,7 +372,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                 Link yourself to a participant to see suggested payments.
               </p>
             </div>
-          ) : myTransactions.length === 0 ? (
+          ) : activeTransactions.length === 0 ? (
             <div className="bg-positive/10 border border-positive/30 rounded-lg p-6 text-center">
               <PartyPopper size={48} className="mx-auto text-positive mb-2" />
               <h3 className="text-lg font-semibold text-foreground mb-1">
@@ -374,10 +384,36 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
             </div>
           ) : (
             <>
-              <p className="text-sm text-muted-foreground">
-                Suggested payments to settle up:
-              </p>
-              {myTransactions.map((tx, i) => {
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm text-muted-foreground">
+                  Suggested payments to settle up:
+                </p>
+                {showModeToggle && (
+                  <div className="flex rounded-full border border-border bg-muted/50 p-0.5 text-xs shrink-0">
+                    <button
+                      onClick={() => setSettlementMode('optimal')}
+                      className={`px-2.5 py-1 rounded-full transition-colors ${
+                        settlementMode === 'optimal'
+                          ? 'bg-accent text-white font-medium shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      Fewer
+                    </button>
+                    <button
+                      onClick={() => setSettlementMode('greedy')}
+                      className={`px-2.5 py-1 rounded-full transition-colors ${
+                        settlementMode === 'greedy'
+                          ? 'bg-accent text-white font-medium shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      Standard
+                    </button>
+                  </div>
+                )}
+              </div>
+              {activeTransactions.map((tx, i) => {
                 const iOwe = tx.fromId === myEntityId
                 const fromEmails = !iOwe ? fromEmailMap[tx.fromId] : undefined
                 const canRemind = !iOwe && !!fromEmails && fromEmails.length > 0

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -102,10 +102,17 @@ export function SettlementsPage() {
     currentTrip.exchange_rates
   ), [expenses, participants, currentTrip.tracking_mode, settlements, currentTrip.default_currency, currentTrip.exchange_rates])
 
-  // Calculate optimal settlement
+  // Calculate optimal and greedy settlement plans
   const optimalSettlement = useMemo(() => calculateOptimalSettlement(
     balanceCalculation.balances,
-    currentTrip.default_currency
+    currentTrip.default_currency,
+    'optimal'
+  ), [balanceCalculation.balances, currentTrip.default_currency])
+
+  const greedySettlement = useMemo(() => calculateOptimalSettlement(
+    balanceCalculation.balances,
+    currentTrip.default_currency,
+    'greedy'
   ), [balanceCalculation.balances, currentTrip.default_currency])
 
   // Stable string key for recipient IDs to avoid infinite re-fetch
@@ -352,6 +359,7 @@ export function SettlementsPage() {
             <CardContent className="pt-6">
               <SettlementPlan
                 plan={optimalSettlement}
+                greedyPlan={greedySettlement.totalTransactions !== optimalSettlement.totalTransactions ? greedySettlement : undefined}
                 onRecordSettlement={handleRecordSettlement}
                 bankDetailsMap={bankDetailsMap}
                 linkedParticipantIds={linkedParticipantIds}

--- a/src/services/settlementOptimizer.test.ts
+++ b/src/services/settlementOptimizer.test.ts
@@ -91,6 +91,108 @@ describe('calculateOptimalSettlement', () => {
   })
 })
 
+// ─── Optimal mode (bitmask DP) ──────────────────────────────────────
+describe('calculateOptimalSettlement — optimal mode', () => {
+  it('finds two independent zero-sum subsets → fewer transactions', () => {
+    // {A,B,C} sums to 0, {D,E} sums to 0
+    // Greedy mixes them: A(-50)→E(+40)=40, D(-40)→B(+30)=30, D(-10)→C(+20)=10, A(-10)→C(+10)=10 → 4
+    const balances = [
+      balance('a', 'A', -50),
+      balance('b', 'B', 30),
+      balance('c', 'C', 20),
+      balance('d', 'D', -40),
+      balance('e', 'E', 40),
+    ]
+    const optimal = calculateOptimalSettlement(balances, 'EUR', 'optimal')
+    const greedy = calculateOptimalSettlement(balances, 'EUR', 'greedy')
+    // Optimal: {A,B,C} → 2 txns + {D,E} → 1 txn = 3
+    expect(optimal.totalTransactions).toBe(3)
+    // Greedy crosses subsets → 4
+    expect(greedy.totalTransactions).toBe(4)
+  })
+
+  it('finds three independent pairs → 3 transactions instead of 5', () => {
+    const balances = [
+      balance('a', 'A', 10),
+      balance('b', 'B', -10),
+      balance('c', 'C', 20),
+      balance('d', 'D', -20),
+      balance('e', 'E', 30),
+      balance('f', 'F', -30),
+    ]
+    const optimal = calculateOptimalSettlement(balances, 'EUR', 'optimal')
+    expect(optimal.totalTransactions).toBe(3)
+  })
+
+  it('returns same count as greedy when no beneficial partition exists', () => {
+    // A = +60, B = -40, C = -20  — only one zero-sum group (all of them)
+    const balances = [
+      balance('a', 'A', 60),
+      balance('b', 'B', -40),
+      balance('c', 'C', -20),
+    ]
+    const optimal = calculateOptimalSettlement(balances, 'EUR', 'optimal')
+    const greedy = calculateOptimalSettlement(balances, 'EUR', 'greedy')
+    expect(optimal.totalTransactions).toBe(greedy.totalTransactions)
+  })
+
+  it('handles floating-point tolerance in subset sums', () => {
+    // 0.1 + 0.2 - 0.3 should be treated as zero
+    const balances = [
+      balance('a', 'A', 0.1),
+      balance('b', 'B', 0.2),
+      balance('c', 'C', -0.3),
+      balance('d', 'D', 5),
+      balance('e', 'E', -5),
+    ]
+    const result = calculateOptimalSettlement(balances, 'EUR', 'optimal')
+    // {A,B,C} and {D,E} are independent
+    expect(result.totalTransactions).toBe(3)
+  })
+
+  it('preserves total settlement amount after optimization', () => {
+    const balances = [
+      balance('a', 'A', -50),
+      balance('b', 'B', 30),
+      balance('c', 'C', 20),
+      balance('d', 'D', -40),
+      balance('e', 'E', 40),
+    ]
+    const result = calculateOptimalSettlement(balances, 'EUR', 'optimal')
+    const totalSettled = result.transactions.reduce((sum, t) => sum + t.amount, 0)
+    // Total debt = 50 + 40 = 90
+    expect(totalSettled).toBeCloseTo(90, 2)
+  })
+
+  it('greedy mode produces same results as before', () => {
+    const balances = [
+      balance('a', 'A', 100),
+      balance('b', 'B', 50),
+      balance('c', 'C', -80),
+      balance('d', 'D', -70),
+    ]
+    const greedy = calculateOptimalSettlement(balances, 'EUR', 'greedy')
+    const totalPaid = greedy.transactions.reduce((sum, t) => sum + t.amount, 0)
+    expect(totalPaid).toBeCloseTo(150, 2)
+    // Greedy: n-1 = 3 transactions
+    expect(greedy.totalTransactions).toBe(3)
+  })
+
+  it('sorts optimal transactions by amount descending', () => {
+    const balances = [
+      balance('a', 'A', -50),
+      balance('b', 'B', 30),
+      balance('c', 'C', 20),
+      balance('d', 'D', -40),
+      balance('e', 'E', 40),
+    ]
+    const result = calculateOptimalSettlement(balances, 'EUR', 'optimal')
+    for (let i = 1; i < result.transactions.length; i++) {
+      expect(result.transactions[i - 1].amount).toBeGreaterThanOrEqual(result.transactions[i].amount)
+    }
+  })
+})
+
 // ─── formatSettlementTransaction ──────────────────────────────────
 describe('formatSettlementTransaction', () => {
   it('formats transaction as readable string', () => {

--- a/src/services/settlementOptimizer.ts
+++ b/src/services/settlementOptimizer.ts
@@ -16,73 +16,155 @@ export interface OptimalSettlementPlan {
   currency: string
 }
 
-/**
- * Calculate the optimal settlement plan to minimize the number of transactions
- *
- * Uses a greedy algorithm:
- * 1. Create lists of debtors (negative balance) and creditors (positive balance)
- * 2. Match the largest debtor with the largest creditor
- * 3. Create a transaction for the minimum of their absolute balances
- * 4. Update balances and repeat
- *
- * @param balances - Array of participant/family balances
- * @param currency - Currency for the transactions (default: 'EUR')
- * @returns Optimal settlement plan with minimal transactions
- */
-export function calculateOptimalSettlement(
-  balances: ParticipantBalance[],
-  currency: string = 'EUR'
-): OptimalSettlementPlan {
-  // Create working copies of balances
-  const workingBalances = balances.map(b => ({
-    ...b,
-    balance: b.balance,
-  }))
+export type SettlementMode = 'optimal' | 'greedy'
 
+/**
+ * Greedy settlement: match largest debtor with largest creditor repeatedly.
+ * Produces at most n-1 transactions.
+ */
+function settleGreedy(nonZero: ParticipantBalance[]): SettlementTransaction[] {
+  const working = nonZero.map(b => ({ ...b, balance: b.balance }))
   const transactions: SettlementTransaction[] = []
 
-  // Separate into debtors and creditors
   const getDebtors = () =>
-    workingBalances
-      .filter(b => b.balance < -0.01) // Negative balance = owes money
-      .sort((a, b) => a.balance - b.balance) // Most negative first
+    working
+      .filter(b => b.balance < -0.01)
+      .sort((a, b) => a.balance - b.balance)
 
   const getCreditors = () =>
-    workingBalances
-      .filter(b => b.balance > 0.01) // Positive balance = owed money
-      .sort((a, b) => b.balance - a.balance) // Largest first
+    working
+      .filter(b => b.balance > 0.01)
+      .sort((a, b) => b.balance - a.balance)
 
   let debtors = getDebtors()
   let creditors = getCreditors()
 
-  // Continue until all debts are settled
   while (debtors.length > 0 && creditors.length > 0) {
     const debtor = debtors[0]
     const creditor = creditors[0]
+    const transactionAmount = Math.min(Math.abs(debtor.balance), creditor.balance)
 
-    // Calculate transaction amount (minimum of absolute values)
-    const debtAmount = Math.abs(debtor.balance)
-    const creditAmount = creditor.balance
-    const transactionAmount = Math.min(debtAmount, creditAmount)
-
-    // Create transaction
     transactions.push({
       fromId: debtor.id,
       fromName: debtor.name,
       toId: creditor.id,
       toName: creditor.name,
-      amount: Math.round(transactionAmount * 100) / 100, // Round to 2 decimals
+      amount: Math.round(transactionAmount * 100) / 100,
       fromIsFamily: debtor.isFamily,
       toIsFamily: creditor.isFamily,
     })
 
-    // Update balances
     debtor.balance += transactionAmount
     creditor.balance -= transactionAmount
 
-    // Refresh lists (filter out settled balances)
     debtors = getDebtors()
     creditors = getCreditors()
+  }
+
+  return transactions
+}
+
+/**
+ * Find the optimal partition of participants into independent zero-sum subsets.
+ * Uses bitmask DP: dp[mask] = max number of zero-sum subsets that partition mask.
+ * Returns array of index arrays, one per subset.
+ *
+ * Falls back to single group (greedy) if n > 20 or DP fails.
+ */
+function findOptimalPartition(balances: number[]): number[][] {
+  const n = balances.length
+  if (n <= 1 || n > 20) {
+    return [Array.from({ length: n }, (_, i) => i)]
+  }
+
+  const full = (1 << n) - 1
+
+  // Precompute subset sums
+  const subsetSum = new Float64Array(1 << n)
+  for (let mask = 1; mask <= full; mask++) {
+    // Use lowest set bit to build incrementally
+    const lsb = mask & -mask
+    const lsbIdx = 31 - Math.clz32(lsb)
+    subsetSum[mask] = subsetSum[mask ^ lsb] + balances[lsbIdx]
+  }
+
+  // dp[mask] = max zero-sum subsets partitioning mask. -1 = not reachable.
+  const dp = new Int32Array(1 << n).fill(-1)
+  const parent = new Int32Array(1 << n).fill(0) // stores the submask chosen
+  dp[0] = 0
+
+  for (let mask = 1; mask <= full; mask++) {
+    // Try every non-empty submask of mask
+    let sub = mask
+    while (sub > 0) {
+      if (Math.abs(subsetSum[sub]) < 0.01) {
+        const rest = mask ^ sub
+        if (dp[rest] >= 0 && dp[rest] + 1 > dp[mask]) {
+          dp[mask] = dp[rest] + 1
+          parent[mask] = sub
+        }
+      }
+      sub = (sub - 1) & mask
+    }
+  }
+
+  // Fallback if DP didn't find a valid partition
+  if (dp[full] < 0) {
+    return [Array.from({ length: n }, (_, i) => i)]
+  }
+
+  // Reconstruct partition
+  const groups: number[][] = []
+  let remaining = full
+  while (remaining > 0) {
+    const sub = parent[remaining]
+    const group: number[] = []
+    let bits = sub
+    while (bits > 0) {
+      const lsb = bits & -bits
+      group.push(31 - Math.clz32(lsb))
+      bits ^= lsb
+    }
+    groups.push(group)
+    remaining ^= sub
+  }
+
+  return groups
+}
+
+/**
+ * Calculate the settlement plan.
+ *
+ * @param balances - Array of participant/family balances
+ * @param currency - Currency for the transactions (default: 'EUR')
+ * @param mode - 'optimal' (default) uses bitmask DP to find independent zero-sum
+ *               subsets then settles each greedily. 'greedy' uses plain greedy.
+ */
+export function calculateOptimalSettlement(
+  balances: ParticipantBalance[],
+  currency: string = 'EUR',
+  mode: SettlementMode = 'optimal'
+): OptimalSettlementPlan {
+  const nonZero = balances.filter(b => Math.abs(b.balance) > 0.01)
+
+  if (nonZero.length === 0) {
+    return { transactions: [], totalTransactions: 0, currency }
+  }
+
+  let transactions: SettlementTransaction[]
+
+  if (mode === 'greedy') {
+    transactions = settleGreedy(nonZero)
+  } else {
+    // Optimal: partition into independent zero-sum subsets, settle each
+    const partition = findOptimalPartition(nonZero.map(b => b.balance))
+    transactions = []
+    for (const group of partition) {
+      const subset = group.map(i => nonZero[i])
+      transactions.push(...settleGreedy(subset))
+    }
+    // Sort by amount descending for consistent presentation
+    transactions.sort((a, b) => b.amount - a.amount)
   }
 
   return {


### PR DESCRIPTION
## Summary
- Add bitmask DP algorithm (`findOptimalPartition`) that finds independent zero-sum subsets among participants, reducing settlement transactions from n-1 (greedy) to n-k where k = number of subsets
- Extract `settleGreedy` helper from existing code (pure refactor), then settle each subset independently in optimal mode
- Add `SettlementMode` type (`'optimal' | 'greedy'`) with `mode` param on `calculateOptimalSettlement` (default: `'optimal'`)
- Add "Fewer / Standard" segmented pill toggle on `SettlementPlan` (Full mode) and `QuickSettlementSheet` (Quick mode), shown only when the two modes produce different transaction counts
- Fallback to greedy when n > 20 participants (safety bound)
- 7 new test cases covering subset detection, floating-point tolerance, mode switching, and sort order

## Test plan
- [x] All 182 tests pass (`npm test`)
- [x] `npm run type-check` clean
- [ ] Manual: verify toggle appears on SettlementsPage when optimal < greedy
- [ ] Manual: verify toggle appears in Quick mode settle sheet when filtered counts differ
- [ ] Manual: verify toggle hidden when optimal == greedy (no beneficial partition)
- [ ] Manual: verify PDF export still works (exports currently displayed plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)