### PR TITLE
feat: promote Settlements to mobile bottom tab bar

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -114,6 +114,7 @@ export function Layout() {
     const items = [
       { path: `/t/${tripCode}/dashboard`, label: 'Overview', requiresTrip: true },
       { path: `/t/${tripCode}/expenses`, label: 'Expenses', requiresTrip: true },
+      { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
     ]
     if (currentTrip?.enable_meals || currentTrip?.enable_activities) {
       items.push({ path: `/t/${tripCode}/planner`, label: 'Day Planner', requiresTrip: true })
@@ -133,7 +134,6 @@ export function Layout() {
     return [
       { path: '/', label: 'Events & Trips', requiresTrip: false },
       { path: `/t/${tripCode}/manage`, label: manageLabel, requiresTrip: true },
-      { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
     ]
   }
 


### PR DESCRIPTION
## Summary
- Move Settlements from the "More" overflow menu into the primary mobile bottom tab bar, positioned after Expenses
- Settling up is a core workflow that previously required two taps (More → Settlements) — now reachable in one tap

## Test plan
- [ ] Mobile: bottom tab bar shows Settlements between Expenses and Day Planner/Shopping
- [ ] Mobile: "More" menu no longer contains Settlements
- [ ] Mobile: tab bar not too crowded at 375px with all features enabled (max 7 items)
- [ ] Desktop: sidebar unchanged (uses separate `getDesktopNavItems()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)