### PR TITLE
fix: align home page desktop layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -180,7 +180,7 @@ export function Layout() {
           </>
         )}
 
-        <div className={`relative mx-auto px-4 sm:px-6 lg:px-8 ${tripCode ? 'max-w-7xl' : 'max-w-4xl'}`}>
+        <div className={`relative mx-auto ${tripCode ? 'max-w-7xl px-4 sm:px-6 lg:px-8' : 'max-w-4xl px-4'}`}>
           <div className="flex flex-col">
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -177,7 +177,7 @@ export function HomePage() {
   )
 
   const renderTripGrid = (trips: typeof visibleTrips) => (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div className={`grid grid-cols-1 gap-4 ${trips.length >= 2 ? 'md:grid-cols-2' : ''}`}>
       {trips.map(({ trip, myBalance }, i) => (
         <motion.div
           key={trip.id}
@@ -290,7 +290,7 @@ export function HomePage() {
 
     return (
       <>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className={`grid grid-cols-1 gap-4 ${localTrips.length >= 2 ? 'md:grid-cols-2' : ''}`}>
         {localTrips.map((trip) => (
           <Card
             key={trip.tripCode}


### PR DESCRIPTION
## Summary
- Header padding on home page uses `px-4` only (no `lg:px-8`) so the logo aligns with content below
- Trip grids only use 2-column layout when 2+ trips, so a single trip card spans full width

## Test plan
- [ ] Desktop home (1 trip): logo aligns with content; trip card matches banner width
- [ ] Desktop home (2+ trips): 2-column grid still works
- [ ] In-trip pages: header unchanged
- [ ] Mobile: no visible change

🤖 Generated with [Claude Code](https://claude.com/claude-code)