### PR TITLE
fix: improve Equal split chip color hierarchy

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -587,7 +587,7 @@ export function ExpenseForm({
 
               return (
                 <div key={group.label ?? `standalone-${gi}`} className={group.label
-                      ? 'rounded-lg bg-muted/40 border border-border/50 p-2.5 flex flex-wrap gap-2'
+                      ? 'border-l-2 border-primary/30 pl-3 flex flex-wrap gap-2'
                       : 'flex flex-wrap gap-2'
                     }>
                   {group.label && (
@@ -597,7 +597,7 @@ export function ExpenseForm({
                       disabled={loading}
                       className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
                         allGroupSelected
-                          ? 'bg-primary text-primary-foreground border-primary'
+                          ? 'bg-primary/15 text-primary border-primary/30'
                           : 'bg-muted text-muted-foreground border-input hover:border-primary/50'
                       }`}
                     >

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -161,7 +161,7 @@ export function WizardStep3({
                     return (
                       <div
                         key={group.label ?? `standalone-${gi}`}
-                        className={group.label ? 'rounded-lg bg-muted/40 border border-border/50 p-2 mt-2 first:mt-0' : ''}
+                        className={group.label ? 'border-l-2 border-primary/30 pl-3 mt-2 first:mt-0' : ''}
                       >
                         {group.label && (
                           <div


### PR DESCRIPTION
## Summary
- Group header chips use soft tinted style (`bg-primary/15 text-primary`) instead of solid coral — acts as a label/toggle, not another participant chip
- Group containers use a left accent border (`border-l-2 border-primary/30`) instead of full bordered box — eliminates double border clutter
- Applied consistently to both `ExpenseForm` (desktop) and `WizardStep3` (mobile wizard)

## Test plan
- [ ] Open expense form with wallet groups — group header chip is visually distinct (tinted, not solid coral)
- [ ] Left accent line separates groups without box-in-box effect
- [ ] Standalone participants render as plain chips with no accent
- [ ] Mobile wizard step 3 groups also use left accent (no bordered box)

🤖 Generated with [Claude Code](https://claude.com/claude-code)