### PR TITLE
fix: desktop header alignment + mobile participant action menu

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -180,7 +180,7 @@ export function Layout() {
           </>
         )}
 
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className={`relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 ${tripCode ? 'lg:ml-64' : ''}`}>
           <div className="flex flex-col">
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect, useCallback, FormEvent } from 'react'
 import { motion } from 'framer-motion'
-import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users, ChevronRight, Plus, Send, Baby } from 'lucide-react'
+import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users, ChevronRight, Plus, Send, Baby, MoreHorizontal } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useAuth } from '@/contexts/AuthContext'
@@ -16,6 +16,13 @@ import { fadeInUp } from '@/lib/animations'
 import type { Participant } from '@/types/participant'
 import { logger } from '@/lib/logger'
 import { getGroupBorderColor } from '@/lib/groupColors'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 interface ParticipantsSetupProps {
   onComplete?: () => void
@@ -428,59 +435,106 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
           )}
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
-          <Button
-            onClick={() => handleStartEditNickname(participant)}
-            variant="ghost"
-            size="sm"
-            className="h-8 w-8 p-0"
-            title={participant.nickname ? `Nickname: ${participant.nickname}` : 'Set nickname'}
-          >
-            <Pencil size={15} className={participant.nickname ? 'text-accent' : 'text-muted-foreground'} />
-          </Button>
-          <Button
-            onClick={() => handleStartEditGroup(participant)}
-            variant="ghost"
-            size="sm"
-            className="h-8 w-8 p-0"
-            title={participant.wallet_group ? `Group: ${participant.wallet_group}` : 'Set shared wallet group'}
-          >
-            <Users size={15} className={participant.wallet_group ? 'text-accent' : 'text-muted-foreground'} />
-          </Button>
-          {!participant.user_id && (
+          {/* Mobile: dropdown menu with labeled actions */}
+          <div className="sm:hidden flex items-center gap-1">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                  <MoreHorizontal size={16} className="text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => handleStartEditNickname(participant)}>
+                  <Pencil size={14} className="mr-2" />
+                  {participant.nickname ? `Nickname: ${participant.nickname}` : 'Edit nickname'}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleStartEditGroup(participant)}>
+                  <Users size={14} className="mr-2" />
+                  {participant.wallet_group ? `Group: ${participant.wallet_group}` : 'Set group'}
+                </DropdownMenuItem>
+                {!participant.user_id && (
+                  <DropdownMenuItem onClick={() => handleStartEditEmail(participant)}>
+                    <Mail size={14} className="mr-2" />
+                    {participant.email ? `Email: ${participant.email}` : 'Add email'}
+                  </DropdownMenuItem>
+                )}
+                {participant.email && user && (
+                  <DropdownMenuItem
+                    onClick={() => handleSendInvite(participant)}
+                    disabled={sendingInviteId === participant.id || sentInviteIds.has(participant.id)}
+                  >
+                    <Send size={14} className="mr-2" />
+                    {sentInviteIds.has(participant.id) ? 'Invite sent' : 'Send invite'}
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => handleDelete(participant.id)}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <X size={14} className="mr-2" />
+                  Remove
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          {/* Desktop: icon buttons with hover tooltips */}
+          <div className="hidden sm:flex items-center gap-1">
             <Button
-              onClick={() => handleStartEditEmail(participant)}
+              onClick={() => handleStartEditNickname(participant)}
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
-              title={participant.email ? `Email: ${participant.email}` : 'Add email'}
+              title={participant.nickname ? `Nickname: ${participant.nickname}` : 'Set nickname'}
             >
-              <Mail size={15} className={participant.email ? 'text-accent' : 'text-muted-foreground'} />
+              <Pencil size={15} className={participant.nickname ? 'text-accent' : 'text-muted-foreground'} />
             </Button>
-          )}
-          {participant.email && user && (
             <Button
-              onClick={() => handleSendInvite(participant)}
+              onClick={() => handleStartEditGroup(participant)}
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
-              title="Send invite email"
-              disabled={sendingInviteId === participant.id || sentInviteIds.has(participant.id)}
+              title={participant.wallet_group ? `Group: ${participant.wallet_group}` : 'Set shared wallet group'}
             >
-              {sentInviteIds.has(participant.id) ? (
-                <Check size={15} className="text-positive" />
-              ) : (
-                <Send size={15} className="text-muted-foreground" />
-              )}
+              <Users size={15} className={participant.wallet_group ? 'text-accent' : 'text-muted-foreground'} />
             </Button>
-          )}
-          <Button
-            onClick={() => handleDelete(participant.id)}
-            variant="ghost"
-            size="sm"
-            className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
-          >
-            <X size={16} />
-          </Button>
+            {!participant.user_id && (
+              <Button
+                onClick={() => handleStartEditEmail(participant)}
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                title={participant.email ? `Email: ${participant.email}` : 'Add email'}
+              >
+                <Mail size={15} className={participant.email ? 'text-accent' : 'text-muted-foreground'} />
+              </Button>
+            )}
+            {participant.email && user && (
+              <Button
+                onClick={() => handleSendInvite(participant)}
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                title="Send invite email"
+                disabled={sendingInviteId === participant.id || sentInviteIds.has(participant.id)}
+              >
+                {sentInviteIds.has(participant.id) ? (
+                  <Check size={15} className="text-positive" />
+                ) : (
+                  <Send size={15} className="text-muted-foreground" />
+                )}
+              </Button>
+            )}
+            <Button
+              onClick={() => handleDelete(participant.id)}
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+            >
+              <X size={16} />
+            </Button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- **#544** — Desktop Full-mode header inner container now gets `lg:ml-64` when inside a trip, aligning the back arrow / trip name with main content below the sidebar
- **#543** — On mobile, participant action icons (nickname, group, email, invite) are collapsed into a labeled `DropdownMenu` for discoverability. Desktop keeps the existing icon row with hover tooltips. Remove button moved into the menu on mobile.

Closes #543, closes #544.

## Test plan
- [ ] Desktop: open a trip in Full mode → header text aligns with page content below the sidebar
- [ ] Desktop: home page (no trip) → header stays centered (no `ml-64`)
- [ ] Mobile: open Manage Trip → participant row shows `⋯` menu button
- [ ] Mobile: tap `⋯` → dropdown with labeled actions (Edit nickname, Set group, Add email, Send invite, Remove)
- [ ] Desktop: participant row still shows icon buttons with hover tooltips
- [ ] `npm run type-check` clean
- [ ] `npm test` — all 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)