### PR TITLE
fix: route unauth shared link recipients to Full mode (#585)

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ import { Link } from 'react-router-dom'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
 import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
 import { CostBreakdownDialog } from '@/components/CostBreakdownDialog'
+import { OnboardingPrompts } from '@/components/OnboardingPrompts'
 import { ParticipantBalance } from '@/services/balanceCalculator'
 import type { Participant } from '@/types/participant'
 
@@ -133,6 +134,8 @@ export function DashboardPage() {
           )}
         </div>
       </div>
+
+      <OnboardingPrompts />
 
       {loading ? (
         <PageLoadingState />

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation, Link } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { SignInButton } from '@/components/auth/SignInButton'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -34,6 +36,7 @@ import {
 export function QuickGroupDetailPage() {
   const navigate = useNavigate()
   const location = useLocation()
+  const { user } = useAuth()
   const { currentTrip, loading: tripLoading } = useCurrentTrip()
   const { myParticipant, isLinked } = useMyParticipant()
   const { participants, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
@@ -136,10 +139,32 @@ export function QuickGroupDetailPage() {
       ) : !isLinked ? (
         <Card className="mb-6">
           <CardContent className="pt-6 text-center">
-            <p className="text-muted-foreground mb-4">
-              Link yourself to a participant to see your balance
-            </p>
-            <LinkParticipantDialog />
+            {!user ? (
+              <>
+                <p className="text-muted-foreground mb-2">
+                  Quick view tracks your personal balance.
+                </p>
+                <p className="text-muted-foreground mb-4 text-sm">
+                  Sign in to link yourself to a participant, or view the full trip overview.
+                </p>
+                <div className="flex flex-col items-center gap-3">
+                  <SignInButton type="standard" />
+                  <Link
+                    to={`/t/${currentTrip.trip_code}/dashboard`}
+                    className="text-sm text-accent hover:underline"
+                  >
+                    View full trip overview
+                  </Link>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-muted-foreground mb-4">
+                  Link yourself to a participant to see your balance
+                </p>
+                <LinkParticipantDialog />
+              </>
+            )}
           </CardContent>
         </Card>
       ) : (

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -18,9 +18,27 @@ import { TripNotFoundPage } from './pages/TripNotFoundPage'
 import { QuickGroupDetailPage } from './pages/QuickGroupDetailPage'
 import { QuickHistoryPage } from './pages/QuickHistoryPage'
 import { useUserPreferences } from './contexts/UserPreferencesContext'
+import { useAuth } from './contexts/AuthContext'
+import { Loader2 } from 'lucide-react'
 
 function TripModeRedirect() {
   const { mode } = useUserPreferences()
+  const { user, loading: authLoading } = useAuth()
+
+  // Wait for auth to resolve before routing — prevents flash where auth users briefly see dashboard
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  // Unauth users always get Full mode — Quick view requires auth + participant linking
+  if (!user) {
+    return <Navigate to="dashboard" replace />
+  }
+
   return <Navigate to={mode === 'quick' ? 'quick' : 'dashboard'} replace />
 }
 


### PR DESCRIPTION
## Summary
- **TripModeRedirect**: unauth users landing on `/t/:tripCode` now redirect to `dashboard` (Full mode) instead of Quick view, which requires auth + participant linking
- **QuickGroupDetailPage**: unauth users who manually toggle to Quick mode see a helpful card with sign-in button + "View full trip overview" link instead of a broken LinkParticipantDialog
- **DashboardPage**: added `OnboardingPrompts` so unauth users see a dismissible sign-in nudge

Fixes #585

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — all 182 tests pass
- [ ] Open a trip link in incognito (mobile viewport) — should land on Dashboard, not Quick view
- [ ] On Dashboard as unauth — sign-in nudge card should appear (dismissible)
- [ ] Toggle to Quick mode while unauth — should see welcome card with sign-in + "View full overview" link
- [ ] Sign in — mode preference resumes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)