### PR TITLE
fix: use outline style for selected group header chip

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -597,7 +597,7 @@ export function ExpenseForm({
                       disabled={loading}
                       className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
                         allGroupSelected
-                          ? 'bg-primary/15 text-primary border-primary/30'
+                          ? 'bg-background text-primary border-primary'
                           : 'bg-muted text-muted-foreground border-input hover:border-primary/50'
                       }`}
                     >


### PR DESCRIPTION
## Summary
- Selected group header chip changed from tinted fill (`bg-primary/15 border-primary/30`) to outline style (`bg-background border-primary`) so it reads as active instead of washed-out next to solid member chips
- Left accent border unchanged

## Test plan
- [ ] Open Equal split participant picker with wallet groups
- [ ] Verify selected group header has solid coral border + coral text on white background
- [ ] Verify unselected group header still uses muted grey style
- [ ] Verify member chips remain solid coral when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)