### PR TITLE
fix: desktop header cleanup — width, remove Row 2 pills, compact mode toggle

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -25,6 +25,7 @@ import { UserMenu } from '@/components/auth/UserMenu'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
 import { isAdminUser } from '@/lib/adminAuth'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
+import { ModeToggle } from '@/components/quick/ModeToggle'
 import { QuickScanContextSheet } from '@/components/quick/QuickScanContextSheet'
 import { QuickScanCreateFlow } from '@/components/quick/QuickScanCreateFlow'
 import { PullToRefreshProvider } from '@/contexts/PullToRefreshContext'
@@ -181,7 +182,7 @@ export function Layout() {
           </>
         )}
 
-        <div className={`relative mx-auto ${tripCode ? 'max-w-7xl px-4 sm:px-6 lg:px-8 lg:ml-64' : 'max-w-4xl px-4'}`}>
+        <div className={`relative mx-auto ${tripCode ? 'max-w-7xl px-4 sm:px-6 lg:px-8' : 'max-w-4xl px-4'}`}>
           <div className="flex flex-col">
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">
@@ -223,12 +224,16 @@ export function Layout() {
                   </button>
                 )}
                 <ReportIssueButton onGradient={onGradient} />
-
+                {tripCode && currentTrip && (
+                  <div className="hidden lg:flex">
+                    <ModeToggle onGradient={onGradient} />
+                  </div>
+                )}
                 {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
               </div>
             </div>
 
-            {/* Row 2: action pills — shown when in a trip and loaded */}
+            {/* Row 2: action pills — shown when in a trip and loaded (mobile only) */}
             {tripCode && currentTrip && (() => {
               const pillClass = `flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors ${
                 onGradient ? 'bg-white/10 hover:bg-white/20 text-white' : 'bg-muted hover:bg-muted/70 text-foreground'
@@ -237,7 +242,7 @@ export function Layout() {
                 onGradient ? 'border-white/40 bg-white/15 hover:bg-white/25 text-white' : 'border-primary/40 bg-primary/10 hover:bg-primary/15 text-primary'
               }`
               return (
-                <div className={`grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
+                <div className={`grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 lg:hidden ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
                   <button onClick={handleScanTap} className={pillClass}>
                     <ScanLine size={14} />
                     Scan
@@ -258,7 +263,7 @@ export function Layout() {
       </header>
 
       {/* Main content */}
-      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px]' : 'mt-20'}`}>
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
         <LayoutPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>
@@ -398,7 +403,7 @@ export function Layout() {
       </nav>}
 
       {/* Side navigation (desktop) */}
-      {tripCode && <aside className="hidden lg:block fixed left-0 top-[108px] bottom-0 w-64 bg-card border-r border-border soft-shadow">
+      {tripCode && <aside className="hidden lg:block fixed left-0 top-16 bottom-0 w-64 bg-card border-r border-border soft-shadow">
         <nav className="px-3 py-6 space-y-1">
           {desktopNavItems.map((item) => {
             const Icon = iconMap[item.label as keyof typeof iconMap]

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -21,6 +21,7 @@ import { Toaster } from '@/components/ui/toaster'
 import { getTripGradientPattern } from '@/services/tripGradientService'
 import { ReportIssueButton } from '@/components/ReportIssueButton'
 import { isAdminUser } from '@/lib/adminAuth'
+import { ModeToggle } from '@/components/quick/ModeToggle'
 import { PullToRefreshProvider } from '@/contexts/PullToRefreshContext'
 import { usePullToRefresh } from '@/hooks/usePullToRefresh'
 import { PullToRefreshIndicator } from '@/components/PullToRefreshIndicator'
@@ -82,7 +83,7 @@ export function QuickLayout() {
           </>
         )}
 
-        <div className="relative max-w-lg lg:max-w-7xl mx-auto px-4 lg:px-8">
+        <div className="relative max-w-lg mx-auto px-4">
           <div className="flex flex-col">
             {/* Row 1: back/logo + trip name (full width) + avatar */}
             <div className="flex items-center justify-between py-3">
@@ -131,14 +132,18 @@ export function QuickLayout() {
                   </button>
                 )}
                 <ReportIssueButton onGradient={onGradient} />
-
+                {isInTrip && !isSubPage && (
+                  <div className="hidden lg:flex">
+                    <ModeToggle onGradient={onGradient} />
+                  </div>
+                )}
                 {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
               </div>
             </div>
 
             {/* Row 2: full-width action strip — only on trip detail page, not sub-pages */}
             {isInTrip && !isSubPage && currentTrip && (
-              <div className={`grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
+              <div className={`grid grid-cols-3 gap-1.5 pb-2 border-t pt-1.5 lg:hidden ${onGradient ? 'border-white/15' : 'border-border/60'}`}>
                 <button
                   onClick={handleScanTap}
                   className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors ${
@@ -179,7 +184,7 @@ export function QuickLayout() {
       </header>
 
       {/* Main content — extra top padding when two-row header is active */}
-      <main className={isInTrip && !isSubPage ? 'pt-[108px]' : 'pt-16'}>
+      <main className={isInTrip && !isSubPage ? 'pt-[108px] lg:pt-16' : 'pt-16'}>
         <QuickPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>


### PR DESCRIPTION
## Summary
- **Hide Row 2 mobile pills on desktop** (`lg:hidden`) in both Layout and QuickLayout — Scan/Manage are accessible via sidebar (Full) or not needed (Quick)
- **Add ModeToggle to Row 1 right side on desktop** (`hidden lg:flex`) in both layouts, between ReportIssueButton and UserMenu
- **Fix Layout header width** — remove `lg:ml-64` offset from inner container; fix side nav `top` from `108px` to `16` (single-row on desktop); add `lg:mt-20` to main content
- **Fix QuickLayout header width** — narrow from `lg:max-w-7xl` to `max-w-lg` (matches content); add `lg:pt-16` to main content

## Test plan
- [ ] Desktop Full mode: single-row header, ModeToggle visible, no Row 2 pills, side nav aligned correctly
- [ ] Desktop Quick mode: narrow header (`max-w-lg`), ModeToggle visible, no Row 2 pills
- [ ] Mobile both modes: Row 2 pills still visible and functional, no ModeToggle in Row 1
- [ ] Home page (both viewports): no ModeToggle shown (no trip context)
- [ ] Type-check and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)