### PR TITLE
fix: participant linking error handling + email conflict retry

### DIFF
--- a/src/components/LinkParticipantDialog.tsx
+++ b/src/components/LinkParticipantDialog.tsx
@@ -3,6 +3,7 @@ import { UserCheck } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { logger } from '@/lib/logger'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -20,10 +21,11 @@ interface LinkParticipantDialogProps {
 
 export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDialogProps) {
   const { user, userProfile } = useAuth()
-  const { participants, linkUserToParticipant } = useParticipantContext()
+  const { participants, linkUserToParticipant, error, clearError } = useParticipantContext()
   const { isLinked } = useMyParticipant()
   const [open, setOpen] = useState(false)
   const [linking, setLinking] = useState(false)
+  const [linkError, setLinkError] = useState<string | null>(null)
 
   if (!user || isLinked) return null
 
@@ -32,17 +34,30 @@ export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDial
 
   const handleLink = async (participantId: string) => {
     setLinking(true)
+    setLinkError(null)
     const success = await linkUserToParticipant(participantId, user.id, user.email ?? undefined, userProfile?.display_name ?? undefined)
     setLinking(false)
 
     if (success) {
       setOpen(false)
       onLinked?.()
+    } else {
+      const msg = error || 'Failed to link — please try again'
+      setLinkError(msg)
+      logger.error('LinkParticipantDialog: link failed', { participantId, error: msg })
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (nextOpen) {
+      setLinkError(null)
+      clearError()
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         {trigger || (
           <Button variant="outline" size="sm" className="gap-2">
@@ -58,6 +73,12 @@ export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDial
             Link yourself to a participant so we can show your personal balance and pre-fill forms.
           </DialogDescription>
         </DialogHeader>
+        {linkError && (
+          <div className="rounded-lg bg-destructive/10 border border-destructive/20 px-4 py-3 mt-2">
+            <p className="text-sm font-medium text-destructive">Failed to link — please try again</p>
+            <p className="text-xs text-destructive/80 mt-1">{linkError}</p>
+          </div>
+        )}
         <div className="space-y-2 mt-4">
           {adultParticipants.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-4">

--- a/src/components/auth/SignInButton.tsx
+++ b/src/components/auth/SignInButton.tsx
@@ -1,5 +1,6 @@
 import { GoogleLogin } from '@react-oauth/google'
 import { useAuth } from '@/contexts/AuthContext'
+import { logger } from '@/lib/logger'
 
 interface SignInButtonProps {
   type?: 'icon' | 'standard'
@@ -16,6 +17,7 @@ export function SignInButton({ type = 'icon' }: SignInButtonProps) {
         }
       }}
       onError={() => {
+        logger.error('Google Sign-In failed')
         console.error('Google Sign-In failed')
       }}
       size="medium"

--- a/src/contexts/ParticipantContext.tsx
+++ b/src/contexts/ParticipantContext.tsx
@@ -9,6 +9,7 @@ import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { withTimeout } from '@/lib/fetchWithTimeout'
 import { useAbortController } from '@/hooks/useAbortController'
+import { logger } from '@/lib/logger'
 
 interface ParticipantContextType {
   participants: Participant[]
@@ -214,13 +215,44 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
         controller
       )
 
-      if (linkError) throw linkError
+      let emailApplied = !!userEmail
+      if (linkError) {
+        // If email unique constraint violation, retry without email
+        const isEmailConflict = linkError.message?.includes('participants_trip_email_unique') ||
+          linkError.code === '23505'
+        if (isEmailConflict && userEmail) {
+          logger.warn('linkUserToParticipant: email conflict, retrying without email', { participantId, userEmail })
+          emailApplied = false
+          const retryPayload: Record<string, unknown> = { user_id: userId }
+          if (displayName) {
+            retryPayload.name = displayName
+            const existing = participants.find(p => p.id === participantId)
+            if (existing && !existing.nickname && existing.name !== displayName) {
+              retryPayload.nickname = existing.name
+            }
+          }
+          const retryController = new AbortController()
+          const { error: retryError } = await withTimeout<any>(
+            (supabase as any)
+              .from('participants')
+              .update(retryPayload)
+              .eq('id', participantId)
+              .abortSignal(retryController.signal),
+            15000,
+            'Linking user timed out. Please check your connection and try again.',
+            retryController
+          )
+          if (retryError) throw retryError
+        } else {
+          throw linkError
+        }
+      }
 
       setParticipants(prev =>
         prev.map(p => {
           if (p.id !== participantId) return p
           const updates: Partial<Participant> = { user_id: userId }
-          if (userEmail) updates.email = userEmail
+          if (emailApplied) updates.email = userEmail
           if (displayName) {
             updates.name = displayName
             if (!p.nickname && p.name !== displayName) {
@@ -233,7 +265,9 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
 
       return true
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to link user to participant')
+      const msg = err instanceof Error ? err.message : 'Failed to link user to participant'
+      setError(msg)
+      logger.error('linkUserToParticipant failed', { participantId, userId, error: msg })
       console.error('Error linking user to participant:', err)
       return false
     }


### PR DESCRIPTION
## Summary
- **LinkParticipantDialog**: Shows error message when "This is me" linking fails (previously silent failure with no feedback). Clears error on dialog reopen. Logs failures to Grafana via `logger.error`.
- **ParticipantContext**: When `linkUserToParticipant` fails with email unique constraint violation (`participants_trip_email_unique` / code `23505`), automatically retries without setting email — just links `user_id`, `name`, `nickname`. This handles cases where another participant already has the same email in the trip.
- **SignInButton**: Adds `logger.error` alongside `console.error` for Google Sign-In failures so they appear in Grafana.

## Context
User reported "fatal error" when trying to link participant. Root cause: `LinkParticipantDialog` had zero error handling — when `linkUserToParticipant` returned `false`, the dialog stayed open with no feedback.

## Test plan
- [x] `npm run type-check` passes clean
- [x] All 182 unit tests pass
- [ ] Manual: open trip as authenticated user, click "This is me", verify error banner appears if link fails
- [ ] Manual: verify email conflict scenario (two participants with same email) succeeds via retry
- [ ] Check Grafana logs for `linkUserToParticipant failed` and `Google Sign-In failed` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)