### PR TITLE
fix: match header width to content on home page

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -180,7 +180,7 @@ export function Layout() {
           </>
         )}
 
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className={`relative mx-auto px-4 sm:px-6 lg:px-8 ${tripCode ? 'max-w-7xl' : 'max-w-4xl'}`}>
           <div className="flex flex-col">
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">


### PR DESCRIPTION
## Summary
- On desktop home page, header inner container now uses `max-w-4xl` (matching `HomePage` content) instead of `max-w-7xl`, so logo and avatar align with page content
- In-trip pages unchanged (`max-w-7xl`)
- Uses existing `tripCode` route param to switch dynamically

## Test plan
- [ ] Desktop home page: logo and avatar align with `max-w-4xl` content area
- [ ] Desktop in-trip pages: header unchanged at `max-w-7xl`
- [ ] Mobile: no visible change (viewport narrower than both max-widths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)