### PR TITLE
fix: visually nest group members in Equal split chips

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -586,7 +586,10 @@ export function ExpenseForm({
               const allGroupSelected = memberIds.every(id => selectedParticipants.includes(id))
 
               return (
-                <div key={group.label ?? `standalone-${gi}`} className="contents">
+                <div key={group.label ?? `standalone-${gi}`} className={group.label
+                      ? 'rounded-lg bg-muted/40 border border-border/50 p-2 flex flex-wrap gap-2'
+                      : 'contents'
+                    }>
                   {group.label && (
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- Groups with a `wallet_group` in the desktop ExpenseForm "Equal" split mode now render inside a visible rounded container (`bg-muted/40` + border), matching the existing nesting in "By %" and "By Amount" modes
- Standalone participants (no wallet group) remain flat as before
- No logic changes — purely visual

## Test plan
- [ ] Open desktop ExpenseForm → Equal split → confirm groups are visually contained with members nested inside
- [ ] Toggle group chip → all members inside toggle together
- [ ] Switch to "By %" mode → confirm existing nested layout still works
- [ ] Check mobile wizard step 3 → unchanged behavior
- [ ] `npm run type-check` passes ✅
- [ ] `npm test` passes (193/193) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)