### PR TITLE
fix: add section labels to mobile participant dropdown

### DIFF
--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
@@ -444,9 +445,10 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">Edit</DropdownMenuLabel>
                 <DropdownMenuItem onClick={() => handleStartEditNickname(participant)}>
                   <Pencil size={14} className="mr-2" />
-                  {participant.nickname ? `Nickname: ${participant.nickname}` : 'Edit nickname'}
+                  {participant.nickname ? `Nickname: ${participant.nickname}` : 'Set nickname'}
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => handleStartEditGroup(participant)}>
                   <Users size={14} className="mr-2" />
@@ -455,9 +457,11 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                 {!participant.user_id && (
                   <DropdownMenuItem onClick={() => handleStartEditEmail(participant)}>
                     <Mail size={14} className="mr-2" />
-                    {participant.email ? `Email: ${participant.email}` : 'Add email'}
+                    {participant.email ? `Email: ${participant.email}` : 'Set email'}
                   </DropdownMenuItem>
                 )}
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">Actions</DropdownMenuLabel>
                 {participant.email && user && (
                   <DropdownMenuItem
                     onClick={() => handleSendInvite(participant)}
@@ -467,7 +471,6 @@ export function ParticipantsSetup({ onComplete: _onComplete, hasSetup: _hasSetup
                     {sentInviteIds.has(participant.id) ? 'Invite sent' : 'Send invite'}
                   </DropdownMenuItem>
                 )}
-                <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => handleDelete(participant.id)}
                   className="text-destructive focus:text-destructive"


### PR DESCRIPTION
## Summary
- Adds **"Edit"** and **"Actions"** section headers (`DropdownMenuLabel`) to the mobile participant dropdown menu
- Moves "Send invite" below the separator into the Actions group (it fires immediately, not an inline editor)
- Renames "Edit nickname" → "Set nickname" and "Add email" → "Set email" for consistency with "Set group"

Closes #549.

## Before / After
**Before:** All 5 items look identical — no way to tell which opens an editor vs performs an action.
**After:** Clear "Edit" section (nickname, group, email) separated from "Actions" section (send invite, remove).

## Test plan
- [ ] Mobile: open Manage Trip → tap ⋯ on a participant → dropdown shows "Edit" label above editor items, separator, then "Actions" label above send invite / remove
- [ ] `npm run type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)