### PR TITLE
feat: add trip gradient accent to home page cards

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -2,6 +2,7 @@ import { Calendar, ChevronRight } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Event } from '@/types/trip'
 import { ParticipantBalance, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { getTripGradientPattern } from '@/services/tripGradientService'
 
 interface TripCardProps {
   trip: Event
@@ -19,6 +20,7 @@ function formatCardDate(isoDate: string): string {
 }
 
 export function TripCard({ trip, balance, isActive, onClick, actions }: TripCardProps) {
+  const pattern = getTripGradientPattern(trip.name)
   const hasDate = trip.start_date || trip.end_date
   const dateLabel = hasDate
     ? trip.end_date && trip.end_date !== trip.start_date
@@ -27,7 +29,11 @@ export function TripCard({ trip, balance, isActive, onClick, actions }: TripCard
     : null
 
   return (
-    <Card className="overflow-hidden">
+    <Card className="overflow-hidden relative">
+      <div
+        className="absolute left-0 top-0 bottom-0 w-1 rounded-l-xl"
+        style={{ background: pattern.gradient }}
+      />
       <div
         className="cursor-pointer hover:bg-accent/30 transition-colors"
         onClick={onClick}


### PR DESCRIPTION
## Summary
- Adds a 4px left accent strip to each trip card on the home page using the trip's deterministic gradient from `getTripGradientPattern`
- Creates visual identity linking cards to their trip header gradients

## Test plan
- [ ] `npm run type-check` passes
- [ ] Each trip card shows a colored left accent matching its header gradient
- [ ] Different trips display different gradient colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)