### PR TITLE
fix: stack Settle/Remind buttons vertically on desktop

### DIFF
--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -184,7 +184,7 @@ function SettlementTransactionCard({
           </div>
           {/* Amount + buttons inline on desktop */}
           <span className="text-base font-semibold text-accent tabular-nums shrink-0 ml-auto hidden md:inline">{formattedAmount}</span>
-          <div className="hidden md:flex gap-1.5 shrink-0">
+          <div className="hidden md:flex flex-col gap-1 shrink-0">
             {onSettle && (
               <Button onClick={onSettle} size="sm" className="h-7 text-xs">
                 Settle


### PR DESCRIPTION
## Summary
- Stack Settle and Remind buttons vertically on desktop settlement plan cards (`flex-col gap-1`) for a cleaner layout

## Test plan
- [ ] Visual check: desktop Settlement Plan cards show Settle above Remind

🤖 Generated with [Claude Code](https://claude.com/claude-code)