### PR TITLE
feat: auto-categorize expenses + compact desktop form

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -8,6 +8,7 @@ import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
 import { useAuth } from '@/contexts/AuthContext'
 import { calculateBalances, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { inferCategory } from '@/lib/categoryInference'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -62,6 +63,24 @@ export function ExpenseForm({
   )
   const [comment, setComment] = useState(initialValues?.comment || '')
   const [showMoreDetails, setShowMoreDetails] = useState(false)
+
+  // Track whether the user manually picked a category (don't override with auto-inference)
+  const categoryManuallySet = useRef(!!initialValues?.category)
+
+  const handleCategoryChange = (cat: ExpenseCategory) => {
+    categoryManuallySet.current = true
+    setCategory(cat)
+  }
+
+  // Auto-infer category from description (debounced)
+  useEffect(() => {
+    if (categoryManuallySet.current) return
+    const timer = setTimeout(() => {
+      const inferred = inferCategory(description)
+      if (inferred) setCategory(inferred)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [description])
 
   // Distribution state — always individuals
   const [selectedParticipants, setSelectedParticipants] = useState<string[]>([])
@@ -398,6 +417,28 @@ export function ExpenseForm({
         />
       </div>
 
+      {/* Category (inline pills) */}
+      <div className="space-y-1.5">
+        <Label>Category</Label>
+        <div className="flex flex-wrap gap-1.5">
+          {CATEGORIES.map(cat => (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => handleCategoryChange(cat)}
+              disabled={loading}
+              className={`h-7 px-3 text-xs rounded-full border transition-colors ${
+                category === cat
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background text-muted-foreground border-input hover:border-primary/50'
+              }`}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
       {/* Amount and Currency */}
       <div className="space-y-2">
         <Label htmlFor="amount">Amount</Label>
@@ -478,39 +519,24 @@ export function ExpenseForm({
       </div>
 
       {/* Split Mode Selector */}
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         <Label>Split Method</Label>
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            variant={splitMode === 'equal' ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => handleSplitModeChange('equal')}
-            disabled={loading}
-            className="flex-1"
-          >
-            Equal Split
-          </Button>
-          <Button
-            type="button"
-            variant={splitMode === 'percentage' ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => handleSplitModeChange('percentage')}
-            disabled={loading}
-            className="flex-1"
-          >
-            By %
-          </Button>
-          <Button
-            type="button"
-            variant={splitMode === 'amount' ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => handleSplitModeChange('amount')}
-            disabled={loading}
-            className="flex-1"
-          >
-            By Amount
-          </Button>
+        <div className="flex gap-1.5">
+          {([['equal', 'Equal'], ['percentage', 'By %'], ['amount', 'By Amount']] as const).map(([mode, label]) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => handleSplitModeChange(mode)}
+              disabled={loading}
+              className={`h-7 px-3 text-xs rounded-full border transition-colors ${
+                splitMode === mode
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background text-muted-foreground border-input hover:border-primary/50'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
         </div>
         {splitMode !== 'equal' && (
           <p className="text-xs text-muted-foreground">
@@ -702,27 +728,6 @@ export function ExpenseForm({
                     onChange={e => setExpenseDate(e.target.value)}
                     disabled={loading}
                   />
-                </div>
-
-                {/* Category */}
-                <div className="space-y-2">
-                  <Label htmlFor="category">Category</Label>
-                  <Select
-                    value={category}
-                    onValueChange={(value) => setCategory(value as ExpenseCategory)}
-                    disabled={loading}
-                  >
-                    <SelectTrigger id="category">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {CATEGORIES.map(cat => (
-                        <SelectItem key={cat} value={cat}>
-                          {cat}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                 </div>
 
                 {/* Comment */}

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -14,6 +14,7 @@ import { calculateBalances } from '@/services/balanceCalculator'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
+import { inferCategory } from '@/lib/categoryInference'
 
 import { X } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
@@ -124,6 +125,24 @@ function MobileWizard({
   // Proportional group splitting (per-expense toggle)
   const [accountForFamilySize, setAccountForFamilySize] = useState(false)
 
+  // Track whether user manually picked a category (don't override with auto-inference)
+  const categoryManuallySet = useRef(!!initialValues?.category)
+
+  // Auto-infer category from description (debounced)
+  useEffect(() => {
+    if (categoryManuallySet.current) return
+    const timer = setTimeout(() => {
+      const inferred = inferCategory(description)
+      if (inferred) setCategory(inferred)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [description])
+
+  const handleManualCategoryChange = (cat: string) => {
+    categoryManuallySet.current = true
+    setCategory(cat)
+  }
+
   const adults = getAdultParticipants()
 
   // Compute available currencies from trip settings
@@ -174,6 +193,7 @@ function MobileWizard({
         setSplitMode('equal')
         setParticipantSplitValues({})
         setAccountForFamilySize(false)
+        categoryManuallySet.current = false
         // Don't reset category, currency, date - likely to be reused
       }, 300)
       return () => clearTimeout(timer)
@@ -495,7 +515,7 @@ function MobileWizard({
               splitMode={splitMode}
               onSplitModeChange={handleSplitModeChange}
               category={category}
-              onCategoryChange={setCategory}
+              onCategoryChange={handleManualCategoryChange}
               expenseDate={expenseDate}
               onExpenseDateChange={setExpenseDate}
               comment={comment}

--- a/src/lib/categoryInference.ts
+++ b/src/lib/categoryInference.ts
@@ -1,0 +1,66 @@
+import type { ExpenseCategory } from '@/types/expense'
+
+const CATEGORY_KEYWORDS: Record<Exclude<ExpenseCategory, 'Other'>, string[]> = {
+  Food: [
+    'restaurant', 'dinner', 'lunch', 'breakfast', 'café', 'cafe', 'coffee',
+    'groceries', 'pizza', 'burger', 'snack', 'bar', 'drinks', 'food',
+    'bakery', 'kebab', 'sushi', 'brunch', 'beer', 'wine', 'ice cream',
+    'gelato', 'supermarket', 'market', 'deli',
+    // Estonian
+    'restoran', 'õhtusöök', 'lõunasöök', 'hommikusöök', 'kohv', 'kohvik',
+    'toidupood', 'snäkk', 'joogid', 'toit', 'pagariäri', 'õlu', 'vein',
+    'jäätis', 'pood', 'söök', 'eine', 'turg',
+  ],
+  Accommodation: [
+    'hotel', 'airbnb', 'hostel', 'apartment', 'villa', 'rent', 'booking',
+    'stay', 'resort', 'lodge', 'cabin', 'motel', 'bnb', 'accommodation',
+    // Estonian
+    'hotell', 'hostel', 'korter', 'majutus', 'üür', 'puhkemaja',
+    'suvila', 'maamaja', 'ööbimine',
+  ],
+  Transport: [
+    'taxi', 'uber', 'bus', 'train', 'flight', 'fuel', 'gas', 'petrol',
+    'parking', 'ferry', 'metro', 'lyft', 'car', 'rental', 'transfer',
+    'toll', 'highway', 'grab', 'bolt',
+    // Estonian
+    'takso', 'buss', 'rong', 'lend', 'lennuk', 'kütus', 'bensiin',
+    'parkimine', 'praam', 'auto', 'rent', 'teemaks', 'maantee',
+  ],
+  Activities: [
+    'museum', 'tour', 'ticket', 'excursion', 'hike', 'ski', 'surf',
+    'dive', 'concert', 'show', 'entrance', 'cinema', 'spa', 'massage',
+    'sauna', 'pool', 'golf', 'boat', 'kayak', 'zip', 'climb',
+    'theme park', 'zoo', 'aquarium', 'attraction',
+    // Estonian
+    'muuseum', 'ekskursioon', 'pilet', 'matk', 'suusatamine', 'kontsert',
+    'etendus', 'kino', 'massaaž', 'bassein', 'paat', 'loomaaed',
+    'akvaarium', 'vaatamisväärsus', 'tegevus',
+  ],
+  Training: [
+    'gym', 'workout', 'yoga', 'lesson', 'class', 'coach', 'instructor',
+    'training', 'session', 'course', 'personal trainer',
+    // Estonian
+    'jõusaal', 'trenn', 'treening', 'tund', 'kursus', 'treener',
+    'juhendaja', 'õppetund',
+  ],
+}
+
+/**
+ * Infer an expense category from a description using keyword matching.
+ * Returns null when no confident match is found.
+ */
+export function inferCategory(description: string): ExpenseCategory | null {
+  if (!description || description.trim().length < 2) return null
+
+  const lower = description.toLowerCase()
+
+  for (const [category, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
+    for (const keyword of keywords) {
+      if (lower.includes(keyword)) {
+        return category as ExpenseCategory
+      }
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- Auto-infer expense category from description using keyword matching (English + Estonian)
- Move category selector from hidden "More details" to inline pill chips on desktop ExpenseForm
- Compact split method buttons to small `rounded-full` pills matching category style
- Auto-inference runs debounced (300ms) on both desktop and mobile; manual pick stops it

## Test plan
- [ ] Desktop: type "Uber to airport" → category auto-selects Transport
- [ ] Desktop: type "Hotell" → Accommodation (Estonian keyword)
- [ ] Desktop: manually change category → stays even if description changes
- [ ] Desktop: edit existing expense → category stays as saved
- [ ] Mobile: auto-inference applied silently (visible in Step 4 Advanced)
- [ ] Visual: desktop form is more compact, participant list visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)