### PR TITLE
fix: optimize anonymous trip fetch + improve empty state UX (#603)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,16 @@ Mode is stored per-user in `user_preferences.preferred_mode` and synced from Sup
 
 All contexts wrap Supabase calls in `withTimeout` (15 s, from `src/lib/fetchWithTimeout.ts`) so a slow network never leaves the UI stuck.
 
+### Home Page Trip Visibility
+
+The home page shows different trip lists depending on auth state:
+
+**Anonymous users:** Trip references (code + name) are cached in `localStorage` key `trip-splitter:my-trips` (max 100 entries). Trip data always lives in Supabase. `useCurrentTrip` auto-populates localStorage when any trip URL is visited. `TripContext` fetches only these specific trips from DB by `trip_code` (not all trips). If localStorage is cleared (iOS WebKit eviction, new device), the reference list is empty with no recovery path — sign-in is the only way to persist trip links permanently.
+
+**Authenticated users:** `TripContext` fetches trips from DB via three paths: (1) user is creator, (2) user linked as participant (`user_id`), (3) email discovery — someone else added a participant with the user's email but no `user_id` link yet. Then merges any localStorage trips not already in the result. `HomePage` splits these into "My Trips" (creator or linked participant with balance) and "Visited" (localStorage-only, no participant record). Email-discovered trips appear in "My Trips" since they have a participant record.
+
+**Key invariant:** `ensureTripLoaded(tripCode)` in `useCurrentTrip` handles navigation to any trip URL regardless of auth state — even if the trip isn't in the local array. The home page list is a convenience view; the URL is always the access token.
+
 ### Tracking Modes (expense splitting)
 
 All expenses use a single distribution type: `individuals`. The `tracking_mode` column still exists in the DB but is always `'individuals'` for new trips (UI selector removed).

--- a/src/contexts/TripContext.test.tsx
+++ b/src/contexts/TripContext.test.tsx
@@ -3,6 +3,12 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { TripProvider, useTripContext } from './TripContext'
 import { buildTrip } from '@/test/factories'
 
+const mockGetMyTrips = vi.hoisted(() => vi.fn().mockReturnValue([]))
+
+vi.mock('@/lib/myTripsStorage', () => ({
+  getMyTrips: mockGetMyTrips,
+}))
+
 const mockSupabase = vi.hoisted(() => ({
   from: vi.fn(),
   auth: {
@@ -51,7 +57,9 @@ function TestConsumer() {
 describe('TripContext', () => {
   beforeEach(() => {
     mockAuth.loading = false
+    mockAuth.user = null
     mockSupabase.from.mockReset()
+    mockGetMyTrips.mockReturnValue([])
   })
 
   it('waits for authLoading=false before fetching', async () => {
@@ -70,14 +78,21 @@ describe('TripContext', () => {
     expect(mockSupabase.from).not.toHaveBeenCalled()
   })
 
-  it('sets trips from response', async () => {
+  it('sets trips from response (anonymous with localStorage trips)', async () => {
     const trips = [
       buildTrip({ id: 'trip-1', name: 'Summer', trip_code: 'summer-trip-Ab1234' }),
-      buildTrip({ id: 'trip-2', name: 'Winter' }),
+      buildTrip({ id: 'trip-2', name: 'Winter', trip_code: 'winter-trip-Cd5678' }),
     ]
 
+    mockGetMyTrips.mockReturnValue([
+      { tripCode: 'summer-trip-Ab1234', tripName: 'Summer', lastAccessed: '2025-01-01', addedAt: '2025-01-01' },
+      { tripCode: 'winter-trip-Cd5678', tripName: 'Winter', lastAccessed: '2025-01-01', addedAt: '2025-01-01' },
+    ])
+
     mockSupabase.from.mockReturnValue({
-      select: () => ({ order: () => ({ abortSignal: () => Promise.resolve({ data: trips, error: null }) }) }),
+      select: () => ({
+        in: () => ({ order: () => ({ abortSignal: () => Promise.resolve({ data: trips, error: null }) }) }),
+      }),
     })
 
     render(
@@ -95,7 +110,25 @@ describe('TripContext', () => {
     expect(screen.getByTestId('tripByCode').textContent).toBe('Summer')
   })
 
+  it('anonymous with empty localStorage sets empty trips without DB call', async () => {
+    mockGetMyTrips.mockReturnValue([])
+
+    render(
+      <TripProvider>
+        <TestConsumer />
+      </TripProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('count').textContent).toBe('0')
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
   it('getTripById returns undefined when not found', async () => {
+    mockGetMyTrips.mockReturnValue([])
     mockSupabase.from.mockReturnValue({
       select: () => ({ order: () => ({ abortSignal: () => Promise.resolve({ data: [], error: null }) }) }),
     })

--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -36,9 +36,22 @@ export function TripProvider({ children }: { children: ReactNode }) {
     setError(null)
     try {
       if (!user) {
-        // Anonymous: fetch all trips so URL-based access (/t/:tripCode) keeps working
+        // Anonymous: fetch only trips the user previously visited (tracked in localStorage).
+        // We intentionally do NOT fetch all trips — that would be a scalability issue and
+        // the data is never displayed on the home page anyway (HomePage reads localStorage
+        // directly for anonymous users). Navigation to new trip URLs is handled by
+        // ensureTripLoaded() which fetches a single trip by trip_code on demand.
+        const localTrips = getMyTrips()
+        const codes = localTrips.map(t => t.tripCode)
+        if (codes.length === 0) {
+          setTrips([])
+          return
+        }
         const { data, error: fetchError } = await withTimeout(
-          supabase.from('trips').select('*').order('created_at', { ascending: false }).abortSignal(signal),
+          supabase.from('trips').select('*')
+            .in('trip_code', codes)
+            .order('created_at', { ascending: false })
+            .abortSignal(signal),
           15000,
           'Loading trips timed out. Please check your connection and try again.'
         )

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -24,9 +24,10 @@ export function ConditionalHomePage() {
   const fromTrip = !!(location.state as any)?.fromTrip
 
   // Track sign-in transition (null → non-null user) to avoid redirecting
-  // to a stranger's trip. When unauthenticated, TripContext fetches ALL trips
-  // (RLS is open). On sign-in there's a render cycle where `user` is set but
-  // `trips` still contains all trips — skip the redirect for that cycle.
+  // to a stranger's trip. When unauthenticated, TripContext fetches only
+  // localStorage-known trips (by trip_code). On sign-in there's a render
+  // cycle where `user` is set but `trips` still contains the old set —
+  // skip the redirect for that cycle.
   const prevUserIdRef = useRef<string | null | undefined>(undefined)
   const justSignedInRef = useRef(false)
 
@@ -52,8 +53,8 @@ export function ConditionalHomePage() {
     if (document.querySelector('[role="dialog"][data-state="open"]')) return
 
     // Only auto-redirect for authenticated users. For unauthenticated users,
-    // TripContext fetches ALL trips and localStorage includes shared-link trips,
-    // so there's no reliable way to distinguish "my trip" from "visited via link".
+    // TripContext fetches only localStorage-known trips — there's no reliable
+    // way to distinguish "my trip" from "visited via link".
     if (!user) return
 
     // Skip redirect on the render cycle right after sign-in — trips list

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -25,6 +25,39 @@ import { motion } from 'framer-motion'
 
 const DEMO_TRIP_CODE = 'livigno-2025'
 
+/**
+ * Home Page — Trip Visibility Contract
+ *
+ * Anonymous users (not signed in):
+ *   Data source: localStorage key `trip-splitter:my-trips`
+ *   - Populated automatically by useCurrentTrip when any trip URL is visited
+ *   - Only trip references (code + name) are stored locally; trip data lives in Supabase
+ *   - Ephemeral: iOS WebKit may evict localStorage after ~7 days of inactivity
+ *   - If localStorage is empty → empty state with sign-in suggestion
+ *   - If localStorage has entries → TripContext fetches those specific trips
+ *     from DB (by trip_code), shown as simple cards with name + last accessed
+ *   - No balance calculation (requires participant link)
+ *
+ * Authenticated users:
+ *   Data source: Supabase DB (primary) + localStorage merge (visited trips)
+ *   - DB query finds trips via 3 paths:
+ *     1. User is trip creator (created_by = user.id)
+ *     2. User linked as participant (participants.user_id = user.id)
+ *     3. Email discovery: participant with matching email but no user_id link yet
+ *   - localStorage trips not in DB results are fetched individually and merged
+ *   - Split into "My Trips" (creator or has participant link → myBalance !== null)
+ *     and "Visited" (localStorage-only, no participant record → myBalance === null)
+ *   - TripCards show balance summary via useMyTripBalances hook
+ *
+ * PWA considerations:
+ *   - localStorage holds only trip references (codes); trip data is always in Supabase
+ *   - After iOS eviction, anonymous users lose their trip links; auth users are unaffected
+ *
+ * Trip access model:
+ *   - Trip URL = access token. Anyone with /t/:tripCode can view any trip.
+ *   - ensureTripLoaded() handles navigation to trips not in the local array
+ *   - useCurrentTrip auto-adds every visited trip to localStorage
+ */
 export function HomePage() {
   const navigate = useNavigate()
   const { user, userProfile } = useAuth()
@@ -123,7 +156,7 @@ export function HomePage() {
             Nothing yet
           </h3>
           <p className="text-muted-foreground mb-6">
-            Create a new trip or event, or access one via a shared link
+            Create a new trip, access one via a shared link, or sign in to access your trips from anywhere
           </p>
           <Button onClick={handleCreateTrip} variant="outline" className="gap-2">
             <Plus size={18} />
@@ -256,8 +289,9 @@ export function HomePage() {
     }
 
     return (
+      <>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {localTrips.map(trip => (
+        {localTrips.map((trip) => (
           <Card
             key={trip.tripCode}
             className="overflow-hidden"
@@ -314,6 +348,11 @@ export function HomePage() {
           </Card>
         ))}
       </div>
+      <p className="mt-6 text-xs text-center text-muted-foreground">
+        Your trip links are saved on this device only.{' '}
+        Sign in to access them from anywhere.
+      </p>
+    </>
     )
   }
 


### PR DESCRIPTION
## Summary

- **TripContext**: Anonymous users no longer fetch ALL trips from the database. Now fetches only trips tracked in localStorage (by `trip_code`). Empty localStorage skips the DB call entirely.
- **HomePage**: Empty state text suggests signing in. Anonymous users with trips see an ephemeral storage warning ("saved on this device only"). Added JSDoc visibility contract documenting what each user state sees.
- **ConditionalHomePage**: Updated stale comments referencing "fetches ALL trips".
- **CLAUDE.md**: Added "Home Page Trip Visibility" architecture section.
- **Tests**: Updated anonymous fetch tests to expect `.in()` chain; added test for empty localStorage → no DB call.

Closes #603

## Test plan

- [ ] `npm run type-check` — passes clean
- [ ] `npm test` — all 193 tests pass
- [ ] Incognito (anon, no localStorage) → empty state shows sign-in text
- [ ] Visit trip via URL in incognito → go back to home → trip appears with ephemeral warning
- [ ] Sign in → trips load from DB, "My Trips" / "Visited" split works
- [ ] Network tab: anonymous home page does NOT fetch all trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)