### PR TITLE
fix: settlement form mobile UX — bottom sheet + sticky footer

### DIFF
--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent, useRef, useEffect, useMemo } from 'react'
+import { useState, FormEvent, useRef, useEffect, useMemo, forwardRef, useImperativeHandle } from 'react'
 import { motion } from 'framer-motion'
 import { Clipboard, Check, ExternalLink, Lightbulb } from 'lucide-react'
 import { CreateSettlementInput } from '@/types/settlement'
@@ -19,6 +19,11 @@ import {
 import { fadeInUp } from '@/lib/animations'
 import { buildShortNameMap } from '@/lib/participantUtils'
 
+export interface SettlementFormHandle {
+  submit: () => void
+  loading: boolean
+}
+
 interface SettlementFormProps {
   onSubmit: (input: CreateSettlementInput) => Promise<void>
   onCancel?: () => void
@@ -28,6 +33,7 @@ interface SettlementFormProps {
   initialToId?: string
   recipientBankDetails?: { holder: string; iban: string } | null
   recipientName?: string
+  hideButtons?: boolean
 }
 
 function CopyButton({ value }: { value: string }) {
@@ -73,7 +79,7 @@ const BANK_SHORTCUTS = [
   },
 ]
 
-export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote, initialFromId, initialToId, recipientBankDetails, recipientName }: SettlementFormProps) {
+export const SettlementForm = forwardRef<SettlementFormHandle, SettlementFormProps>(function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote, initialFromId, initialToId, recipientBankDetails, recipientName, hideButtons }, ref) {
   const { currentTrip } = useCurrentTrip()
   const { participants } = useParticipantContext()
 
@@ -89,6 +95,13 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
   const [error, setError] = useState<string | null>(null)
   const [errorDetail, setErrorDetail] = useState<string | null>(null)
   const isMounted = useRef(true)
+
+  const formRef = useRef<HTMLFormElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    submit: () => formRef.current?.requestSubmit(),
+    loading,
+  }), [loading])
 
   useEffect(() => {
     return () => { isMounted.current = false }
@@ -192,6 +205,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
 
   return (
     <motion.form
+      ref={formRef}
       onSubmit={handleSubmit}
       className="space-y-4"
       variants={fadeInUp}
@@ -308,7 +322,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
           value={note}
           onChange={e => setNote(e.target.value)}
           placeholder="e.g., Paid in cash, Partial payment, etc."
-          rows={2}
+          rows={1}
           disabled={loading}
         />
       </div>
@@ -379,7 +393,7 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
                 href={bank.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex flex-col items-center gap-1.5 rounded-lg border border-border p-3 hover:bg-muted/50 transition-colors"
+                className="flex flex-col items-center gap-1.5 rounded-lg border border-border p-2 hover:bg-muted/50 transition-colors"
               >
                 <span className={`inline-flex items-center justify-center w-9 h-9 rounded-lg text-xs ${bank.badgeClass}`}>
                   {bank.badgeText}
@@ -395,25 +409,27 @@ export function SettlementForm({ onSubmit, onCancel, initialAmount, initialNote,
       )}
 
       {/* Submit Buttons */}
-      <div className="flex gap-3 pt-2">
-        <Button
-          type="submit"
-          disabled={loading}
-          className="flex-1"
-        >
-          {loading ? 'Confirming...' : 'Confirm Payment'}
-        </Button>
-        {onCancel && (
+      {!hideButtons && (
+        <div className="flex gap-3 pt-2">
           <Button
-            type="button"
-            onClick={onCancel}
+            type="submit"
             disabled={loading}
-            variant="outline"
+            className="flex-1"
           >
-            Cancel
+            {loading ? 'Confirming...' : 'Confirm Payment'}
           </Button>
-        )}
-      </div>
+          {onCancel && (
+            <Button
+              type="button"
+              onClick={onCancel}
+              disabled={loading}
+              variant="outline"
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+      )}
     </motion.form>
   )
-}
+})

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Receipt, FileDown, X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
@@ -15,10 +16,11 @@ import { exportSettlementPlanToPDF } from '@/services/pdfExport'
 import type { SettlementTransaction } from '@/services/settlementOptimizer'
 import type { CreateSettlementInput } from '@/types/settlement'
 import { SettlementPlan, BankDetails } from '@/components/SettlementPlan'
-import { SettlementForm } from '@/components/SettlementForm'
+import { SettlementForm, SettlementFormHandle } from '@/components/SettlementForm'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/lib/logger'
 
@@ -41,6 +43,9 @@ export function SettlementsPage() {
   const [bankDetailsMap, setBankDetailsMap] = useState<Record<string, BankDetails>>({})
   const [linkedParticipantIds, setLinkedParticipantIds] = useState<Set<string>>(new Set())
   const [retrying, setRetrying] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  const formRef = useRef<SettlementFormHandle>(null)
 
   const handleRefresh = useCallback(
     () => Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()]).then(() => {}),
@@ -197,11 +202,16 @@ export function SettlementsPage() {
   }
 
   const handleCustomSettlement = async (input: CreateSettlementInput) => {
-    const result = await createSettlement(input)
-    if (!result) {
-      throw new Error('Failed to record settlement')
+    setSubmitting(true)
+    try {
+      const result = await createSettlement(input)
+      if (!result) {
+        throw new Error('Failed to record settlement')
+      }
+      closeDialog()
+    } finally {
+      setSubmitting(false)
     }
-    closeDialog()
   }
 
   const handleRemind = async (transaction: SettlementTransaction, emails: string[]): Promise<void> => {
@@ -455,34 +465,74 @@ export function SettlementsPage() {
         </>}
       </div>
 
-      {/* Record Settlement Dialog */}
-      <Dialog open={showRecordDialog} onOpenChange={(open) => { if (!open) closeDialog() }}>
-        <DialogContent hideClose className="max-w-lg max-h-[85vh] p-0 gap-0 flex flex-col">
-          <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-            <div className="w-8" />
-            <DialogTitle className="text-base font-semibold">Settle Up</DialogTitle>
-            <button onClick={closeDialog} aria-label="Close"
-              className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors">
-              <X className="w-4 h-4 text-muted-foreground" />
-            </button>
-          </div>
-          <div className="flex-1 overflow-y-auto p-4">
-            <p className="text-sm text-muted-foreground mb-4">
-              Log a payment between participants.
-            </p>
-            <SettlementForm
-              onSubmit={handleCustomSettlement}
-              onCancel={closeDialog}
-              initialAmount={prefill?.amount}
-              initialNote={prefill?.note}
-              initialFromId={prefill?.fromId}
-              initialToId={prefill?.toId}
-              recipientBankDetails={prefill?.bankDetails}
-              recipientName={prefill?.recipientName}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Record Settlement — Sheet on mobile, Dialog on desktop */}
+      {isMobile ? (
+        <Sheet open={showRecordDialog} onOpenChange={(open) => { if (!open) closeDialog() }}>
+          <SheetContent side="bottom" hideClose className="flex flex-col p-0 rounded-t-2xl" style={{ height: '92dvh' }}>
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+              <div className="w-8" />
+              <SheetTitle className="text-base font-semibold">Settle Up</SheetTitle>
+              <button onClick={closeDialog} aria-label="Close"
+                className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors">
+                <X className="w-4 h-4 text-muted-foreground" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto overscroll-contain p-4">
+              <p className="text-sm text-muted-foreground mb-4">
+                Log a payment between participants.
+              </p>
+              <SettlementForm
+                ref={formRef}
+                onSubmit={handleCustomSettlement}
+                initialAmount={prefill?.amount}
+                initialNote={prefill?.note}
+                initialFromId={prefill?.fromId}
+                initialToId={prefill?.toId}
+                recipientBankDetails={prefill?.bankDetails}
+                recipientName={prefill?.recipientName}
+                hideButtons
+              />
+            </div>
+            <div className="shrink-0 border-t border-border px-4 py-3">
+              <Button
+                onClick={() => formRef.current?.submit()}
+                disabled={submitting}
+                className="w-full"
+              >
+                {submitting ? 'Confirming...' : 'Confirm Payment'}
+              </Button>
+            </div>
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <Dialog open={showRecordDialog} onOpenChange={(open) => { if (!open) closeDialog() }}>
+          <DialogContent hideClose className="max-w-lg max-h-[85vh] p-0 gap-0 flex flex-col">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+              <div className="w-8" />
+              <DialogTitle className="text-base font-semibold">Settle Up</DialogTitle>
+              <button onClick={closeDialog} aria-label="Close"
+                className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors">
+                <X className="w-4 h-4 text-muted-foreground" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto p-4">
+              <p className="text-sm text-muted-foreground mb-4">
+                Log a payment between participants.
+              </p>
+              <SettlementForm
+                onSubmit={handleCustomSettlement}
+                onCancel={closeDialog}
+                initialAmount={prefill?.amount}
+                initialNote={prefill?.note}
+                initialFromId={prefill?.fromId}
+                initialToId={prefill?.toId}
+                recipientBankDetails={prefill?.bankDetails}
+                recipientName={prefill?.recipientName}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- On mobile Full mode, the Settle Up dialog now uses a bottom **Sheet** (92dvh) instead of a Dialog, matching the app's established pattern (ExpenseWizard, QuickSettlementSheet)
- **Sticky footer** with Confirm Payment button so users don't have to scroll past payment details and bank shortcuts to submit
- Compacted form: Note textarea rows 2→1, bank shortcut padding p-3→p-2
- `SettlementForm` now supports `forwardRef` + `hideButtons` prop for external submit triggers
- Desktop Dialog unchanged

## Test plan
- [ ] Mobile Full mode: open Settle Up → form scrollable, Confirm button always visible at bottom
- [ ] Mobile Full mode with bank details: payment details + bank shortcuts scroll, button stays fixed
- [ ] Desktop Full mode: dialog unchanged, Cancel + Confirm buttons inline
- [ ] Quick mode: unchanged (already uses Sheet)
- [ ] Type-check clean, 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)