### PR TITLE
fix: sign out button not responding

### DIFF
--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -70,7 +70,7 @@ export function UserMenu({ onGradient = false, compact = false }: UserMenuProps)
           Bank Details
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={signOut} className="gap-2 text-destructive focus:text-destructive">
+        <DropdownMenuItem onSelect={() => { signOut() }} className="gap-2 text-destructive focus:text-destructive">
           <LogOut size={16} />
           Sign out
         </DropdownMenuItem>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -212,10 +212,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signOut = async () => {
     logger.info('User signed out', { user_id: user?.id })
     clearMyTrips()
-    const { error } = await supabase.auth.signOut()
-    if (error) {
-      logger.error('Sign-out failed', { error: error.message })
+    try {
+      const { error } = await supabase.auth.signOut()
+      if (error) {
+        logger.error('Sign-out failed', { error: error.message })
+      }
+    } catch (err) {
+      logger.error('Sign-out threw', { error: err instanceof Error ? err.message : String(err) })
     }
+    // Always clear local state — don't rely solely on onAuthStateChange
+    setUser(null)
+    setSession(null)
+    setUserProfile(null)
   }
 
   return (


### PR DESCRIPTION
## Summary
- **UserMenu**: Changed `onClick` to `onSelect` on the sign-out `DropdownMenuItem` — `onSelect` is the canonical Radix handler and is more reliable across touch/PWA contexts
- **AuthContext**: Wrapped `supabase.auth.signOut()` in try/catch and always clears local state (`user`, `session`, `userProfile`) so the UI updates even if the Supabase call fails or `onAuthStateChange` doesn't fire

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — 193 tests pass
- [ ] Manual: sign in → click Sign out → verify menu disappears and sign-in button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)