### PR TITLE
fix: ConditionalHomePage only redirects to owned/participated trips

### DIFF
--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -10,6 +10,7 @@ import { getMyTrips } from '@/lib/myTripsStorage'
 
 interface TripContextType {
   trips: Event[]
+  myTripIds: Set<string>
   loading: boolean
   error: string | null
   getTripById: (id: string) => Event | undefined
@@ -26,6 +27,7 @@ const TripContext = createContext<TripContextType | undefined>(undefined)
 export function TripProvider({ children }: { children: ReactNode }) {
   const { loading: authLoading, user } = useAuth()
   const [trips, setTrips] = useState<Event[]>([])
+  const [myTripIds, setMyTripIds] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { newSignal, cancel } = useAbortController()
@@ -57,6 +59,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
         )
         if (signal.aborted) return
         if (fetchError) throw fetchError
+        setMyTripIds(new Set())
         setTrips((data as unknown as Event[]) || [])
         return
       }
@@ -105,6 +108,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
       if (signal.aborted) return
       if (fetchError) throw fetchError
       const fetchedTrips = (data as unknown as Event[]) || []
+      setMyTripIds(new Set(fetchedTrips.map(t => t.id)))
       setTrips(fetchedTrips)
 
       // Merge localStorage trips that weren't returned by the DB query.
@@ -337,6 +341,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
 
   const value: TripContextType = {
     trips,
+    myTripIds,
     loading,
     error,
     getTripById,

--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 // Mock TripContext
 const mockTrips = {
   trips: [] as any[],
+  myTripIds: new Set<string>(),
   loading: false,
   error: null,
   getTripById: vi.fn(),
@@ -70,6 +71,7 @@ describe('ConditionalHomePage', () => {
     mockAuth.loading = false
     mockTrips.loading = false
     mockTrips.trips = []
+    mockTrips.myTripIds = new Set()
     vi.mocked(getActiveTripId).mockReturnValue(null)
     // Default: desktop viewport (no mobile redirect)
     Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true })
@@ -114,6 +116,7 @@ describe('ConditionalHomePage', () => {
       end_date: tomorrow.toISOString().slice(0, 10),
     })
     mockTrips.trips = [trip]
+    mockTrips.myTripIds = new Set(['trip-1'])
     vi.mocked(getActiveTripId).mockReturnValue('trip-1')
 
     render(
@@ -144,6 +147,7 @@ describe('ConditionalHomePage', () => {
       end_date: endMonth.toISOString().slice(0, 10),
     })
     mockTrips.trips = [trip]
+    mockTrips.myTripIds = new Set(['trip-1'])
     vi.mocked(getActiveTripId).mockReturnValue('trip-1')
 
     render(

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -18,7 +18,7 @@ export function ConditionalHomePage() {
   const navigate = useNavigate()
   const location = useLocation()
   const { user } = useAuth()
-  const { trips, loading: tripsLoading } = useTripContext()
+  const { trips, myTripIds, loading: tripsLoading } = useTripContext()
 
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
   const fromTrip = !!(location.state as any)?.fromTrip
@@ -65,7 +65,8 @@ export function ConditionalHomePage() {
       return
     }
 
-    const activeTripId = getActiveTripId(trips)
+    const myTrips = trips.filter(t => myTripIds.has(t.id))
+    const activeTripId = getActiveTripId(myTrips)
 
     if (activeTripId) {
       const activeTrip = trips.find(t => t.id === activeTripId)


### PR DESCRIPTION
## Summary
- After Google login on mobile PWA, `ConditionalHomePage` was auto-redirecting to visited (shared link) trips that happen to be active today — trips the user has no creator/participant relationship with
- **Fix:** `TripContext` now exposes `myTripIds: Set<string>` containing IDs from the authenticated DB query (creator or participant). `ConditionalHomePage` filters trips through `myTripIds` before checking for an active trip redirect
- Updated `ConditionalHomePage.test.tsx` mock to include `myTripIds`

## Test plan
- [x] `npm run type-check` passes
- [x] All 193 unit tests pass
- [ ] Manual: sign in on mobile PWA → should only auto-redirect to trips you own or participate in, not visited-only trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)