### PR TITLE
fix: compact payer suggestion as inline clickable hint

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -474,31 +474,25 @@ export function ExpenseForm({
 
       {/* Who Paid */}
       <div className="space-y-2">
-        <Label htmlFor="paidBy">Who Paid?</Label>
-
-        {/* Smart Payer Suggestion */}
-        {suggestedPayer && expenses.length > 0 && (
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            className="p-3 bg-accent/10 border border-accent/20 rounded-lg"
-          >
-            <div className="flex items-center justify-between">
-              <div className="flex-1">
-                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                  <Lightbulb size={16} className="text-accent" />
-                  <span><strong>{suggestedPayer.name}</strong> should pay next</span>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Current balance:{' '}
-                  <span className={getBalanceColorClass(suggestedPayer.balance)}>
-                    {formatBalance(suggestedPayer.balance, currentTrip?.default_currency || 'EUR')}
-                  </span>
-                </p>
-              </div>
-            </div>
-          </motion.div>
-        )}
+        <div className="flex items-center justify-between">
+          <Label htmlFor="paidBy">Who Paid?</Label>
+          {suggestedPayer && expenses.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setPaidBy(suggestedPayer.id)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Lightbulb size={12} className="text-accent" />
+              <span>
+                <strong className="font-medium text-foreground">{suggestedPayer.name}</strong>
+                {' '}should pay next{' '}
+                <span className={getBalanceColorClass(suggestedPayer.balance)}>
+                  ({formatBalance(suggestedPayer.balance, currentTrip?.default_currency || 'EUR')})
+                </span>
+              </span>
+            </button>
+          )}
+        </div>
 
         <Select
           value={paidBy}


### PR DESCRIPTION
## Summary
- Replace the ~65px tall "should pay next" banner in desktop ExpenseForm with a compact `text-xs` inline hint next to the "Who Paid?" label
- The hint is now **clickable** — sets the suggested payer on click (matching mobile behavior)
- Saves vertical space in the already tall Add Expense dialog

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 182 tests pass
- [ ] Desktop: open Add Expense dialog with existing expenses → suggestion appears inline next to label, clicking it selects the payer
- [ ] Desktop: open Add Expense dialog with no expenses → no suggestion shown
- [ ] Mobile wizard: unchanged (uses WizardStep2.tsx, not ExpenseForm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)