### PR TITLE
fix: add pwa-safe-bottom to SettlementsPage settlement footer

### DIFF
--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -524,7 +524,7 @@ export function SettlementsPage() {
                 hideButtons
               />
             </div>
-            <div className="shrink-0 border-t border-border px-4 py-3">
+            <div className="shrink-0 border-t border-border px-4 py-3 pwa-safe-bottom">
               <Button
                 onClick={() => formRef.current?.submit()}
                 disabled={submitting}


### PR DESCRIPTION
## Summary
- Add `pwa-safe-bottom` class to the "Confirm Payment" sticky footer in SettlementsPage
- Prevents the button from sitting behind the iPhone home indicator in PWA standalone mode
- Matches existing pattern in QuickSettlementSheet

## Test plan
- [ ] PWA on iPhone: "Confirm Payment" button has safe-area padding below home indicator
- [ ] Regular browser: no visual change

🤖 Generated with [Claude Code](https://claude.com/claude-code)