### PR TITLE
fix: align in-trip header width with content on desktop

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -181,7 +181,7 @@ export function Layout() {
           </>
         )}
 
-        <div className={`relative mx-auto ${tripCode ? 'max-w-7xl px-4 sm:px-6 lg:px-8' : 'max-w-4xl px-4'}`}>
+        <div className={`relative mx-auto ${tripCode ? 'max-w-7xl px-4 sm:px-6 lg:px-8 lg:ml-64' : 'max-w-4xl px-4'}`}>
           <div className="flex flex-col">
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -82,7 +82,7 @@ export function QuickLayout() {
           </>
         )}
 
-        <div className="relative max-w-lg lg:max-w-7xl mx-auto px-4 lg:px-8">
+        <div className="relative max-w-lg mx-auto px-4">
           <div className="flex flex-col">
             {/* Row 1: back/logo + trip name (full width) + avatar */}
             <div className="flex items-center justify-between py-3">


### PR DESCRIPTION
## Summary
- **Layout (Full view):** Add `lg:ml-64` to header inner div when in a trip, matching the sidebar offset so trip name aligns with main content
- **QuickLayout (Quick view):** Remove `lg:max-w-7xl` breakpoint so header stays `max-w-lg`, matching `QuickGroupDetailPage` content width

## Test plan
- [ ] Full view desktop: trip name in header aligns with content start (after sidebar)
- [ ] Quick view desktop: header width matches content cards below
- [ ] Mobile (both modes): no visible change
- [ ] Home page: unaffected (uses separate `max-w-4xl` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)