### PR TITLE
fix: only show Remove on localStorage-only trips

### DIFF
--- a/src/components/quick/GroupActions.tsx
+++ b/src/components/quick/GroupActions.tsx
@@ -17,11 +17,12 @@ import { EyeOff, X } from 'lucide-react'
 interface GroupActionsProps {
   tripCode: string
   tripName: string
+  showRemove?: boolean
   onHidden?: () => void
   onLeft?: () => void
 }
 
-export function GroupActions({ tripCode, tripName, onHidden, onLeft }: GroupActionsProps) {
+export function GroupActions({ tripCode, tripName, showRemove, onHidden, onLeft }: GroupActionsProps) {
   return (
     <div className="flex gap-2">
       <Button
@@ -37,7 +38,7 @@ export function GroupActions({ tripCode, tripName, onHidden, onLeft }: GroupActi
         Hide
       </Button>
 
-      <AlertDialog>
+      {showRemove && <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground">
             <X size={14} />
@@ -63,7 +64,7 @@ export function GroupActions({ tripCode, tripName, onHidden, onLeft }: GroupActi
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
-      </AlertDialog>
+      </AlertDialog>}
     </div>
   )
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -168,6 +168,7 @@ export function HomePage() {
                   <GroupActions
                     tripCode={trip.trip_code}
                     tripName={trip.name}
+                    showRemove={trip.created_by !== user?.id && myBalance === null}
                     onHidden={() => handleHidden(trip.trip_code)}
                     onLeft={() => handleLeft(trip.trip_code)}
                   />


### PR DESCRIPTION
## Summary
- Only show the "Remove" button on trip cards where the trip is localStorage-only (user is not the creator AND has no linked participant)
- Trips backed by Supabase (created by user or user is a participant) only show "Hide" — Remove would be ineffective since the trip reappears on next fetch
- Added `showRemove` prop to `GroupActions` component

## Test plan
- [ ] Type-check passes (`npm run type-check`)
- [ ] All 192 unit tests pass (`npm test`)
- [ ] On home page, trips where user is creator show only "Hide"
- [ ] Trips where user has a linked participant show only "Hide"
- [ ] Trips visited via shared link (no participant link, not creator) show both "Hide" and "Remove"

🤖 Generated with [Claude Code](https://claude.com/claude-code)