### PR TITLE
fix: strip iOS native date-input chrome that inflates height

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border border-input bg-background px-4 py-2 text-base transition-smooth file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-lg border border-input bg-background px-4 py-2 text-base transition-smooth file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 [&[type=date]]:appearance-none",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- Adds `[&[type=date]]:appearance-none` to the base `Input` component className
- Strips iOS Safari native date-picker chrome that makes `type="date"` inputs taller than `h-10`
- No visual change on desktop browsers (already respect `h-10`)

## Test plan
- [ ] On iOS Safari: date input in SettlementForm matches amount input height
- [ ] Desktop: date input appearance unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)