### PR TITLE
fix: skip auto-redirect on sign-in to prevent stranger's trip — closes #554

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import { UserProfile } from '@/types/auth'
 import { logger } from '@/lib/logger'
 import { withTimeout } from '@/lib/fetchWithTimeout'
 import { debugLog } from '@/lib/debugLogger'
+import { clearMyTrips } from '@/lib/myTripsStorage'
 
 interface AuthContextType {
   user: User | null
@@ -210,6 +211,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signOut = async () => {
     logger.info('User signed out', { user_id: user?.id })
+    clearMyTrips()
     const { error } = await supabase.auth.signOut()
     if (error) {
       logger.error('Sign-out failed', { error: error.message })

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
@@ -23,6 +23,20 @@ export function ConditionalHomePage() {
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
   const fromTrip = !!(location.state as any)?.fromTrip
 
+  // Track sign-in transition (null → non-null user) to avoid redirecting
+  // to a stranger's trip. When unauthenticated, TripContext fetches ALL trips
+  // (RLS is open). On sign-in there's a render cycle where `user` is set but
+  // `trips` still contains all trips — skip the redirect for that cycle.
+  const prevUserIdRef = useRef<string | null | undefined>(undefined)
+  const justSignedInRef = useRef(false)
+
+  useEffect(() => {
+    if (prevUserIdRef.current === null && user?.id) {
+      justSignedInRef.current = true
+    }
+    prevUserIdRef.current = user?.id ?? null
+  }, [user?.id])
+
   useEffect(() => {
     if (!isMobile || tripsLoading) return
 
@@ -41,6 +55,14 @@ export function ConditionalHomePage() {
     // TripContext fetches ALL trips and localStorage includes shared-link trips,
     // so there's no reliable way to distinguish "my trip" from "visited via link".
     if (!user) return
+
+    // Skip redirect on the render cycle right after sign-in — trips list
+    // may still contain all trips (pre-auth fetch) and we'd redirect to
+    // a stranger's active trip.
+    if (justSignedInRef.current) {
+      justSignedInRef.current = false
+      return
+    }
 
     const activeTripId = getActiveTripId(trips)
 


### PR DESCRIPTION
## Summary
- Track `null → non-null` user transition in `ConditionalHomePage` and skip the auto-redirect for that render cycle, preventing redirect to a stranger's active trip when the trips list hasn't re-fetched yet
- Clear `myTrips` localStorage on sign-out as defense-in-depth for shared devices

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 182 tests pass
- [ ] Manual: open app unauthenticated → sign in → verify home page shows (no redirect to stranger's trip)
- [ ] Manual: close and reopen while signed in → verify auto-redirect to own active trip still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)