### PR TITLE
fix: desktop trip creation navigates to Full mode instead of Quick

### DIFF
--- a/src/components/quick/QuickCreateSheet.tsx
+++ b/src/components/quick/QuickCreateSheet.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { X } from 'lucide-react'
 import { useTripContext } from '@/contexts/TripContext'
-import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { EventForm } from '@/components/EventForm'
 import { CreateEventInput } from '@/types/trip'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
@@ -18,7 +17,6 @@ interface QuickCreateSheetProps {
 export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) {
   const navigate = useNavigate()
   const { createTrip } = useTripContext()
-  const { mode } = useUserPreferences()
   const keyboard = useKeyboardHeight()
   const scrollRef = useIOSScrollFix()
   const isMobile = useMediaQuery('(max-width: 767px)')
@@ -27,7 +25,7 @@ export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) 
     const newEvent = await createTrip(input)
     if (newEvent) {
       onOpenChange(false)
-      navigate(mode === 'quick' ? `/t/${newEvent.trip_code}/quick` : `/t/${newEvent.trip_code}/manage`)
+      navigate(isMobile ? `/t/${newEvent.trip_code}/quick` : `/t/${newEvent.trip_code}/manage`)
     }
   }
 

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -248,7 +248,7 @@ export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowP
   const handleDone = () => {
     if (createdTripCode) {
       onOpenChange(false)
-      navigate(`/t/${createdTripCode}/quick`)
+      navigate(isMobile ? `/t/${createdTripCode}/quick` : `/t/${createdTripCode}/manage`)
     } else {
       onOpenChange(false)
     }


### PR DESCRIPTION
## Summary
- **QuickCreateSheet**: replace `mode`-based navigation with `isMobile` viewport check — desktop → `/manage`, mobile → `/quick`
- **QuickScanCreateFlow**: replace hardcoded `/quick` navigation with same `isMobile` check
- Remove unused `useUserPreferences` import from QuickCreateSheet

## Root cause
Stored `preferredMode: 'quick'` in localStorage/Supabase caused desktop trip creation to navigate to `/quick` instead of `/manage`.

## Test plan
- [ ] Desktop: create trip via button → lands on `/t/:code/manage`
- [ ] Desktop: create trip via scan → lands on `/t/:code/manage`
- [ ] Mobile (< 768px): create trip via button → lands on `/t/:code/quick`
- [ ] Mobile: create trip via scan → lands on `/t/:code/quick`
- [ ] `npm run type-check` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)