### PR TITLE
fix: settlement date alignment + mobile nav label wrapping (#606, #607)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -50,6 +50,7 @@ const iconMap: Record<string, React.ElementType> = {
   'Expenses': DollarSign,
   'Settlements': CreditCard,
   'Day Planner': CalendarDays,
+  'Planner': CalendarDays,
   'Shopping': ShoppingCart,
   'Dashboard': BarChart3,
   'More': MoreHorizontal,
@@ -117,7 +118,7 @@ export function Layout() {
       { path: `/t/${tripCode}/settlements`, label: 'Settlements', requiresTrip: true },
     ]
     if (currentTrip?.enable_meals || currentTrip?.enable_activities) {
-      items.push({ path: `/t/${tripCode}/planner`, label: 'Day Planner', requiresTrip: true })
+      items.push({ path: `/t/${tripCode}/planner`, label: 'Planner', requiresTrip: true })
     }
     if (currentTrip?.enable_shopping) {
       items.push({ path: `/t/${tripCode}/shopping`, label: 'Shopping', requiresTrip: true })

--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -269,7 +269,7 @@ export const SettlementForm = forwardRef<SettlementFormHandle, SettlementFormPro
       </div>
 
       {/* Amount + Date */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 gap-3 items-end">
         <div className="space-y-2">
           <Label htmlFor="amount">Amount</Label>
           <div className="flex gap-2">
@@ -321,6 +321,7 @@ export const SettlementForm = forwardRef<SettlementFormHandle, SettlementFormPro
             id="settlementDate"
             value={settlementDate}
             onChange={e => setSettlementDate(e.target.value)}
+            className="text-lg tabular-nums"
             disabled={loading}
           />
         </div>


### PR DESCRIPTION
## Summary
- **#607**: Settlement form date input was visually taller than amount input on iOS. Added `items-end` grid alignment and `text-lg tabular-nums` to date input to match.
- **#606**: "Day Planner" label wrapped to 2 lines in mobile bottom nav on narrow screens. Shortened to "Planner" (desktop sidebar still says "Day Planner").

## Test plan
- [ ] Mobile settlement sheet: date and amount inputs same height
- [ ] Mobile bottom nav with all features enabled: no label wrapping
- [ ] Desktop sidebar: still shows "Day Planner"

Closes #606, closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)