### PR TITLE
fix: sync bank details fields when profile loads after dialog opens — closes #557

### DIFF
--- a/src/components/auth/BankDetailsDialog.tsx
+++ b/src/components/auth/BankDetailsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useToast } from '@/hooks/use-toast'
 import { Button } from '@/components/ui/button'
@@ -24,6 +24,13 @@ export function BankDetailsDialog({ open, onOpenChange }: BankDetailsDialogProps
   const [holder, setHolder] = useState(userProfile?.bank_account_holder || '')
   const [iban, setIban] = useState(userProfile?.bank_iban || '')
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (open && userProfile) {
+      setHolder(userProfile.bank_account_holder || '')
+      setIban(userProfile.bank_iban || '')
+    }
+  }, [open, userProfile])
 
   const handleSave = async () => {
     setSaving(true)


### PR DESCRIPTION
## Summary
- `BankDetailsDialog` initialized `holder`/`iban` state once at mount via `useState`. In incognito (no cached session), `userProfile` loads asynchronously after the dialog mounts, so fields stayed empty.
- Added `useEffect` that syncs fields when the dialog opens or `userProfile` changes.

Closes #557

## Test plan
- [ ] Sign in via incognito → open Bank Details → fields should show saved values
- [ ] Open Bank Details before profile loads → fields populate once profile arrives
- [ ] Edit and save bank details → reopen dialog → values persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)