### PR TITLE
fix: remove redundant "Events & Trips" from desktop sidebar

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -81,9 +81,7 @@ export function Layout() {
 
   // Desktop navigation - all items visible
   const getDesktopNavItems = () => {
-    const items = [
-      { path: '/', label: 'Events & Trips', requiresTrip: false },
-    ]
+    const items: { path: string; label: string; requiresTrip: boolean }[] = []
 
     if (tripCode) {
       items.push(


### PR DESCRIPTION
## Summary
- Removed the "Events & Trips" nav item from the desktop sidebar — the header back arrow already navigates home
- Sidebar only renders when inside a trip, so the home link was never needed there

## Test plan
- [ ] Desktop in-trip: sidebar shows Manage, Expenses, Settlements, Dashboard (no "Events & Trips")
- [ ] Back arrow in header still navigates home
- [ ] Mobile bottom nav unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)