### PR TITLE
fix: hide duplicate create button on home page

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -418,7 +418,7 @@ export function HomePage() {
         )}
 
         {/* Action Buttons — unauthenticated only (authenticated uses sheet + scan CTA) */}
-        {!isAuthenticated && (
+        {!isAuthenticated && localTrips.length > 0 && (
           <div className="flex gap-3 mb-8">
             <Button onClick={handleCreateTrip} className="gap-2">
               <Plus size={18} />


### PR DESCRIPTION
## Summary
- Only show the coral "Create New" button for unauthenticated users who already have trips
- When no trips exist, the empty state "Create Your First" button is the sole entry point
- Eliminates having two create buttons visible simultaneously

## Test plan
- [ ] Unauthenticated, no trips → only "Create Your First" in empty state card
- [ ] Unauthenticated, has trips → only "Create New" coral button at top
- [ ] Authenticated → unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)