### PR TITLE
feat: show bank details nudge in trip views when owed money

### DIFF
--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -18,6 +18,7 @@ import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { Button } from '@/components/ui/button'
 import { useToast } from '@/hooks/use-toast'
 import { useAuth } from '@/contexts/AuthContext'
+import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/lib/logger'
 
@@ -54,6 +55,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
   const [sendingRemind, setSendingRemind] = useState(false)
   const [remindResults, setRemindResults] = useState<Record<number, 'sent' | 'error'>>({})
   const [checkedEmails, setCheckedEmails] = useState<Record<string, boolean>>({})
+  const [bankDialogOpen, setBankDialogOpen] = useState(false)
   const isSubmittingRef = useRef(false)
   const keyboard = useKeyboardHeight()
   const isMobile = useMediaQuery('(max-width: 767px)')
@@ -476,9 +478,12 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
                           )
                         }
                         return (
-                          <p className="mt-2 text-xs text-muted-foreground italic">
-                            Add your bank details in your profile so others can pay you
-                          </p>
+                          <button
+                            onClick={() => setBankDialogOpen(true)}
+                            className="mt-2 text-xs text-primary hover:underline"
+                          >
+                            Add your bank details so others can pay you →
+                          </button>
                         )
                       })()}
 
@@ -606,44 +611,52 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
     </div>
   )
 
+  const bankDialog = <BankDetailsDialog open={bankDialogOpen} onOpenChange={setBankDialogOpen} />
+
   if (isMobile) {
     return (
-      <Sheet open={open} onOpenChange={handleOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{
-            height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-            bottom: keyboard.isVisible
-              ? `${Math.max(0, keyboard.keyboardHeight - keyboard.viewportOffset)}px`
-              : undefined,
-            paddingBottom: keyboard.isVisible && keyboard.viewportOffset > 0
-              ? `${keyboard.viewportOffset}px`
-              : undefined,
-          }}
-        >
-          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-            {leftSlot}
-            <SheetTitle className="text-base font-semibold">{titleText}</SheetTitle>
-            {closeBtn}
-          </div>
-          {scrollContent}
-        </SheetContent>
-      </Sheet>
+      <>
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+          <SheetContent
+            side="bottom"
+            hideClose
+            className="flex flex-col p-0 rounded-t-2xl"
+            style={{
+              height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
+              bottom: keyboard.isVisible
+                ? `${Math.max(0, keyboard.keyboardHeight - keyboard.viewportOffset)}px`
+                : undefined,
+              paddingBottom: keyboard.isVisible && keyboard.viewportOffset > 0
+                ? `${keyboard.viewportOffset}px`
+                : undefined,
+            }}
+          >
+            <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+              {leftSlot}
+              <SheetTitle className="text-base font-semibold">{titleText}</SheetTitle>
+              {closeBtn}
+            </div>
+            {scrollContent}
+          </SheetContent>
+        </Sheet>
+        {bankDialog}
+      </>
     )
   }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
-        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-          {leftSlot}
-          <DialogTitle className="text-base font-semibold">{titleText}</DialogTitle>
-          {closeBtn}
-        </div>
-        {scrollContent}
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
+          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+            {leftSlot}
+            <DialogTitle className="text-base font-semibold">{titleText}</DialogTitle>
+            {closeBtn}
+          </div>
+          {scrollContent}
+        </DialogContent>
+      </Dialog>
+      {bankDialog}
+    </>
   )
 }

--- a/src/hooks/useBankDetailsPrompt.ts
+++ b/src/hooks/useBankDetailsPrompt.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+
+const DISMISS_KEY = 'spl1t:dismiss-bank-details'
+
+export function useBankDetailsPrompt() {
+  const { user, userProfile } = useAuth()
+
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISS_KEY) === 'true'
+  )
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const hasBankDetails = !!(userProfile?.bank_account_holder || userProfile?.bank_iban)
+
+  const dismiss = useCallback(() => {
+    localStorage.setItem(DISMISS_KEY, 'true')
+    setDismissed(true)
+  }, [])
+
+  /** For dismissible nudge cards — authenticated + no bank details + not dismissed + owed money */
+  const shouldShowNudge = useCallback(
+    (isOwedMoney: boolean) => !!user && !hasBankDetails && !dismissed && isOwedMoney,
+    [user, hasBankDetails, dismissed]
+  )
+
+  /** For settlement sheet — authenticated + no bank details (never dismissible) */
+  const shouldShowActionLink = !!user && !hasBankDetails
+
+  return { shouldShowNudge, shouldShowActionLink, dialogOpen, setDialogOpen, dismiss }
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,19 +1,22 @@
 import { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
-import { Lightbulb, Receipt, FileDown, Share2 } from 'lucide-react'
+import { Lightbulb, Receipt, FileDown, Share2, Landmark, X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useBankDetailsPrompt } from '@/hooks/useBankDetailsPrompt'
 import { PageLoadingState } from '@/components/PageLoadingState'
 import { PageErrorState } from '@/components/PageErrorState'
-import { calculateBalances } from '@/services/balanceCalculator'
+import { calculateBalances, buildEntityMap } from '@/services/balanceCalculator'
 import { exportTripSummaryToPDF } from '@/services/pdfExport'
 import { BalanceCard } from '@/components/BalanceCard'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Link } from 'react-router-dom'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
+import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
 import { CostBreakdownDialog } from '@/components/CostBreakdownDialog'
 import { ParticipantBalance } from '@/services/balanceCalculator'
 import type { Participant } from '@/types/participant'
@@ -28,6 +31,8 @@ export function DashboardPage() {
   const { participants, loading: pLoading, error: pError, refreshParticipants } = useParticipantContext()
   const { expenses, loading: eLoading, error: eError, refreshExpenses } = useExpenseContext()
   const { settlements, loading: sLoading, error: sError, refreshSettlements } = useSettlementContext()
+  const { myParticipant } = useMyParticipant()
+  const bankPrompt = useBankDetailsPrompt()
   const [selectedBalance, setSelectedBalance] = useState<ParticipantBalance | null>(null)
   const [retrying, setRetrying] = useState(false)
 
@@ -246,6 +251,38 @@ export function DashboardPage() {
         </Card>
       )}
 
+      {/* Bank details nudge */}
+      {(() => {
+        if (!myParticipant || !currentTrip) return null
+        const entityMap = buildEntityMap(participants, currentTrip.tracking_mode)
+        const myEntityId = entityMap.participantToEntityId.get(myParticipant.id) ?? myParticipant.id
+        const myBal = displayBalances.find(b => b.id === myEntityId)
+        if (!bankPrompt.shouldShowNudge(!!myBal && myBal.balance > 0)) return null
+        return (
+          <Card className="border-amber-200 bg-amber-50 dark:bg-amber-950/20">
+            <CardContent className="pt-4 pb-4 flex items-center justify-between gap-3">
+              <div className="flex items-start gap-3">
+                <Landmark size={18} className="text-amber-600 mt-0.5 shrink-0" />
+                <div>
+                  <p className="font-medium text-sm">Add your bank details</p>
+                  <p className="text-xs text-muted-foreground">So others know where to pay you</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <Button size="sm" onClick={() => bankPrompt.setDialogOpen(true)}>Add</Button>
+                <button
+                  onClick={bankPrompt.dismiss}
+                  aria-label="Dismiss"
+                  className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })()}
+
       {/* Analytics & Insights */}
       {expenses.length > 0 && (
         <>
@@ -306,6 +343,9 @@ export function DashboardPage() {
       )}
 
       </>}
+
+      {/* Bank details dialog */}
+      <BankDetailsDialog open={bankPrompt.dialogOpen} onOpenChange={bankPrompt.setDialogOpen} />
 
       {/* Cost Breakdown Dialog */}
       {selectedBalance && (

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -24,9 +24,11 @@ import { PageErrorState } from '@/components/PageErrorState'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useToast } from '@/hooks/use-toast'
+import { useBankDetailsPrompt } from '@/hooks/useBankDetailsPrompt'
+import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
-  Loader2, Users
+  Loader2, Users, Landmark, X
 } from 'lucide-react'
 
 export function QuickGroupDetailPage() {
@@ -55,6 +57,7 @@ export function QuickGroupDetailPage() {
   const [historyOpen, setHistoryOpen] = useState(false)
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [retrying, setRetrying] = useState(false)
+  const bankPrompt = useBankDetailsPrompt()
   // Open receipt capture sheet when navigated here with openScan state
   useEffect(() => {
     if ((location.state as any)?.openScan) {
@@ -152,6 +155,29 @@ export function QuickGroupDetailPage() {
                 <span>{balanceCalc.balances.length} members</span>
               </button>
             </div>
+          )}
+          {bankPrompt.shouldShowNudge(!!myBalance && myBalance.balance > 0) && (
+            <Card className="mb-4 border-amber-200 bg-amber-50 dark:bg-amber-950/20">
+              <CardContent className="pt-4 pb-4 flex items-center justify-between gap-3">
+                <div className="flex items-start gap-3">
+                  <Landmark size={18} className="text-amber-600 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="font-medium text-sm">Add your bank details</p>
+                    <p className="text-xs text-muted-foreground">So others know where to pay you</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button size="sm" onClick={() => bankPrompt.setDialogOpen(true)}>Add</Button>
+                  <button
+                    onClick={bankPrompt.dismiss}
+                    aria-label="Dismiss"
+                    className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
       )}
@@ -270,6 +296,9 @@ export function QuickGroupDetailPage() {
         open={historyOpen}
         onOpenChange={setHistoryOpen}
       />
+
+      {/* Bank details dialog */}
+      <BankDetailsDialog open={bankPrompt.dialogOpen} onOpenChange={bankPrompt.setDialogOpen} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add amber "Add your bank details" nudge card to **QuickGroupDetailPage** and **DashboardPage** — shown when authenticated user is owed money and hasn't saved bank details
- Upgrade passive italic hint in **QuickSettlementSheet** to a clickable link that opens `BankDetailsDialog` inline
- Extract shared condition logic into `useBankDetailsPrompt` hook (dismiss state via `spl1t:dismiss-bank-details` localStorage)

## Test plan
- [ ] Sign in → navigate directly to trip in Quick mode → nudge card appears when owed money
- [ ] Dismiss nudge → stays dismissed across Quick and Dashboard pages
- [ ] Click "Add" → fill in bank details → card disappears automatically
- [ ] Open Settle Up when owed → clickable "Add your bank details" link opens dialog
- [ ] Verify nudge does NOT appear when user has bank details or is not owed money
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — all 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)