### PR TITLE
fix: desktop Quick View Settle up dialog shows no content

### DIFF
--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -415,8 +415,8 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
   )
 
   const scrollContent = (
-    <div className="relative flex-1 min-h-0 overflow-hidden">
-      <div ref={scrollRef} onScroll={handleScroll} className="absolute inset-0 overflow-y-auto overscroll-contain px-6 py-4">
+    <div className="relative flex-1 min-h-0 flex flex-col overflow-hidden">
+      <div ref={scrollRef} onScroll={handleScroll} className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-6 py-4">
       {view === 'suggestions' ? (
         <div className="space-y-4">
           {allSettled ? (


### PR DESCRIPTION
## Summary
- Replace `absolute inset-0` scroll pattern with `flex-1 min-h-0` in `QuickSettlementSheet` `scrollContent`
- The `absolute` pattern requires a parent with defined height — works in mobile Sheet (explicit `92dvh`) but breaks in desktop Dialog which only has `max-h-[85vh]`, giving zero intrinsic height
- Fix works for both mobile (flex fills remaining space) and desktop (content has intrinsic height, clamped by `max-h`)

## Test plan
- [ ] Desktop: open Quick view → "Settle up" → dialog shows suggestions/form content
- [ ] Mobile: "Settle up" sheet still works correctly with keyboard handling
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (182/182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)