### PR TITLE
fix: desktop header — single mode button, avatar-only in Quick, edge-aligned in Full

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -182,7 +182,7 @@ export function Layout() {
           </>
         )}
 
-        <div className={`relative mx-auto ${tripCode ? 'max-w-7xl px-4 sm:px-6 lg:px-8' : 'max-w-4xl px-4'}`}>
+        <div className={`relative mx-auto ${tripCode ? 'px-4 sm:px-6 lg:px-8' : 'max-w-4xl px-4'}`}>
           <div className="flex flex-col">
             {/* Row 1 */}
             <div className="flex items-center justify-between py-4">

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -137,7 +137,7 @@ export function QuickLayout() {
                     <ModeToggle onGradient={onGradient} />
                   </div>
                 )}
-                {user ? <UserMenu onGradient={onGradient} /> : <SignInButton />}
+                {user ? <UserMenu onGradient={onGradient} compact /> : <SignInButton />}
               </div>
             </div>
 

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -13,9 +13,10 @@ import { BankDetailsDialog } from './BankDetailsDialog'
 
 interface UserMenuProps {
   onGradient?: boolean
+  compact?: boolean
 }
 
-export function UserMenu({ onGradient = false }: UserMenuProps) {
+export function UserMenu({ onGradient = false, compact = false }: UserMenuProps) {
   const { user, userProfile, signOut } = useAuth()
   const [showBankDetails, setShowBankDetails] = useState(false)
 
@@ -49,7 +50,7 @@ export function UserMenu({ onGradient = false }: UserMenuProps) {
               {initials}
             </div>
           )}
-          <span className={`hidden sm:inline text-sm font-medium max-w-[120px] truncate ${
+          <span className={`${compact ? 'hidden' : 'hidden sm:inline'} text-sm font-medium max-w-[120px] truncate ${
             onGradient ? 'text-white' : ''
           }`}>
             {displayName}

--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -18,8 +18,8 @@ export function ModeToggle({ onGradient = false }: ModeToggleProps) {
   const isOnFullTripRoute = !isOnQuickRoute && /\/t\/[^/]+\//.test(location.pathname)
   const effectiveMode = isOnQuickRoute ? 'quick' : isOnFullTripRoute ? 'full' : mode
 
-  const handleModeChange = async (newMode: 'quick' | 'full') => {
-    if (newMode === effectiveMode) return
+  const handleToggle = async () => {
+    const newMode = effectiveMode === 'quick' ? 'full' : 'quick'
     await setMode(newMode)
 
     // Navigate to the appropriate view only when inside a trip
@@ -33,38 +33,21 @@ export function ModeToggle({ onGradient = false }: ModeToggleProps) {
     // On home page (no tripCode): just update preference, no navigation needed
   }
 
-  const containerClass = onGradient
-    ? 'flex items-center bg-white/20 rounded-lg p-0.5'
-    : 'flex items-center bg-muted rounded-lg p-0.5'
+  const buttonClass = onGradient
+    ? 'border-white/40 bg-white/15 hover:bg-white/25 text-white'
+    : 'border-primary/40 bg-primary/10 hover:bg-primary/15 text-primary'
 
-  const activeClass = onGradient
-    ? 'bg-white/30 text-white shadow-sm'
-    : 'bg-background text-foreground shadow-sm'
-
-  const inactiveClass = onGradient
-    ? 'text-white/70 hover:text-white'
-    : 'text-muted-foreground hover:text-foreground'
+  // Show the opposite mode — clicking navigates to it
+  const Icon = effectiveMode === 'quick' ? LayoutGrid : Zap
+  const label = effectiveMode === 'quick' ? 'Full view' : 'Quick view'
 
   return (
-    <div className={containerClass}>
-      <button
-        onClick={() => handleModeChange('quick')}
-        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-          effectiveMode === 'quick' ? activeClass : inactiveClass
-        }`}
-      >
-        <Zap size={14} />
-        Quick
-      </button>
-      <button
-        onClick={() => handleModeChange('full')}
-        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-          effectiveMode === 'full' ? activeClass : inactiveClass
-        }`}
-      >
-        <LayoutGrid size={14} />
-        Full
-      </button>
-    </div>
+    <button
+      onClick={handleToggle}
+      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border ${buttonClass}`}
+    >
+      <Icon size={14} />
+      {label}
+    </button>
   )
 }


### PR DESCRIPTION
## Summary
- **ModeToggle**: replaced segmented control (Quick | Full) with a single pill button showing the opposite mode (e.g. "Quick view" when in Full mode), matching mobile pill style
- **UserMenu**: added `compact` prop — when true, hides display name (avatar-only); used in Quick mode desktop
- **Layout header**: removed `max-w-7xl` constraint when in a trip so header content stretches closer to viewport edges

## Test plan
- [ ] Desktop Full mode: single "Quick view" button visible, header content near edges, user name visible next to avatar
- [ ] Desktop Quick mode: single "Full view" button visible, avatar-only (no name), narrow header unchanged
- [ ] Mobile: unchanged — ModeToggle hidden (`lg:flex`), Row 2 pills still work
- [ ] Home page: no mode toggle shown, header unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)