### PR TITLE
fix: stack wallet groups vertically in Equal split chips

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -580,15 +580,15 @@ export function ExpenseForm({
         </div>
 
         {splitMode === 'equal' ? (
-          <div className="flex flex-wrap gap-2 rounded-lg border border-input p-3">
+          <div className="rounded-lg border border-input p-3 space-y-3">
             {participantGroups.map((group, gi) => {
               const memberIds = group.members.map(m => m.id)
               const allGroupSelected = memberIds.every(id => selectedParticipants.includes(id))
 
               return (
                 <div key={group.label ?? `standalone-${gi}`} className={group.label
-                      ? 'rounded-lg bg-muted/40 border border-border/50 p-2 flex flex-wrap gap-2'
-                      : 'contents'
+                      ? 'rounded-lg bg-muted/40 border border-border/50 p-2.5 flex flex-wrap gap-2'
+                      : 'flex flex-wrap gap-2'
                     }>
                   {group.label && (
                     <button


### PR DESCRIPTION
## Summary
- Switch Equal split chip outer container from `flex flex-wrap` to `space-y-3` so wallet groups render as full-width blocks instead of flowing inline with standalone participants
- Standalone participants use `flex flex-wrap gap-2` instead of `contents` for proper chip flow
- Group container padding bumped from `p-2` to `p-2.5` for better breathing room

Fixes the visual issue from PR #609 where group containers floated inline next to standalone chips.

## Test plan
- [ ] `npm run type-check` passes
- [ ] Visual: wallet groups are full-width blocks with header + member chips inside
- [ ] Visual: standalone participants flow as flat chips below groups
- [ ] No double-border clutter

🤖 Generated with [Claude Code](https://claude.com/claude-code)