### PR TITLE
fix: disambiguate participants with same first name

### DIFF
--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -6,7 +6,7 @@ import { ParticipantBalance, formatBalance, getBalanceColorClass, convertToBaseC
 import { Expense } from '@/types/expense'
 import { Participant } from '@/types/participant'
 import { Settlement } from '@/types/settlement'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 
 interface CostBreakdownDialogProps {
   open: boolean
@@ -106,11 +106,7 @@ export function CostBreakdownDialog({
     )
   }, [settlements, groupMembers, groupName])
 
-  const participantNameMap = useMemo(() => {
-    const map = new Map<string, string>()
-    participants.forEach(p => map.set(p.id, getShortName(p)))
-    return map
-  }, [participants])
+  const participantNameMap = useMemo(() => buildShortNameMap(participants), [participants])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -12,6 +12,7 @@ import {
   Tag,
   ScanLine,
 } from 'lucide-react'
+import { useMemo } from 'react'
 import { Expense } from '@/types/expense'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -19,7 +20,7 @@ import { convertToBaseCurrency } from '@/services/balanceCalculator'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 
 interface ExpenseCardProps {
   expense: Expense
@@ -31,6 +32,7 @@ interface ExpenseCardProps {
 export function ExpenseCard({ expense, onEdit, onDelete, onViewReceipt }: ExpenseCardProps) {
   const { participants } = useParticipantContext()
   const { currentTrip } = useCurrentTrip()
+  const shortNames = useMemo(() => buildShortNameMap(participants), [participants])
 
   const defaultCurrency = currentTrip?.default_currency || 'EUR'
   const exchangeRates = currentTrip?.exchange_rates || {}
@@ -52,15 +54,14 @@ export function ExpenseCard({ expense, onEdit, onDelete, onViewReceipt }: Expens
   }
 
   const getPaidByName = () => {
-    const participant = participants.find(p => p.id === expense.paid_by)
-    return participant ? getShortName(participant) : 'Unknown'
+    return shortNames.get(expense.paid_by) || 'Unknown'
   }
 
   const getDistributionText = () => {
     const dist = expense.distribution
     const ids = dist.type === 'individuals' ? dist.participants : []
     const names = ids
-      .map(id => { const p = participants.find(pp => pp.id === id); return p ? getShortName(p) : null })
+      .map(id => shortNames.get(id))
       .filter(Boolean)
     if (names.length === participants.length) {
       return 'Everyone'

--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent, useRef, useEffect } from 'react'
+import { useState, FormEvent, useRef, useEffect, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { ArrowRight, Clipboard, Check, ExternalLink, Lightbulb } from 'lucide-react'
 import { CreateSettlementInput } from '@/types/settlement'
@@ -17,7 +17,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 
 interface SettlementFormProps {
   onSubmit: (input: CreateSettlementInput) => Promise<void>
@@ -125,11 +125,12 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
     : ['EUR', 'USD', 'GBP', 'THB']
 
   // Get all adults for selection
+  const shortNames = useMemo(() => buildShortNameMap(participants), [participants])
   const adultsForSelection = participants
     .filter(p => p.is_adult)
     .map(p => ({
       id: p.id,
-      name: getShortName(p),
+      name: shortNames.get(p.id) || p.name,
       groupName: p.wallet_group || null,
     }))
 

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -20,7 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 import { ExpenseSplitPreview } from './ExpenseSplitPreview'
 
 interface ExpenseFormProps {
@@ -102,6 +102,7 @@ export function ExpenseForm({
   }, [])
 
   const adults = getAdultParticipants()
+  const shortNames = useMemo(() => buildShortNameMap(participants), [participants])
 
   // Compute available currencies from trip settings
   const availableCurrencies = currentTrip
@@ -435,7 +436,7 @@ export function ExpenseForm({
               <div className="flex-1">
                 <div className="flex items-center gap-2 text-sm font-medium text-foreground">
                   <Lightbulb size={16} className="text-accent" />
-                  <span><strong>{suggestedPayer.name.split(' ')[0]}</strong> should pay next</span>
+                  <span><strong>{suggestedPayer.name}</strong> should pay next</span>
                 </div>
                 <p className="text-xs text-muted-foreground mt-1">
                   Current balance:{' '}
@@ -459,7 +460,7 @@ export function ExpenseForm({
           <SelectContent>
             {adults.map(adult => (
               <SelectItem key={adult.id} value={adult.id}>
-                {getShortName(adult)}
+                {shortNames.get(adult.id) || adult.name}
               </SelectItem>
             ))}
           </SelectContent>
@@ -585,7 +586,7 @@ export function ExpenseForm({
                       htmlFor={`participant-${participant.id}`}
                       className="text-sm text-foreground cursor-pointer flex-1"
                     >
-                      {getShortName(participant)} {participant.is_adult ? '' : '(child)'}
+                      {shortNames.get(participant.id) || participant.name} {participant.is_adult ? '' : '(child)'}
                     </label>
                     {splitMode !== 'equal' && selectedParticipants.includes(participant.id) && (
                       <Input

--- a/src/components/expenses/ExpenseSplitPreview.tsx
+++ b/src/components/expenses/ExpenseSplitPreview.tsx
@@ -4,7 +4,7 @@ import { Participant } from '@/types/participant'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { User } from 'lucide-react'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 
 interface ExpenseSplitPreviewProps {
   amount: number
@@ -25,6 +25,8 @@ export function ExpenseSplitPreview({
   distribution,
   participants,
 }: ExpenseSplitPreviewProps) {
+  const shortNames = useMemo(() => buildShortNameMap(participants), [participants])
+
   const splitEntries = useMemo(() => {
     const entries: SplitEntry[] = []
     if (distribution.type !== 'individuals') return entries
@@ -45,7 +47,7 @@ export function ExpenseSplitPreview({
           if (existing) {
             existing.memberIds.push(pid)
           } else {
-            entityMap.set(key, { name: p.wallet_group ?? getShortName(p), memberIds: [pid] })
+            entityMap.set(key, { name: p.wallet_group ?? (shortNames.get(pid) || p.name), memberIds: [pid] })
           }
         }
         const perEntity = amount / entityMap.size
@@ -54,7 +56,7 @@ export function ExpenseSplitPreview({
           for (const mid of entity.memberIds) {
             const p = participants.find(pp => pp.id === mid)
             if (p) {
-              entries.push({ id: mid, name: getShortName(p), amount: perMember })
+              entries.push({ id: mid, name: shortNames.get(mid) || p.name, amount: perMember })
             }
           }
         }
@@ -67,7 +69,7 @@ export function ExpenseSplitPreview({
           if (participant) {
             entries.push({
               id: participantId,
-              name: getShortName(participant),
+              name: shortNames.get(participantId) || participant.name,
               amount: shareAmount,
             })
           }
@@ -80,7 +82,7 @@ export function ExpenseSplitPreview({
           const shareAmount = (amount * split.value) / 100
           entries.push({
             id: split.participantId,
-            name: getShortName(participant),
+            name: shortNames.get(split.participantId) || participant.name,
             amount: shareAmount,
           })
         }
@@ -91,7 +93,7 @@ export function ExpenseSplitPreview({
         if (participant) {
           entries.push({
             id: split.participantId,
-            name: getShortName(participant),
+            name: shortNames.get(split.participantId) || participant.name,
             amount: split.value,
           })
         }
@@ -99,7 +101,7 @@ export function ExpenseSplitPreview({
     }
 
     return entries
-  }, [amount, distribution, participants])
+  }, [amount, distribution, participants, shortNames])
 
   const formatAmount = (value: number) => {
     return new Intl.NumberFormat('en-US', {

--- a/src/components/expenses/wizard/WizardStep2.tsx
+++ b/src/components/expenses/wizard/WizardStep2.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { Lightbulb } from 'lucide-react'
 import { Label } from '@/components/ui/label'
@@ -9,7 +10,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 
 interface SuggestedPayer {
@@ -43,6 +44,7 @@ export function WizardStep2({
   currency,
   disabled = false,
 }: WizardStep2Props) {
+  const shortNames = useMemo(() => buildShortNameMap(adults), [adults])
   const formatBalance = (balance: number, curr: string) => {
     const formatted = new Intl.NumberFormat('en-US', {
       style: 'currency',
@@ -82,7 +84,7 @@ export function WizardStep2({
             <Lightbulb size={20} className="text-accent flex-shrink-0" />
             <div className="flex-1 min-w-0">
               <p className="font-medium text-foreground">
-                <strong>{suggestedPayer.name.split(' ')[0]}</strong> should pay next
+                <strong>{suggestedPayer.name}</strong> should pay next
               </p>
               <p className="text-sm text-muted-foreground mt-0.5">
                 Balance: {formatBalance(suggestedPayer.balance, currency)}
@@ -110,7 +112,7 @@ export function WizardStep2({
               <SelectItem key={adult.id} value={adult.id}>
                 <span className="flex items-center gap-2">
                   <ParticipantAvatar participant={adult} size="sm" />
-                  {getShortName(adult)}
+                  {shortNames.get(adult.id) || adult.name}
                 </span>
               </SelectItem>
             ))}

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { fadeInUp } from '@/lib/animations'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 
 interface Participant {
@@ -42,6 +42,7 @@ export function WizardStep3({
   onAccountForFamilySizeChange,
   disabled = false,
 }: WizardStep3Props) {
+  const shortNames = useMemo(() => buildShortNameMap(participants), [participants])
   const [showDetails, setShowDetails] = useState(false)
 
   // Show toggle only when any selected participant belongs to a wallet_group
@@ -199,7 +200,7 @@ export function WizardStep3({
                               className="text-base text-foreground cursor-pointer flex-1 flex items-center gap-2"
                             >
                               <ParticipantAvatar participant={participant} size="sm" />
-                              {getShortName(participant)}
+                              {shortNames.get(participant.id) || participant.name}
                               {!participant.is_adult && (
                                 <span className="text-sm text-muted-foreground">
                                   (child)

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -28,7 +28,7 @@ import { useToast } from '@/hooks/use-toast'
 import { ExtractedItem, MappedItem } from '@/types/receipt'
 import { IndividualsDistribution, ExpenseCategory } from '@/types/expense'
 import { Participant } from '@/types/participant'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 
 interface ReceiptReviewSheetProps {
   open: boolean
@@ -169,6 +169,7 @@ export function ReceiptReviewSheet({
   }, [receiptError])
 
   const adultParticipants = getAdultParticipants()
+  const shortNames = useMemo(() => buildShortNameMap(participants), [participants])
   const baseCurrency = currentTrip?.default_currency ?? 'EUR'
   const knownCurrencies = useMemo(
     () => [baseCurrency, ...Object.keys(currentTrip?.exchange_rates ?? {})],
@@ -497,7 +498,7 @@ export function ReceiptReviewSheet({
           </SelectTrigger>
           <SelectContent>
             {adultParticipants.map(p => (
-              <SelectItem key={p.id} value={p.id}>{getShortName(p)}</SelectItem>
+              <SelectItem key={p.id} value={p.id}>{shortNames.get(p.id) || p.name}</SelectItem>
             ))}
           </SelectContent>
         </Select>
@@ -521,6 +522,7 @@ export function ReceiptReviewSheet({
                 index={i}
                 item={item}
                 participants={participants}
+                shortNames={shortNames}
                 onNameChange={name => updateItemName(i, name)}
                 onPriceChange={price => updateItemPrice(i, price)}
                 onToggleParticipant={pid => toggleParticipant(i, pid)}
@@ -688,6 +690,7 @@ interface ItemRowProps {
   index: number
   item: EditableItem
   participants: Participant[]
+  shortNames: Map<string, string>
   onNameChange: (name: string) => void
   onPriceChange: (price: string) => void
   onToggleParticipant: (pid: string) => void
@@ -699,6 +702,7 @@ function ItemRow({
   index,
   item,
   participants,
+  shortNames,
   onNameChange,
   onPriceChange,
   onToggleParticipant,
@@ -753,7 +757,7 @@ function ItemRow({
               ].join(' ')}
               title={p.name}
             >
-              {getShortName(p)}
+              {shortNames.get(p.id) || p.name}
             </button>
           )
         })}

--- a/src/lib/participantUtils.ts
+++ b/src/lib/participantUtils.ts
@@ -4,3 +4,30 @@ export function getShortName(p: Pick<Participant, 'name' | 'nickname'>): string 
   if (p.nickname) return p.nickname
   return p.name.split(' ')[0]
 }
+
+type NameableParticipant = Pick<Participant, 'id' | 'name' | 'nickname'>
+
+/** Pre-compute short display names, using full name when short names collide. */
+export function buildShortNameMap(participants: NameableParticipant[]): Map<string, string> {
+  const map = new Map<string, string>()
+
+  // First pass: compute short names (same logic as getShortName)
+  const entries = participants.map(p => ({
+    id: p.id,
+    short: p.nickname || p.name.split(' ')[0],
+    full: p.name,
+  }))
+
+  // Count short name occurrences
+  const counts = new Map<string, number>()
+  for (const { short } of entries) {
+    counts.set(short, (counts.get(short) || 0) + 1)
+  }
+
+  // Use full name when short name is ambiguous
+  for (const { id, short, full } of entries) {
+    map.set(id, (counts.get(short) || 0) > 1 ? full : short)
+  }
+
+  return map
+}

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -1,7 +1,7 @@
 import { Expense } from '@/types/expense'
 import { Participant } from '@/types/participant'
 import { Settlement } from '@/types/settlement'
-import { getShortName } from '@/lib/participantUtils'
+import { buildShortNameMap } from '@/lib/participantUtils'
 
 export interface ParticipantBalance {
   id: string
@@ -66,6 +66,7 @@ export function buildEntityMap(
   void trackingMode // kept for call-site compat; grouping is always wallet_group-based
   const entities: EntityInfo[] = []
   const participantToEntityId = new Map<string, string>()
+  const shortNames = buildShortNameMap(participants)
 
   const walletGroups = new Map<string, Participant[]>()
 
@@ -76,7 +77,7 @@ export function buildEntityMap(
       walletGroups.set(p.wallet_group, group)
     } else {
       // Standalone participant (no wallet_group)
-      entities.push({ id: p.id, name: getShortName(p), isFamily: false })
+      entities.push({ id: p.id, name: shortNames.get(p.id) || p.name, isFamily: false })
       participantToEntityId.set(p.id, p.id)
     }
   }
@@ -366,9 +367,10 @@ export function calculateWithinGroupBalances(
   }
 
   // Compute raw balances per member: balance = paid - share
+  const shortNames = buildShortNameMap(participants)
   const rawBalances = groupMembers.map(m => ({
     id: m.id,
-    name: getShortName(m),
+    name: shortNames.get(m.id) || m.name,
     is_adult: m.is_adult,
     totalPaid: paid.get(m.id) || 0,
     totalShare: share.get(m.id) || 0,


### PR DESCRIPTION
## Summary
- Add `buildShortNameMap()` utility that detects when two or more participants share the same short name (first name or nickname) and falls back to their full name for display
- Migrate all 10 consuming files (expense forms, wizard steps, split preview, expense cards, settlement forms, cost breakdown, receipt review, balance calculator) from per-call `getShortName()` to the pre-computed map
- Fix inline `.split(' ')[0]` in ExpenseForm and WizardStep2 suggested payer text

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — all 182 tests pass
- [ ] Manual: open trip with "Liis Krigul" and "Liis Köster" → both show full names everywhere
- [ ] Manual: participants with unique first names still show short names (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)