### PR TITLE
fix: update version display to v1.2.0 (closes #644)

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -460,7 +460,7 @@ export function HomePage() {
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
-              What's New · v1.0.0
+              What's New · v1.2.0
               <ExternalLink size={12} />
             </a>
           )}


### PR DESCRIPTION
## Summary
- Updates hardcoded version string in HomePage footer from `v1.0.0` to `v1.2.0` to match current release notes

## Test plan
- [ ] Verify HomePage footer shows "What's New · v1.2.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)