### PR TITLE
fix: mobile trip creation and join navigate to /quick

### DIFF
--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { logger } from '@/lib/logger'
 import { withTimeout } from '@/lib/fetchWithTimeout'
 import { useAbortController } from '@/hooks/useAbortController'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 
 interface InvitationData {
   id: string
@@ -28,6 +29,7 @@ export function JoinPage() {
   const { refreshTrips } = useTripContext()
   const navigate = useNavigate()
   const { newSignal, cancel } = useAbortController()
+  const isMobile = useMediaQuery('(max-width: 767px)')
 
   const [pageState, setPageState] = useState<PageState>('loading')
   const [invitation, setInvitation] = useState<InvitationData | null>(null)
@@ -173,7 +175,7 @@ export function JoinPage() {
         await refreshTrips()
 
         // Navigate to the trip
-        navigate(`/t/${invitation!.trip_code}/quick`, { replace: true })
+        navigate(isMobile ? `/t/${invitation!.trip_code}/quick` : `/t/${invitation!.trip_code}/manage`, { replace: true })
       } catch (err) {
         logger.error('Failed to link user to participant', { error: String(err) })
         setLinkError('Failed to link your account. Please try again.')
@@ -186,7 +188,7 @@ export function JoinPage() {
 
   const handleOpenTrip = () => {
     if (invitation) {
-      navigate(`/t/${invitation.trip_code}/quick`)
+      navigate(isMobile ? `/t/${invitation.trip_code}/quick` : `/t/${invitation.trip_code}/manage`)
     }
   }
 

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { EventForm } from '@/components/EventForm'
 import { SignInButton } from '@/components/auth/SignInButton'
 import { CreateEventInput } from '@/types/trip'
@@ -11,13 +12,14 @@ export function TripsPage() {
   const navigate = useNavigate()
   const { user } = useAuth()
   const { createTrip, error } = useTripContext()
+  const isMobile = useMediaQuery('(max-width: 767px)')
 
   const handleCreate = async (input: CreateEventInput) => {
     const newEvent = await createTrip(input)
     if (!newEvent) {
       throw new Error('Failed to create')
     }
-    navigate(`/t/${newEvent.trip_code}/manage`)
+    navigate(isMobile ? `/t/${newEvent.trip_code}/quick` : `/t/${newEvent.trip_code}/manage`)
   }
 
   const handleCancel = () => {


### PR DESCRIPTION
## Summary
- **TripsPage**: Use `isMobile` media query so mobile users land on `/quick` after creating a trip in Full mode (instead of `/manage`)
- **JoinPage**: Use `isMobile` for both navigation calls (auto-link and manual "Open" button) — mobile → `/quick`, desktop → `/manage`

## Test plan
- [ ] Mobile: create trip via Full mode (`/create-trip`) → lands on `/t/:code/quick`
- [ ] Desktop: create trip via Full mode → lands on `/t/:code/manage`
- [ ] Mobile: accept invitation → lands on `/quick`
- [ ] Desktop: accept invitation → lands on `/manage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)