### PR TITLE
feat: auto-link participants by email match

### DIFF
--- a/src/components/TripRouteGuard.tsx
+++ b/src/components/TripRouteGuard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useAutoLinkParticipant } from '@/hooks/useAutoLinkParticipant'
 import { useTripContext } from '@/contexts/TripContext'
 import { LinkParticipantDialog } from '@/components/LinkParticipantDialog'
 import { Card, CardContent } from '@/components/ui/card'
@@ -24,6 +25,7 @@ export function TripRouteGuard({ children }: TripRouteGuardProps) {
   const { currentTrip, tripCode, loading } = useCurrentTrip()
   const { user } = useAuth()
   const { isLinked, loading: participantsLoading } = useMyParticipant()
+  const { autoLinked } = useAutoLinkParticipant()
   const { error, refreshTrips } = useTripContext()
   const navigate = useNavigate()
 
@@ -76,7 +78,7 @@ export function TripRouteGuard({ children }: TripRouteGuardProps) {
 
   return (
     <>
-      {user && !participantsLoading && !isLinked && (
+      {user && !participantsLoading && !isLinked && !autoLinked && (
         <div className="mb-4 p-3 rounded-lg border border-border bg-accent/30 flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <UserCheck size={16} />

--- a/src/hooks/useAutoLinkParticipant.test.tsx
+++ b/src/hooks/useAutoLinkParticipant.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAutoLinkParticipant } from './useAutoLinkParticipant'
+import { buildParticipant } from '@/test/factories'
+
+const mockToast = vi.fn()
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}))
+
+const mockAuth: any = {
+  user: null,
+  userProfile: null,
+}
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+const mockParticipantCtx: any = {
+  participants: [],
+  loading: false,
+  linkUserToParticipant: vi.fn(),
+}
+vi.mock('@/contexts/ParticipantContext', () => ({
+  useParticipantContext: () => mockParticipantCtx,
+}))
+
+const mockCurrentTrip: any = {
+  currentTrip: null,
+}
+vi.mock('@/hooks/useCurrentTrip', () => ({
+  useCurrentTrip: () => mockCurrentTrip,
+}))
+
+beforeEach(() => {
+  mockAuth.user = null
+  mockAuth.userProfile = null
+  mockCurrentTrip.currentTrip = null
+  mockParticipantCtx.participants = []
+  mockParticipantCtx.loading = false
+  mockParticipantCtx.linkUserToParticipant = vi.fn().mockResolvedValue(true)
+  mockToast.mockClear()
+})
+
+describe('useAutoLinkParticipant', () => {
+  it('returns autoLinked=false when user is not authenticated', () => {
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', email: 'alice@example.com' }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    expect(result.current.autoLinked).toBe(false)
+    expect(mockParticipantCtx.linkUserToParticipant).not.toHaveBeenCalled()
+  })
+
+  it('returns autoLinked=false when participants are loading', () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.loading = true
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    expect(result.current.autoLinked).toBe(false)
+  })
+
+  it('auto-links when exactly one email match', async () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockAuth.userProfile = { display_name: 'Alice Smith' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Alice', email: 'alice@example.com', is_adult: true }),
+      buildParticipant({ id: 'p2', name: 'Bob', email: 'bob@example.com', is_adult: true }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+
+    // Wait for async linkUserToParticipant to resolve
+    await act(async () => {})
+
+    expect(mockParticipantCtx.linkUserToParticipant).toHaveBeenCalledWith(
+      'p1', 'u1', 'alice@example.com', 'Alice Smith'
+    )
+    expect(result.current.autoLinked).toBe(true)
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "You've been linked!" })
+    )
+  })
+
+  it('does not link when email matches are ambiguous (2+)', async () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Alice A', email: 'alice@example.com', is_adult: true }),
+      buildParticipant({ id: 'p2', name: 'Alice B', email: 'alice@example.com', is_adult: true }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    await act(async () => {})
+
+    expect(mockParticipantCtx.linkUserToParticipant).not.toHaveBeenCalled()
+    expect(result.current.autoLinked).toBe(false)
+  })
+
+  it('does not link when no email matches', async () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Bob', email: 'bob@example.com', is_adult: true }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    await act(async () => {})
+
+    expect(mockParticipantCtx.linkUserToParticipant).not.toHaveBeenCalled()
+    expect(result.current.autoLinked).toBe(false)
+  })
+
+  it('skips participants already linked to another user', async () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Alice', email: 'alice@example.com', user_id: 'other-user', is_adult: true }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    await act(async () => {})
+
+    expect(mockParticipantCtx.linkUserToParticipant).not.toHaveBeenCalled()
+    expect(result.current.autoLinked).toBe(false)
+  })
+
+  it('skips child participants', async () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Alice Jr', email: 'alice@example.com', is_adult: false }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    await act(async () => {})
+
+    expect(mockParticipantCtx.linkUserToParticipant).not.toHaveBeenCalled()
+    expect(result.current.autoLinked).toBe(false)
+  })
+
+  it('does not link when user is already linked in trip', async () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Alice', email: 'alice@example.com', user_id: 'u1', is_adult: true }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    await act(async () => {})
+
+    expect(mockParticipantCtx.linkUserToParticipant).not.toHaveBeenCalled()
+    expect(result.current.autoLinked).toBe(false)
+  })
+
+  it('handles case-insensitive email matching', async () => {
+    mockAuth.user = { id: 'u1', email: 'Alice@Example.COM' }
+    mockAuth.userProfile = { display_name: 'Alice' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Alice', email: 'alice@example.com', is_adult: true }),
+    ]
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    await act(async () => {})
+
+    expect(mockParticipantCtx.linkUserToParticipant).toHaveBeenCalled()
+    expect(result.current.autoLinked).toBe(true)
+  })
+
+  it('stays autoLinked=false when linkUserToParticipant fails', async () => {
+    mockAuth.user = { id: 'u1', email: 'alice@example.com' }
+    mockCurrentTrip.currentTrip = { id: 'trip-1' }
+    mockParticipantCtx.participants = [
+      buildParticipant({ id: 'p1', name: 'Alice', email: 'alice@example.com', is_adult: true }),
+    ]
+    mockParticipantCtx.linkUserToParticipant = vi.fn().mockResolvedValue(false)
+
+    const { result } = renderHook(() => useAutoLinkParticipant())
+    await act(async () => {})
+
+    expect(result.current.autoLinked).toBe(false)
+    expect(mockToast).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useAutoLinkParticipant.ts
+++ b/src/hooks/useAutoLinkParticipant.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useToast } from '@/hooks/use-toast'
+import { logger } from '@/lib/logger'
+
+/**
+ * Auto-links the authenticated user to a participant if their email
+ * matches exactly one unlinked adult participant. Silent operation
+ * with a toast on success.
+ */
+export function useAutoLinkParticipant(): { autoLinked: boolean } {
+  const { user, userProfile } = useAuth()
+  const { participants, loading, linkUserToParticipant } = useParticipantContext()
+  const { currentTrip } = useCurrentTrip()
+  const { toast } = useToast()
+  const [autoLinked, setAutoLinked] = useState(false)
+  const attemptedForTripRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!currentTrip?.id) {
+      attemptedForTripRef.current = null
+      setAutoLinked(false)
+      return
+    }
+
+    if (attemptedForTripRef.current === currentTrip.id) return
+    if (!user?.email) return
+    if (loading || participants.length === 0) return
+
+    // Already linked to this trip
+    if (participants.some(p => p.user_id === user.id)) return
+
+    attemptedForTripRef.current = currentTrip.id
+
+    const userEmailLower = user.email.toLowerCase()
+    const matches = participants.filter(
+      p => p.email?.toLowerCase() === userEmailLower && !p.user_id && p.is_adult
+    )
+
+    if (matches.length !== 1) return
+
+    const match = matches[0]
+    const displayName = userProfile?.display_name ?? undefined
+
+    linkUserToParticipant(match.id, user.id, user.email, displayName).then(success => {
+      if (success) {
+        setAutoLinked(true)
+        toast({
+          title: 'You\'ve been linked!',
+          description: `Linked as ${match.nickname || match.name}`,
+        })
+        logger.info('Auto-linked participant by email match', {
+          participantId: match.id,
+          tripId: currentTrip.id,
+        })
+      }
+    })
+  }, [user, userProfile, participants, loading, currentTrip, linkUserToParticipant, toast])
+
+  return { autoLinked }
+}


### PR DESCRIPTION
## Summary

- New `useAutoLinkParticipant` hook: when an authenticated user opens a shared trip link, auto-links them to a participant if their email matches exactly one unlinked adult participant
- Shows a success toast on auto-link; falls back to manual "This is me" banner for ambiguous/no matches
- `TripRouteGuard` hides the banner while auto-link is in progress to prevent flash

## Edge cases handled

- No user email → skip, show banner
- Zero or 2+ email matches → skip, show banner (ambiguous)
- Participant already linked to another user → filtered out
- Child participants → filtered out
- `linkUserToParticipant` fails → `autoLinked` stays false, banner shows
- Trip navigation → ref resets, re-evaluates for new trip

## Test plan

- [x] `npm run type-check` passes clean
- [x] `npm test` — all 192 tests pass (10 new hook tests)
- [ ] Manual: create trip, add participant with your email, open shared link signed in → auto-links with toast
- [ ] Manual: participant without email → manual "This is me" banner shows
- [ ] Manual: two participants with same email → manual banner shows (ambiguous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)