### PR TITLE
fix: fix ThemeToggle sizing in UserMenu and ManageTripPage

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -9,20 +9,22 @@ const options = [
 
 interface ThemeToggleProps {
   size?: 'default' | 'compact'
+  iconOnly?: boolean
 }
 
-export function ThemeToggle({ size = 'default' }: ThemeToggleProps) {
+export function ThemeToggle({ size = 'default', iconOnly = false }: ThemeToggleProps) {
   const { theme, setTheme } = useTheme()
 
   const isCompact = size === 'compact'
 
   return (
-    <div className="flex items-center rounded-lg border border-border bg-muted/50 p-1 gap-1">
+    <div className="flex items-center rounded-lg border border-border bg-muted/50 p-1 gap-1 w-fit">
       {options.map(({ value, icon: Icon, label }) => (
         <button
           key={value}
           onClick={() => setTheme(value)}
           aria-label={label}
+          title={label}
           className={`flex items-center gap-1.5 rounded-md transition-colors ${
             isCompact ? 'px-2 py-1' : 'px-3 py-1.5'
           } ${
@@ -32,7 +34,7 @@ export function ThemeToggle({ size = 'default' }: ThemeToggleProps) {
           }`}
         >
           <Icon size={isCompact ? 14 : 16} />
-          <span className="text-xs font-medium">{label}</span>
+          {!iconOnly && <span className="text-xs font-medium">{label}</span>}
         </button>
       ))}
     </div>

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -72,7 +72,7 @@ export function UserMenu({ onGradient = false, compact = false }: UserMenuProps)
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <div className="px-2 py-1.5">
-          <ThemeToggle size="compact" />
+          <ThemeToggle size="compact" iconOnly />
         </div>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => { signOut() }} className="gap-2 text-destructive focus:text-destructive">


### PR DESCRIPTION
## Summary
- Add `w-fit` to ThemeToggle container so it self-sizes instead of stretching to fill parent (fixes ManageTripPage full-width stretch)
- Add `iconOnly` prop to ThemeToggle, used in UserMenu dropdown to prevent "Dark" text truncation in the `w-56` dropdown
- Add `title` attribute to buttons for tooltip on hover when labels are hidden

## Test plan
- [ ] UserMenu dropdown: toggle fits without truncation, shows icons only with tooltips
- [ ] ManageTripPage: toggle is self-sized, not full-width
- [ ] HomePage footer: unchanged (centered, default size with labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)