### PR TITLE
feat: add Invited section to HomePage for email-discovered trips

### DIFF
--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -11,6 +11,7 @@ import { getMyTrips } from '@/lib/myTripsStorage'
 interface TripContextType {
   trips: Event[]
   myTripIds: Set<string>
+  emailDiscoveredTripIds: Set<string>
   loading: boolean
   error: string | null
   getTripById: (id: string) => Event | undefined
@@ -28,6 +29,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
   const { loading: authLoading, user } = useAuth()
   const [trips, setTrips] = useState<Event[]>([])
   const [myTripIds, setMyTripIds] = useState<Set<string>>(new Set())
+  const [emailDiscoveredTripIds, setEmailDiscoveredTripIds] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { newSignal, cancel } = useAbortController()
@@ -60,6 +62,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
         if (signal.aborted) return
         if (fetchError) throw fetchError
         setMyTripIds(new Set())
+        setEmailDiscoveredTripIds(new Set())
         setTrips((data as unknown as Event[]) || [])
         return
       }
@@ -109,6 +112,10 @@ export function TripProvider({ children }: { children: ReactNode }) {
       if (fetchError) throw fetchError
       const fetchedTrips = (data as unknown as Event[]) || []
       setMyTripIds(new Set(fetchedTrips.map(t => t.id)))
+      const creatorIds = new Set(fetchedTrips.filter(t => t.created_by === user.id).map(t => t.id))
+      setEmailDiscoveredTripIds(
+        new Set(emailTripIds.filter(id => !participantTripIds.includes(id) && !creatorIds.has(id)))
+      )
       setTrips(fetchedTrips)
 
       // Merge localStorage trips that weren't returned by the DB query.
@@ -342,6 +349,7 @@ export function TripProvider({ children }: { children: ReactNode }) {
   const value: TripContextType = {
     trips,
     myTripIds,
+    emailDiscoveredTripIds,
     loading,
     error,
     getTripById,

--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 const mockTrips = {
   trips: [] as any[],
   myTripIds: new Set<string>(),
+  emailDiscoveredTripIds: new Set<string>(),
   loading: false,
   error: null,
   getTripById: vi.fn(),

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -61,7 +61,7 @@ const DEMO_TRIP_CODE = 'livigno-2025'
 export function HomePage() {
   const navigate = useNavigate()
   const { user, userProfile } = useAuth()
-  const { loading: tripsLoading, refreshTrips } = useTripContext()
+  const { loading: tripsLoading, refreshTrips, emailDiscoveredTripIds } = useTripContext()
   const { mode } = useUserPreferences()
   const { tripBalances, loading: balancesLoading } = useMyTripBalances()
   const [localTrips, setLocalTrips] = useState<MyTripEntry[]>([])
@@ -92,9 +92,14 @@ export function HomePage() {
   const visibleTrips = tripBalances.filter(tb => !hiddenCodes.has(tb.trip.trip_code))
   const hiddenTrips = tripBalances.filter(tb => hiddenCodes.has(tb.trip.trip_code))
 
-  // Split visible trips into "my trips" (creator or linked participant) vs "visited" (localStorage-only)
-  const myTrips = visibleTrips.filter(({ trip, myBalance }) => trip.created_by === user?.id || myBalance !== null)
-  const visitedTrips = visibleTrips.filter(({ trip, myBalance }) => trip.created_by !== user?.id && myBalance === null)
+  // Split visible trips into "my trips", "invited" (email-discovered), and "visited" (localStorage-only)
+  const invitedTrips = visibleTrips.filter(({ trip }) => emailDiscoveredTripIds.has(trip.id))
+  const myTrips = visibleTrips.filter(({ trip, myBalance }) =>
+    !emailDiscoveredTripIds.has(trip.id) && (trip.created_by === user?.id || myBalance !== null)
+  )
+  const visitedTrips = visibleTrips.filter(({ trip, myBalance }) =>
+    !emailDiscoveredTripIds.has(trip.id) && trip.created_by !== user?.id && myBalance === null
+  )
 
   const activeTripId = useMemo(
     () => getActiveTripId(visibleTrips.map(tb => tb.trip)),
@@ -194,7 +199,7 @@ export function HomePage() {
               <GroupActions
                 tripCode={trip.trip_code}
                 tripName={trip.name}
-                showRemove={trip.created_by !== user?.id && myBalance === null}
+                showRemove={trip.created_by !== user?.id && myBalance === null && !emailDiscoveredTripIds.has(trip.id)}
                 onHidden={() => handleHidden(trip.trip_code)}
                 onLeft={() => handleLeft(trip.trip_code)}
               />
@@ -215,18 +220,28 @@ export function HomePage() {
       return renderEmptyState()
     }
 
+    const sectionCount = [myTrips, invitedTrips, visitedTrips].filter(s => s.length > 0).length
+    const showHeadings = sectionCount > 1
+
     return (
       <>
-        {myTrips.length > 0 && visitedTrips.length > 0 && (
-          <h2 className="text-sm font-medium text-muted-foreground mb-3">My Trips</h2>
+        {myTrips.length > 0 && (
+          <>
+            {showHeadings && <h2 className="text-sm font-medium text-muted-foreground mb-3">My Trips</h2>}
+            {renderTripGrid(myTrips)}
+          </>
         )}
-        {myTrips.length > 0 && renderTripGrid(myTrips)}
+
+        {invitedTrips.length > 0 && (
+          <div className={myTrips.length > 0 ? 'mt-8' : ''}>
+            {showHeadings && <h2 className="text-sm font-medium text-muted-foreground mb-3">Invited</h2>}
+            {renderTripGrid(invitedTrips)}
+          </div>
+        )}
 
         {visitedTrips.length > 0 && (
-          <div className={myTrips.length > 0 ? 'mt-8' : ''}>
-            {myTrips.length > 0 && (
-              <h2 className="text-sm font-medium text-muted-foreground mb-3">Visited</h2>
-            )}
+          <div className={myTrips.length > 0 || invitedTrips.length > 0 ? 'mt-8' : ''}>
+            {showHeadings && <h2 className="text-sm font-medium text-muted-foreground mb-3">Visited</h2>}
             {renderTripGrid(visitedTrips)}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Expose `emailDiscoveredTripIds` from `TripContext` — trips where a participant matches the user's email but hasn't been linked via "This is me" yet
- Add "Invited" section on `HomePage` between "My Trips" and "Visited" for these trips
- Hide "Remove" button on invited trips (user was explicitly added by someone)
- Section headings only show when 2+ sections have trips

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — all 193 tests pass
- [ ] Manual: sign in as user whose email was added as participant on another trip → appears under "Invited"
- [ ] Manual: click "This is me" on that trip → next refresh moves it to "My Trips"
- [ ] Manual: verify no "Remove" button on invited trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)