### PR TITLE
fix: settlement dialog sticky footer overlap on desktop

### DIFF
--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -415,8 +415,8 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
   )
 
   const scrollContent = (
-    <div className="relative flex-1 min-h-0">
-      <div ref={scrollRef} onScroll={handleScroll} className="h-full overflow-y-auto overscroll-contain px-6 py-4">
+    <div className="relative flex-1 min-h-0 overflow-hidden">
+      <div ref={scrollRef} onScroll={handleScroll} className="absolute inset-0 overflow-y-auto overscroll-contain px-6 py-4">
       {view === 'suggestions' ? (
         <div className="space-y-4">
           {allSettled ? (

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -546,13 +546,14 @@ export function SettlementsPage() {
                 <X className="w-4 h-4 text-muted-foreground" />
               </button>
             </div>
-            <div className="flex-1 overflow-y-auto p-4">
+            <div className="flex-1 min-h-0 overflow-y-auto p-4">
               <p className="text-sm text-muted-foreground mb-4">
                 Log a payment between participants.
               </p>
               <SettlementForm
+                ref={formRef}
+                hideButtons
                 onSubmit={handleCustomSettlement}
-                onCancel={closeDialog}
                 initialAmount={prefill?.amount}
                 initialNote={prefill?.note}
                 initialFromId={prefill?.fromId}
@@ -560,6 +561,16 @@ export function SettlementsPage() {
                 recipientBankDetails={prefill?.bankDetails}
                 recipientName={prefill?.recipientName}
               />
+            </div>
+            <div className="shrink-0 border-t border-border px-4 py-3 flex gap-3">
+              <Button
+                onClick={() => formRef.current?.submit()}
+                disabled={submitting}
+                className="flex-1"
+              >
+                {submitting ? 'Confirming...' : 'Confirm Payment'}
+              </Button>
+              <Button variant="outline" onClick={closeDialog}>Cancel</Button>
             </div>
           </DialogContent>
         </Dialog>


### PR DESCRIPTION
## Summary
- **QuickSettlementSheet**: Fix scroll container using `absolute inset-0` instead of `h-full` so content doesn't overflow behind the sticky footer on desktop
- **SettlementsPage desktop dialog**: Add sticky footer with Confirm/Cancel buttons (matching mobile Sheet pattern) instead of buttons inside the scroll area

## Test plan
- [ ] QuickSettlementSheet on desktop — footer below scroll content, no overlap with payment details card
- [ ] SettlementsPage desktop dialog — sticky footer with Confirm/Cancel, scrollable content above
- [ ] Both mobile sheets unchanged (no mobile code touched)
- [ ] `npm run type-check` ✅
- [ ] `npm test` ✅ (182 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)