### PR TITLE
fix: add PreToolUse hook to block commits on main branch

### DIFF
--- a/.claude/hooks/no-commit-main.sh
+++ b/.claude/hooks/no-commit-main.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Block commits to main branch
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only check Bash tool calls
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+# Only check git commit commands
+if [[ "$COMMAND" != *"git commit"* ]]; then
+  exit 0
+fi
+
+# Block if on main
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [ "$CURRENT_BRANCH" = "main" ]; then
+  echo "BLOCKED: Cannot commit on 'main'. Create a feature branch first: git checkout -b fix/description" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/no-commit-main.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,10 @@ git checkout main && git pull
 git branch -d fix/description
 ```
 
+**Hard rules (enforced by hook):**
+- NEVER commit directly on `main`. The PreToolUse hook in `.claude/hooks/no-commit-main.sh` will block it.
+- If a file changes unexpectedly between your edit and commit, investigate (e.g. check `git diff`) — do not assume a "linter" or external tool made the change. It may be another session or editor process.
+
 - `gh issue close` takes **one issue at a time** (not multiple args in one call)
 - Commit messages end with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
 - Repo remote name: `kristjanelias-xtian/trip-splitter-pro`


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/no-commit-main.sh` — a PreToolUse hook that blocks `git commit` when on `main`
- Registers the hook in `.claude/settings.json`
- Adds hard rules to CLAUDE.md: never commit on `main`, investigate unexpected file changes instead of blaming external tools

## Test plan
- [ ] On `main`, attempt `git commit` via Claude Code — should be blocked with error message
- [ ] On a feature branch, `git commit` should succeed normally
- [ ] Verify `.claude/settings.json` has the `hooks` key
- [ ] Verify CLAUDE.md contains the new hard rules in the Git Workflow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)