### PR TITLE
feat: discover trips by participant email match on home page

### DIFF
--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -49,18 +49,37 @@ export function TripProvider({ children }: { children: ReactNode }) {
       }
 
       // Authenticated: scope to trips where user is creator OR participant
-      const { data: participantRows, error: participantError } = await withTimeout(
-        supabase.from('participants').select('trip_id').eq('user_id', user.id).abortSignal(signal),
-        10000,
-        'Loading trip membership timed out.'
-      )
+      // Run both participant lookups in parallel (user_id link + email match)
+      const [participantResult, emailResult] = await Promise.all([
+        withTimeout(
+          supabase.from('participants').select('trip_id').eq('user_id', user.id).abortSignal(signal),
+          10000,
+          'Loading trip membership timed out.'
+        ),
+        user.email
+          ? withTimeout(
+              supabase.from('participants').select('trip_id')
+                .ilike('email', user.email)
+                .is('user_id', null)
+                .abortSignal(signal),
+              10000,
+              'Loading email-matched trips timed out.'
+            )
+          : Promise.resolve({ data: [], error: null } as { data: { trip_id: string }[] | null; error: any }),
+      ])
       if (signal.aborted) return
-      if (participantError) throw participantError
+      if (participantResult.error) throw participantResult.error
 
-      const participantTripIds = (participantRows ?? []).map((r: any) => r.trip_id as string)
+      if (emailResult.error) {
+        logger.warn('Failed to fetch email-matched trips', { error: emailResult.error.message })
+      }
 
-      const filter = participantTripIds.length > 0
-        ? `created_by.eq.${user.id},id.in.(${participantTripIds.join(',')})`
+      const participantTripIds = (participantResult.data ?? []).map((r: any) => r.trip_id as string)
+      const emailTripIds = (emailResult.data ?? []).map((r: any) => r.trip_id as string)
+      const allTripIds = [...new Set([...participantTripIds, ...emailTripIds])]
+
+      const filter = allTripIds.length > 0
+        ? `created_by.eq.${user.id},id.in.(${allTripIds.join(',')})`
         : `created_by.eq.${user.id}`
 
       if (signal.aborted) return


### PR DESCRIPTION
## Summary

- Adds an email-based participant query to `fetchTrips()` that runs **in parallel** with the existing `user_id` lookup
- When a trip organizer adds a participant with someone's email, that person now sees the trip on their home page after signing in — no shared link needed
- `.ilike('email', user.email)` for case-insensitive matching, `.is('user_id', null)` to skip already-linked participants
- Email query failure is non-fatal (logs warning, continues with existing trips)
- Once the user clicks into the discovered trip, `useAutoLinkParticipant` fires and links them automatically

## Test plan

- [x] `npm run type-check` — passes clean
- [x] `npm test` — all 192 tests pass
- [ ] Manual: create trip as user A, add participant with user B's email → sign in as user B → trip appears on home page → click into trip → auto-linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)