### PR TITLE
feat: settlement form pre-fill + Pay Now helper panel

### DIFF
--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -1,6 +1,6 @@
 import { useState, FormEvent, useRef, useEffect } from 'react'
 import { motion } from 'framer-motion'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, Clipboard, Check, ExternalLink, Lightbulb } from 'lucide-react'
 import { CreateSettlementInput } from '@/types/settlement'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -26,9 +26,54 @@ interface SettlementFormProps {
   initialNote?: string
   initialFromId?: string
   initialToId?: string
+  recipientBankDetails?: { holder: string; iban: string } | null
+  recipientName?: string
 }
 
-export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote, initialFromId, initialToId }: SettlementFormProps) {
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = () => {
+    navigator.clipboard.writeText(value)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-border hover:bg-muted transition-colors shrink-0"
+    >
+      {copied ? (
+        <><Check size={12} className="text-positive" /> Copied!</>
+      ) : (
+        <><Clipboard size={12} /> Copy</>
+      )}
+    </button>
+  )
+}
+
+const BANK_SHORTCUTS = [
+  {
+    name: 'Swedbank',
+    url: 'https://www.swedbank.ee/private/d2d/payments2/smartPayment',
+    badgeClass: 'bg-orange-500 text-white font-bold',
+    badgeText: 'SW',
+  },
+  {
+    name: 'LHV',
+    url: 'https://www.lhv.ee/en/internetbank',
+    badgeClass: 'bg-black text-white font-bold',
+    badgeText: 'LHV',
+  },
+  {
+    name: 'SEB',
+    url: 'https://e.seb.ee/web/ipank',
+    badgeClass: 'bg-green-600 text-white font-bold',
+    badgeText: 'SEB',
+  },
+]
+
+export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote, initialFromId, initialToId, recipientBankDetails, recipientName }: SettlementFormProps) {
   const { currentTrip } = useCurrentTrip()
   const { participants } = useParticipantContext()
 
@@ -297,6 +342,74 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
           disabled={loading}
         />
       </div>
+
+      {/* Pay Now Helper Panel */}
+      {recipientBankDetails?.iban && (
+        <div className="space-y-3 pt-2">
+          <div className="border-t border-border" />
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Payment details
+          </p>
+
+          {/* IBAN row */}
+          <div className="flex items-center justify-between gap-2 rounded-lg bg-muted/50 px-3 py-2.5">
+            <div className="min-w-0">
+              <p className="text-[11px] uppercase text-muted-foreground">
+                {recipientName ? `${recipientName}'s IBAN` : 'Recipient IBAN'}
+              </p>
+              <p className="font-mono text-sm font-semibold text-foreground truncate">
+                {recipientBankDetails.iban}
+              </p>
+            </div>
+            <CopyButton value={recipientBankDetails.iban} />
+          </div>
+
+          {/* Amount row */}
+          <div className="flex items-center justify-between gap-2 rounded-lg bg-muted/50 px-3 py-2.5">
+            <div className="min-w-0">
+              <p className="text-[11px] uppercase text-muted-foreground">
+                Amount ({currency})
+              </p>
+              <p className="text-sm font-semibold text-foreground tabular-nums">
+                {parseFloat(amount || '0').toFixed(2)}
+              </p>
+            </div>
+            <CopyButton value={parseFloat(amount || '0').toFixed(2)} />
+          </div>
+
+          {/* Notice */}
+          <div className="flex gap-2.5 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-3 py-2.5">
+            <Lightbulb size={16} className="text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+            <p className="text-xs text-amber-800 dark:text-amber-300 leading-relaxed">
+              Banks don't allow apps to pre-fill payments directly. Copy the details above and paste them in your bank app — or tap a shortcut below to open it.
+            </p>
+          </div>
+
+          {/* Bank shortcuts */}
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Open your bank
+          </p>
+          <div className="grid grid-cols-3 gap-2">
+            {BANK_SHORTCUTS.map(bank => (
+              <a
+                key={bank.name}
+                href={bank.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex flex-col items-center gap-1.5 rounded-lg border border-border p-3 hover:bg-muted/50 transition-colors"
+              >
+                <span className={`inline-flex items-center justify-center w-9 h-9 rounded-lg text-xs ${bank.badgeClass}`}>
+                  {bank.badgeText}
+                </span>
+                <span className="text-xs font-medium text-foreground flex items-center gap-1">
+                  {bank.name}
+                  <ExternalLink size={10} className="text-muted-foreground" />
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Submit Buttons */}
       <div className="flex gap-3 pt-2">

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -33,6 +33,9 @@ interface Prefill {
   fromId: string
   toId: string
   amount: number
+  note?: string
+  bankDetails?: BankDetails | null
+  toName?: string
 }
 
 export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementSheetProps) {
@@ -274,6 +277,9 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
       fromId: tx.fromId,
       toId: tx.toId,
       amount: tx.amount,
+      note: `Settlement: ${tx.fromName} → ${tx.toName}`,
+      bankDetails: bankDetailsMap[tx.toId] || null,
+      toName: tx.toName,
     })
     setView('form')
   }
@@ -606,6 +612,9 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
           initialFromId={prefill?.fromId}
           initialToId={prefill?.toId}
           initialAmount={prefill?.amount}
+          initialNote={prefill?.note}
+          recipientBankDetails={prefill?.bankDetails}
+          recipientName={prefill?.toName}
         />
       )}
     </div>

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -31,6 +31,10 @@ export function SettlementsPage() {
   const [showCustomSettlement, setShowCustomSettlement] = useState(false)
   const [prefilledAmount, setPrefilledAmount] = useState<number | undefined>(undefined)
   const [prefilledNote, setPrefilledNote] = useState<string | undefined>(undefined)
+  const [prefilledFromId, setPrefilledFromId] = useState<string | undefined>(undefined)
+  const [prefilledToId, setPrefilledToId] = useState<string | undefined>(undefined)
+  const [prefilledBankDetails, setPrefilledBankDetails] = useState<BankDetails | null>(null)
+  const [prefilledRecipientName, setPrefilledRecipientName] = useState<string | undefined>(undefined)
   const customSettlementRef = useRef<HTMLDivElement>(null)
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
   const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
@@ -175,9 +179,13 @@ export function SettlementsPage() {
   }, [user, recipientKey, participants, currentTrip])
 
   const handleRecordSettlement = (transaction: SettlementTransaction) => {
-    // Pre-populate the custom settlement form with amount and note
+    // Pre-populate the custom settlement form with all fields
     setPrefilledAmount(transaction.amount)
-    setPrefilledNote(`Settlement from optimal plan: ${transaction.fromName} → ${transaction.toName}`)
+    setPrefilledNote(`Settlement: ${transaction.fromName} → ${transaction.toName}`)
+    setPrefilledFromId(transaction.fromId)
+    setPrefilledToId(transaction.toId)
+    setPrefilledBankDetails(bankDetailsMap[transaction.toId] || null)
+    setPrefilledRecipientName(transaction.toName)
 
     // Expand the custom settlement section
     setShowCustomSettlement(true)
@@ -199,6 +207,10 @@ export function SettlementsPage() {
     setShowCustomSettlement(false)
     setPrefilledAmount(undefined)
     setPrefilledNote(undefined)
+    setPrefilledFromId(undefined)
+    setPrefilledToId(undefined)
+    setPrefilledBankDetails(null)
+    setPrefilledRecipientName(undefined)
   }
 
   const handleRemind = async (transaction: SettlementTransaction, emails: string[]): Promise<void> => {
@@ -402,6 +414,10 @@ export function SettlementsPage() {
                     onCancel={() => setShowCustomSettlement(false)}
                     initialAmount={prefilledAmount}
                     initialNote={prefilledNote}
+                    initialFromId={prefilledFromId}
+                    initialToId={prefilledToId}
+                    recipientBankDetails={prefilledBankDetails}
+                    recipientName={prefilledRecipientName}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Summary
- **Full pre-fill**: Record button now sets from/to/amount/note in both SettlementsPage and QuickSettlementSheet (previously only amount + note)
- **Pay Now panel**: When recipient has IBAN on file, shows copyable IBAN + amount rows and shortcut buttons to open Swedbank/LHV/SEB internet banking
- Panel only renders when `recipientBankDetails?.iban` is truthy — no UI change when bank details are missing

## Test plan
- [ ] SettlementsPage: click "Record" on a step → form pre-fills from, to, amount, note
- [ ] SettlementsPage: recipient with IBAN → Pay Now panel visible with copy buttons + bank links
- [ ] SettlementsPage: recipient without IBAN → no Pay Now panel
- [ ] QuickSettlementSheet: click "Settle" → form pre-fills all fields; Pay Now panel shows if IBAN available
- [ ] Copy buttons work (IBAN and amount) with 2s feedback
- [ ] Bank links open in new tab
- [ ] Record Settlement still works as final confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)