### PR TITLE
fix: redesign ThemeToggle as self-describing segmented control

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -7,23 +7,32 @@ const options = [
   { value: 'dark' as const, icon: Moon, label: 'Dark' },
 ]
 
-export function ThemeToggle() {
+interface ThemeToggleProps {
+  size?: 'default' | 'compact'
+}
+
+export function ThemeToggle({ size = 'default' }: ThemeToggleProps) {
   const { theme, setTheme } = useTheme()
 
+  const isCompact = size === 'compact'
+
   return (
-    <div className="flex items-center rounded-lg border border-border bg-muted/50 p-0.5">
+    <div className="flex items-center rounded-lg border border-border bg-muted/50 p-1 gap-1">
       {options.map(({ value, icon: Icon, label }) => (
         <button
           key={value}
           onClick={() => setTheme(value)}
           aria-label={label}
-          className={`rounded-md p-1.5 transition-colors ${
+          className={`flex items-center gap-1.5 rounded-md transition-colors ${
+            isCompact ? 'px-2 py-1' : 'px-3 py-1.5'
+          } ${
             theme === value
               ? 'bg-card text-foreground shadow-sm ring-1 ring-border'
               : 'text-muted-foreground hover:text-foreground'
           }`}
         >
-          <Icon size={14} />
+          <Icon size={isCompact ? 14 : 16} />
+          <span className="text-xs font-medium">{label}</span>
         </button>
       ))}
     </div>

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -71,9 +71,8 @@ export function UserMenu({ onGradient = false, compact = false }: UserMenuProps)
           Bank Details
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <div className="px-2 py-1.5 flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">Theme</span>
-          <ThemeToggle />
+        <div className="px-2 py-1.5">
+          <ThemeToggle size="compact" />
         </div>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => { signOut() }} className="gap-2 text-destructive focus:text-destructive">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -451,10 +451,7 @@ export function HomePage() {
         {/* Footer: theme toggle (for anon users) + What's New */}
         <div className="mt-8 flex flex-col items-center gap-3">
           {!isAuthenticated && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">Theme</span>
-              <ThemeToggle />
-            </div>
+            <ThemeToggle />
           )}
           {isAuthenticated && (
             <a

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -481,13 +481,9 @@ export function ManageTripPage() {
       <Card>
         <CardHeader>
           <CardTitle>Appearance</CardTitle>
-          <CardDescription>Choose your preferred color theme</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-between">
-            <Label>Theme</Label>
-            <ThemeToggle />
-          </div>
+          <ThemeToggle />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- Redesign ThemeToggle from icon-only pills to icon + text label buttons ("Light", "System", "Dark") so the control is self-explanatory
- Add `size` prop (`default` / `compact`) — compact variant used in UserMenu dropdown
- Remove redundant "Theme" labels from UserMenu, ManageTripPage, and HomePage footer

## Test plan
- [ ] Verify toggle renders with text labels in all 3 locations (UserMenu dropdown, ManageTripPage, HomePage footer for anon users)
- [ ] Verify compact size fits within the w-56 dropdown without overflow
- [ ] Verify active state styling (shadow + ring) in both light and dark mode
- [ ] Verify theme switching still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)