### PR TITLE
fix: consistent desktop header position across all views

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -180,7 +180,7 @@ export function Layout() {
           </>
         )}
 
-        <div className={`relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 ${tripCode ? 'lg:ml-64' : ''}`}>
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col">
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">


### PR DESCRIPTION
## Summary
Removes `lg:ml-64` from the Layout header inner container. The sidebar starts at `top-20` (below the header), so the header should span the full viewport — not be offset by the sidebar width.

This makes the header left/right positions identical across Full mode, Quick mode, and Home page on desktop. Reverts the header portion of PR #548 while keeping `<main>`'s `lg:ml-64` intact.

Closes #551.

## Test plan
- [ ] Desktop Full mode: header back arrow + trip name at same left position as Quick mode and Home
- [ ] Desktop Full mode: right-side items (mode toggle, avatar) at same right position as Quick/Home
- [ ] Desktop Full mode: main content still offset by sidebar (lg:ml-64 on `<main>` unchanged)
- [ ] Mobile: no change (sidebar not shown)
- [ ] `npm run type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)