### PR TITLE
fix: desktop ExpenseForm dialog sticky footer buttons

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -30,6 +30,7 @@ interface ExpenseFormProps {
   onCancel?: () => void
   initialValues?: Partial<CreateExpenseInput>
   submitLabel?: string
+  stickyFooter?: boolean
 }
 
 const CATEGORIES: ExpenseCategory[] = [
@@ -46,6 +47,7 @@ export function ExpenseForm({
   onCancel,
   initialValues,
   submitLabel = 'Add Expense',
+  stickyFooter = false,
 }: ExpenseFormProps) {
   const { currentTrip } = useCurrentTrip()
   const { participants, getAdultParticipants } = useParticipantContext()
@@ -370,14 +372,8 @@ export function ExpenseForm({
     return groups
   })()
 
-  return (
-    <motion.form
-      onSubmit={handleSubmit}
-      className="space-y-3"
-      variants={fadeInUp}
-      initial="initial"
-      animate="animate"
-    >
+  const formFields = (
+    <>
       {error && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
@@ -801,26 +797,52 @@ export function ExpenseForm({
         </AnimatePresence>
       </div>
 
-      {/* Submit Buttons */}
-      <div className="flex gap-3 pt-2">
+    </>
+  )
+
+  const buttons = (
+    <div className={stickyFooter ? 'shrink-0 border-t border-border px-1 pt-3 flex gap-3' : 'flex gap-3 pt-2'}>
+      <Button
+        type="submit"
+        disabled={loading}
+        className="flex-1"
+      >
+        {loading ? 'Saving...' : submitLabel}
+      </Button>
+      {onCancel && (
         <Button
-          type="submit"
+          type="button"
+          onClick={onCancel}
           disabled={loading}
-          className="flex-1"
+          variant="outline"
         >
-          {loading ? 'Saving...' : submitLabel}
+          Cancel
         </Button>
-        {onCancel && (
-          <Button
-            type="button"
-            onClick={onCancel}
-            disabled={loading}
-            variant="outline"
-          >
-            Cancel
-          </Button>
-        )}
-      </div>
+      )}
+    </div>
+  )
+
+  return (
+    <motion.form
+      onSubmit={handleSubmit}
+      className={stickyFooter ? 'flex flex-col min-h-0 flex-1' : 'space-y-3'}
+      variants={fadeInUp}
+      initial="initial"
+      animate="animate"
+    >
+      {stickyFooter ? (
+        <>
+          <div className="flex-1 overflow-y-auto overscroll-contain space-y-3 pb-3">
+            {formFields}
+          </div>
+          {buttons}
+        </>
+      ) : (
+        <>
+          {formFields}
+          {buttons}
+        </>
+      )}
     </motion.form>
   )
 }

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -48,16 +48,19 @@ export function ExpenseWizard({
   if (mode === 'edit' || !isMobile) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto" aria-describedby={undefined}>
+        <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col p-0 gap-0" aria-describedby={undefined}>
           <DialogTitle className="sr-only">
             {mode === 'edit' ? 'Edit Expense' : 'Add Expense'}
           </DialogTitle>
-          <ExpenseForm
-            onSubmit={onSubmit}
-            onCancel={() => onOpenChange(false)}
-            initialValues={initialValues}
-            submitLabel={mode === 'edit' ? 'Update Expense' : 'Add Expense'}
-          />
+          <div className="flex-1 min-h-0 flex flex-col px-6 py-6">
+            <ExpenseForm
+              onSubmit={onSubmit}
+              onCancel={() => onOpenChange(false)}
+              initialValues={initialValues}
+              submitLabel={mode === 'edit' ? 'Update Expense' : 'Add Expense'}
+              stickyFooter
+            />
+          </div>
         </DialogContent>
       </Dialog>
     )


### PR DESCRIPTION
## Summary
- Add `stickyFooter` prop to `ExpenseForm` that restructures the form into a flex column with scrollable fields and a pinned footer for submit buttons
- Update desktop `ExpenseWizard` dialog to use `flex flex-col` layout with `stickyFooter`, so buttons never scroll out of view when the form is tall (many participants, expanded "More details")
- Mobile wizard unchanged — it already uses the sticky footer pattern via `MobileWizard`

## Test plan
- [ ] Desktop: open "Add Expense" with many participants → buttons stay visible at bottom, form scrolls independently
- [ ] Desktop: edit an existing expense → same sticky footer behavior
- [ ] Mobile: add expense via wizard → unchanged behavior (uses MobileWizard, not affected)
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — all 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)