### PR TITLE
fix: hide scan receipt CTA on desktop home page (#597)

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -340,7 +340,7 @@ export function HomePage() {
           <button
             onClick={handleScanTap}
             disabled={loading}
-            className="w-full flex items-center justify-between px-5 py-4 rounded-2xl bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all mb-6 disabled:opacity-50"
+            className="w-full lg:hidden flex items-center justify-between px-5 py-4 rounded-2xl bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all mb-6 disabled:opacity-50"
           >
             <div className="flex items-center gap-3">
               <div className="w-9 h-9 rounded-full bg-primary-foreground/20 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Add `lg:hidden` to the "Scan a Receipt" CTA button on the home page so it only shows on mobile/tablet
- Scanning receipts is a phone-only action; showing it on desktop is confusing

Closes #597

## Test plan
- [ ] Verify scan CTA is visible on mobile viewport
- [ ] Verify scan CTA is hidden on desktop viewport (≥1024px)
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (192 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)