### PR TITLE
chore: switch license from MIT to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Kristjan Elias
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -165,4 +165,4 @@ supabase functions deploy create-github-issue
 
 ## License
 
-MIT
+Apache 2.0 — see [LICENSE](LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "trip-splitter-pro",
   "private": true,
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Trash2, MapPin, User, ExternalLink } from 'lucide-react'

--- a/src/components/ActivityForm.tsx
+++ b/src/components/ActivityForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { motion } from 'framer-motion'
 import { ArrowDownToLine, ArrowUpFromLine, CheckCircle2 } from 'lucide-react'
 import { ParticipantBalance } from '@/services/balanceCalculator'

--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useMemo } from 'react'
 import { Receipt, Wallet, Users, Check, ArrowRight } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'

--- a/src/components/CostPerParticipantChart.tsx
+++ b/src/components/CostPerParticipantChart.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useMemo } from 'react'
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import type { ParticipantBalance } from '@/services/balanceCalculator'

--- a/src/components/DayAccordion.tsx
+++ b/src/components/DayAccordion.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { MealWithIngredients, MealType } from '@/types/meal'
 import type { Activity } from '@/types/activity'
 import { DateContext } from '@/lib/dateUtils'

--- a/src/components/DayBanner.tsx
+++ b/src/components/DayBanner.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Building2 } from 'lucide-react'
 import { DateContext, formatDayHeader } from '@/lib/dateUtils'
 import { getGradientPattern } from '@/services/gradientService'

--- a/src/components/DayDetailSheet.tsx
+++ b/src/components/DayDetailSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Building2, X } from 'lucide-react'
 import { getDayNumber, getDayContext } from '@/lib/dateUtils'
 import { Badge } from '@/components/ui/badge'

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Component, ErrorInfo, ReactNode } from 'react'
 import { AlertTriangle, Home, RefreshCw } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
 import { Calendar, Zap } from 'lucide-react'

--- a/src/components/ExpenseByCategoryChart.tsx
+++ b/src/components/ExpenseByCategoryChart.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useMemo } from 'react'
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
 import type { Expense } from '@/types/expense'

--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { motion } from 'framer-motion'
 import {
   UtensilsCrossed,

--- a/src/components/InstallGuide.tsx
+++ b/src/components/InstallGuide.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { X, ChevronDown, Smartphone } from 'lucide-react'
 import { usePWAInstall } from '@/hooks/usePWAInstall'

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom'
 import React from 'react'
 import { useState } from 'react'

--- a/src/components/LinkParticipantDialog.tsx
+++ b/src/components/LinkParticipantDialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { UserCheck } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'

--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { ChefHat, Trash2, ShoppingBasket, Utensils, Home, Receipt } from 'lucide-react'

--- a/src/components/MealCompletionRing.tsx
+++ b/src/components/MealCompletionRing.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 

--- a/src/components/MealForm.tsx
+++ b/src/components/MealForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { Sun, CloudSun, Moon, Plus, X, Utensils, Home, Receipt } from 'lucide-react'

--- a/src/components/MealGrid.tsx
+++ b/src/components/MealGrid.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Sunrise, Sun, Moon, Plus } from 'lucide-react'
 import { MealWithIngredients, MealType, MEAL_TYPE_LABELS } from '@/types/meal'

--- a/src/components/OnboardingPrompts.tsx
+++ b/src/components/OnboardingPrompts.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { X, LogIn, Landmark } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'

--- a/src/components/PageErrorState.tsx
+++ b/src/components/PageErrorState.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { AlertCircle, Loader2, RefreshCw } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'

--- a/src/components/PageLoadingState.tsx
+++ b/src/components/PageLoadingState.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import { Loader2 } from 'lucide-react'
 

--- a/src/components/ParticipantAvatar.tsx
+++ b/src/components/ParticipantAvatar.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import type { Participant } from '@/types/participant'
 
 interface ParticipantAvatarProps {

--- a/src/components/PlannerGrid.tsx
+++ b/src/components/PlannerGrid.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { cn } from '@/lib/utils'
 import { getDayContext } from '@/lib/dateUtils'
 import { Card } from '@/components/ui/card'

--- a/src/components/PullToRefreshIndicator.tsx
+++ b/src/components/PullToRefreshIndicator.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { ArrowDown, Loader2 } from 'lucide-react'
 
 const THRESHOLD = 80

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Outlet, Link, useParams, useLocation, useNavigate } from 'react-router-dom'
 import { ArrowLeft, ScanLine, Settings, LayoutGrid, Shield } from 'lucide-react'
 import { useState } from 'react'

--- a/src/components/ReportIssueButton.tsx
+++ b/src/components/ReportIssueButton.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Bug } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'

--- a/src/components/ReportIssueDialog.tsx
+++ b/src/components/ReportIssueDialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useRef } from 'react'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { useToast } from '@/hooks/use-toast'

--- a/src/components/SessionHealthGate.tsx
+++ b/src/components/SessionHealthGate.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { ReactNode } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useSessionHealth } from '@/hooks/useSessionHealth'

--- a/src/components/SettlementForm.tsx
+++ b/src/components/SettlementForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, FormEvent, useRef, useEffect, useMemo, forwardRef, useImperativeHandle } from 'react'
 import { motion } from 'framer-motion'
 import { Clipboard, Check, ExternalLink, Lightbulb } from 'lucide-react'

--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { PartyPopper, Lightbulb, Check, Bell, X } from 'lucide-react'
 import { OptimalSettlementPlan, SettlementTransaction } from '@/services/settlementOptimizer'

--- a/src/components/ShareTripDialog.tsx
+++ b/src/components/ShareTripDialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import QRCode from 'qrcode'
 import { Copy, Share2, Check, Mail, MessageCircle, Send } from 'lucide-react'

--- a/src/components/ShoppingItemCard.tsx
+++ b/src/components/ShoppingItemCard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Edit, Trash2 } from 'lucide-react'

--- a/src/components/ShoppingItemForm.tsx
+++ b/src/components/ShoppingItemForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/components/ShoppingItemRow.tsx
+++ b/src/components/ShoppingItemRow.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Trash2 } from 'lucide-react'
 import { useShoppingContext } from '@/contexts/ShoppingContext'

--- a/src/components/StaleSessionOverlay.tsx
+++ b/src/components/StaleSessionOverlay.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 

--- a/src/components/StayCard.tsx
+++ b/src/components/StayCard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Trash2, ExternalLink, MessageSquare } from 'lucide-react'

--- a/src/components/StayForm.tsx
+++ b/src/components/StayForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/components/StayMap.tsx
+++ b/src/components/StayMap.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet'
 import L from 'leaflet'

--- a/src/components/StaySection.tsx
+++ b/src/components/StaySection.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Building2, Plus } from 'lucide-react'
 import { useStayContext } from '@/contexts/StayContext'

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Sun, Monitor, Moon } from 'lucide-react'
 import { useTheme } from '@/hooks/useTheme'
 

--- a/src/components/TimeSlotGrid.tsx
+++ b/src/components/TimeSlotGrid.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Sunrise, Sun, Moon, Plus } from 'lucide-react'
 import { MealWithIngredients, MealType, MEAL_TYPE_LABELS } from '@/types/meal'

--- a/src/components/TopExpensesList.tsx
+++ b/src/components/TopExpensesList.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useMemo } from 'react'
 import { TrendingUp } from 'lucide-react'
 import type { Expense } from '@/types/expense'

--- a/src/components/TripBanner.tsx
+++ b/src/components/TripBanner.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { getTripGradientPattern } from '@/services/tripGradientService'
 import { motion } from 'framer-motion'
 

--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Calendar, ChevronRight } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Event } from '@/types/trip'

--- a/src/components/TripForm.tsx
+++ b/src/components/TripForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
 import { CreateTripInput } from '@/types/trip'

--- a/src/components/TripRouteGuard.tsx
+++ b/src/components/TripRouteGuard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/components/auth/BankDetailsDialog.tsx
+++ b/src/components/auth/BankDetailsDialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useToast } from '@/hooks/use-toast'

--- a/src/components/auth/SignInButton.tsx
+++ b/src/components/auth/SignInButton.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { GoogleLogin } from '@react-oauth/google'
 import { useAuth } from '@/contexts/AuthContext'
 import { logger } from '@/lib/logger'

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { Button } from '@/components/ui/button'

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useRef, useMemo, FormEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Lightbulb, ChevronDown, ChevronRight, Users, Check } from 'lucide-react'

--- a/src/components/expenses/ExpenseSplitPreview.tsx
+++ b/src/components/expenses/ExpenseSplitPreview.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useMemo } from 'react'
 import { ExpenseDistribution } from '@/types/expense'
 import { Participant } from '@/types/participant'

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useRef } from 'react'
 import {
   CreateExpenseInput,

--- a/src/components/expenses/wizard/WizardNavigation.tsx
+++ b/src/components/expenses/wizard/WizardNavigation.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 

--- a/src/components/expenses/wizard/WizardProgress.tsx
+++ b/src/components/expenses/wizard/WizardProgress.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { motion } from 'framer-motion'
 
 interface WizardProgressProps {

--- a/src/components/expenses/wizard/WizardStep1.tsx
+++ b/src/components/expenses/wizard/WizardStep1.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { motion } from 'framer-motion'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'

--- a/src/components/expenses/wizard/WizardStep2.tsx
+++ b/src/components/expenses/wizard/WizardStep2.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { Lightbulb } from 'lucide-react'

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ChevronDown, ChevronRight, Users, Check } from 'lucide-react'

--- a/src/components/expenses/wizard/WizardStep4.tsx
+++ b/src/components/expenses/wizard/WizardStep4.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { motion } from 'framer-motion'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'

--- a/src/components/quick/GroupActions.tsx
+++ b/src/components/quick/GroupActions.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { hideTrip } from '@/lib/mutedTripsStorage'
 import { removeFromMyTrips } from '@/lib/myTripsStorage'
 import { Button } from '@/components/ui/button'

--- a/src/components/quick/ModeToggle.tsx
+++ b/src/components/quick/ModeToggle.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { Zap, LayoutGrid } from 'lucide-react'

--- a/src/components/quick/QuickActionButton.tsx
+++ b/src/components/quick/QuickActionButton.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { LucideIcon } from 'lucide-react'
 import { motion } from 'framer-motion'
 

--- a/src/components/quick/QuickBalanceHero.tsx
+++ b/src/components/quick/QuickBalanceHero.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { ParticipantBalance, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
 import { motion } from 'framer-motion'
 

--- a/src/components/quick/QuickCreateSheet.tsx
+++ b/src/components/quick/QuickCreateSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useNavigate } from 'react-router-dom'
 import { X } from 'lucide-react'
 import { useTripContext } from '@/contexts/TripContext'

--- a/src/components/quick/QuickExpenseSheet.tsx
+++ b/src/components/quick/QuickExpenseSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
 import { useExpenseContext } from '@/contexts/ExpenseContext'

--- a/src/components/quick/QuickGroupMembersSheet.tsx
+++ b/src/components/quick/QuickGroupMembersSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'

--- a/src/components/quick/QuickHistorySheet.tsx
+++ b/src/components/quick/QuickHistorySheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useMemo } from 'react'
 import { X, FileText } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/components/quick/QuickParticipantPicker.tsx
+++ b/src/components/quick/QuickParticipantPicker.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useMemo, useRef, useCallback, FormEvent } from 'react'
 import { Plus, UserPlus, X, Users, Smartphone, ChevronRight, Check, Baby } from 'lucide-react'
 import { useParticipantContext } from '@/contexts/ParticipantContext'

--- a/src/components/quick/QuickParticipantSetupSheet.tsx
+++ b/src/components/quick/QuickParticipantSetupSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { ParticipantsSetup } from '@/components/setup/ParticipantsSetup'

--- a/src/components/quick/QuickScanContextSheet.tsx
+++ b/src/components/quick/QuickScanContextSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useNavigate } from 'react-router-dom'
 import { Plus, ScanLine, X } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Camera, Upload, Loader2, X, ScanLine, ChevronRight } from 'lucide-react'

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useRef, useMemo, useEffect, useCallback } from 'react'
 import { ArrowRight, ArrowLeft, PartyPopper, Bell, Check, X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/components/quick/TransactionItem.tsx
+++ b/src/components/quick/TransactionItem.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { TransactionItem as TxItem } from '@/services/transactionHistoryBuilder'
 import { convertToBaseCurrency } from '@/services/balanceCalculator'
 import { DollarSign, ArrowUpRight, ArrowDownLeft } from 'lucide-react'

--- a/src/components/receipts/PendingReceiptBanner.tsx
+++ b/src/components/receipts/PendingReceiptBanner.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { ScanLine } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ReceiptTask, ExtractedItem, MappedItem } from '@/types/receipt'

--- a/src/components/receipts/ReceiptCaptureSheet.tsx
+++ b/src/components/receipts/ReceiptCaptureSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useRef } from 'react'
 import { Camera, Upload, Loader2, X, ScanLine } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'

--- a/src/components/receipts/ReceiptDetailsSheet.tsx
+++ b/src/components/receipts/ReceiptDetailsSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { Loader2, Users, ChevronDown, ChevronUp, AlertCircle, SplitSquareHorizontal, Image, X } from 'lucide-react'
 import { logger } from '@/lib/logger'

--- a/src/components/setup/IndividualsSetup.tsx
+++ b/src/components/setup/IndividualsSetup.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, FormEvent } from 'react'
 import { motion } from 'framer-motion'
 import { X, UserPlus, Mail, Pencil, Check, UserCheck } from 'lucide-react'

--- a/src/components/setup/ParticipantsSetup.tsx
+++ b/src/components/setup/ParticipantsSetup.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useMemo, useRef, useEffect, useCallback, FormEvent } from 'react'
 import { motion } from 'framer-motion'
 import { X, UserPlus, Mail, Pencil, Check, UserCheck, Users, ChevronRight, Plus, Send, Baby, MoreHorizontal } from 'lucide-react'

--- a/src/components/ui/AppSheet.tsx
+++ b/src/components/ui/AppSheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * SHEET STANDARD — DO NOT DEVIATE
  *

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
 import { ChevronDown } from "lucide-react"

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { cn } from "@/lib/utils"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { cn } from "@/lib/utils"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 "use client"
 
 import * as React from "react"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { cn } from "@/lib/utils"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 "use client"
 
 import * as React from "react"

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as SwitchPrimitive from "@radix-ui/react-switch"
 import { cn } from "@/lib/utils"

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 "use client"
 
 import * as React from "react"

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from "react"
 import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useToast } from "@/hooks/use-toast"
 import {
   Toast,

--- a/src/contexts/ActivityContext.test.tsx
+++ b/src/contexts/ActivityContext.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { ActivityProvider, useActivityContext } from './ActivityContext'

--- a/src/contexts/ActivityContext.tsx
+++ b/src/contexts/ActivityContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, act, waitFor } from '@testing-library/react'
 import { AuthProvider, useAuth } from './AuthContext'

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { User, Session } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase'

--- a/src/contexts/ExpenseContext.test.tsx
+++ b/src/contexts/ExpenseContext.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { ExpenseProvider, useExpenseContext } from './ExpenseContext'

--- a/src/contexts/ExpenseContext.tsx
+++ b/src/contexts/ExpenseContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import {

--- a/src/contexts/MealContext.tsx
+++ b/src/contexts/MealContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/contexts/ParticipantContext.tsx
+++ b/src/contexts/ParticipantContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, useRef, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import {

--- a/src/contexts/PullToRefreshContext.tsx
+++ b/src/contexts/PullToRefreshContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useRef, useState, useCallback, type ReactNode } from 'react'
 
 interface PullToRefreshContextValue {

--- a/src/contexts/ReceiptContext.tsx
+++ b/src/contexts/ReceiptContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { ReceiptTask, ExtractedItem, MappedItem } from '@/types/receipt'

--- a/src/contexts/SettlementContext.tsx
+++ b/src/contexts/SettlementContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import {

--- a/src/contexts/ShoppingContext.test.tsx
+++ b/src/contexts/ShoppingContext.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
 import { ShoppingProvider, useShoppingContext } from './ShoppingContext'

--- a/src/contexts/ShoppingContext.tsx
+++ b/src/contexts/ShoppingContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/contexts/StayContext.test.tsx
+++ b/src/contexts/StayContext.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { StayProvider, useStayContext } from './StayContext'

--- a/src/contexts/StayContext.tsx
+++ b/src/contexts/StayContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/contexts/TripContext.test.tsx
+++ b/src/contexts/TripContext.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { TripProvider, useTripContext } from './TripContext'

--- a/src/contexts/TripContext.tsx
+++ b/src/contexts/TripContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'

--- a/src/contexts/UserPreferencesContext.test.tsx
+++ b/src/contexts/UserPreferencesContext.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
 import { UserPreferencesProvider, useUserPreferences } from './UserPreferencesContext'

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useEffect, useRef, ReactNode, useCallback } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 "use client"
 
 // Inspired by react-hot-toast library

--- a/src/hooks/useAbortController.ts
+++ b/src/hooks/useAbortController.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useRef, useEffect } from 'react'
 
 export function useAbortController() {

--- a/src/hooks/useAutoLinkParticipant.test.tsx
+++ b/src/hooks/useAutoLinkParticipant.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useAutoLinkParticipant } from './useAutoLinkParticipant'

--- a/src/hooks/useAutoLinkParticipant.ts
+++ b/src/hooks/useAutoLinkParticipant.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useRef, useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'

--- a/src/hooks/useBankDetailsPrompt.ts
+++ b/src/hooks/useBankDetailsPrompt.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useCallback } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 

--- a/src/hooks/useCurrentTrip.test.tsx
+++ b/src/hooks/useCurrentTrip.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'

--- a/src/hooks/useCurrentTrip.ts
+++ b/src/hooks/useCurrentTrip.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTripContext } from '@/contexts/TripContext'

--- a/src/hooks/useIOSScrollFix.ts
+++ b/src/hooks/useIOSScrollFix.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useRef, useEffect, type RefObject } from 'react'
 
 const isIOS =

--- a/src/hooks/useKeyboardHeight.ts
+++ b/src/hooks/useKeyboardHeight.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 
 interface KeyboardState {

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 
 /**

--- a/src/hooks/useMyParticipant.test.tsx
+++ b/src/hooks/useMyParticipant.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useMyParticipant } from './useMyParticipant'

--- a/src/hooks/useMyParticipant.ts
+++ b/src/hooks/useMyParticipant.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 

--- a/src/hooks/useMyTripBalances.ts
+++ b/src/hooks/useMyTripBalances.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
 import { withTimeout } from '@/lib/fetchWithTimeout'

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useCallback } from 'react'
 
 const DISMISSED_KEY = 'spl1t:install-prompt-dismissed'

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useRef, useState, useEffect, useCallback } from 'react'
 import { usePullToRefreshContext } from '@/contexts/PullToRefreshContext'
 

--- a/src/hooks/useRegisterRefresh.ts
+++ b/src/hooks/useRegisterRefresh.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect } from 'react'
 import { usePullToRefreshContext } from '@/contexts/PullToRefreshContext'
 

--- a/src/hooks/useScrollIntoView.ts
+++ b/src/hooks/useScrollIntoView.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, RefObject } from 'react'
 
 interface UseScrollIntoViewOptions {

--- a/src/hooks/useSessionHealth.ts
+++ b/src/hooks/useSessionHealth.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { Session } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase'

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback } from 'react'
 
 type Theme = 'light' | 'dark' | 'system'

--- a/src/hooks/useTripContacts.test.tsx
+++ b/src/hooks/useTripContacts.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { useTripContacts } from './useTripContacts'

--- a/src/hooks/useTripContacts.ts
+++ b/src/hooks/useTripContacts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useRef } from 'react'
 import { supabase } from '@/lib/supabase'
 import { withTimeout } from '@/lib/fetchWithTimeout'

--- a/src/lib/activeTripDetection.test.ts
+++ b/src/lib/activeTripDetection.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getActiveTripId } from './activeTripDetection'
 import { buildTrip } from '@/test/factories'

--- a/src/lib/activeTripDetection.ts
+++ b/src/lib/activeTripDetection.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Trip } from '@/types/trip'
 
 /**

--- a/src/lib/adminAuth.test.ts
+++ b/src/lib/adminAuth.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest'
 import { isAdminUser } from './adminAuth'
 

--- a/src/lib/adminAuth.ts
+++ b/src/lib/adminAuth.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Admin Access Control
  *

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Variants, Transition } from "framer-motion"
 
 /**

--- a/src/lib/categoryInference.ts
+++ b/src/lib/categoryInference.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import type { ExpenseCategory } from '@/types/expense'
 
 const CATEGORY_KEYWORDS: Record<Exclude<ExpenseCategory, 'Other'>, string[]> = {

--- a/src/lib/database.types.generated.ts
+++ b/src/lib/database.types.generated.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type Json =
   | string
   | number

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type Json =
   | string
   | number

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getDayContext, formatDayHeader, getDayNumber, generateDateRange } from './dateUtils'
 

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Date utility functions for meal planner
  */

--- a/src/lib/debugLogger.ts
+++ b/src/lib/debugLogger.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Debug logger for production diagnostics.
  *

--- a/src/lib/fetchWithTimeout.ts
+++ b/src/lib/fetchWithTimeout.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Wraps a promise with a timeout. If the promise doesn't resolve within
  * the specified milliseconds, the returned promise rejects with a timeout error.

--- a/src/lib/groupColors.ts
+++ b/src/lib/groupColors.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 const GROUP_BORDER_COLORS = [
   'border-l-blue-500',
   'border-l-emerald-500',

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { supabase } from '@/lib/supabase'
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error'

--- a/src/lib/mutedTripsStorage.ts
+++ b/src/lib/mutedTripsStorage.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Hidden Trips Storage
  * Tracks trips the user has hidden from Quick Mode home.

--- a/src/lib/myTripsStorage.test.ts
+++ b/src/lib/myTripsStorage.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach } from 'vitest'
 import {
   getMyTrips,

--- a/src/lib/myTripsStorage.ts
+++ b/src/lib/myTripsStorage.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * My Trips Storage Service
  *

--- a/src/lib/participantUtils.ts
+++ b/src/lib/participantUtils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import type { Participant } from '@/types/participant'
 
 export function getShortName(p: Pick<Participant, 'name' | 'nickname'>): string {

--- a/src/lib/sessionHealthBus.ts
+++ b/src/lib/sessionHealthBus.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 type Event = 'auth-error' | 'api-success'
 type Listener = () => void
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { createClient } from '@supabase/supabase-js'
 import type { Database } from './database.types'
 import { sessionHealthBus } from './sessionHealthBus'

--- a/src/lib/tripCodeGenerator.test.ts
+++ b/src/lib/tripCodeGenerator.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest'
 import {
   createTripSlug,

--- a/src/lib/tripCodeGenerator.ts
+++ b/src/lib/tripCodeGenerator.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { customAlphabet } from 'nanoid'
 
 /**

--- a/src/lib/userPreferencesStorage.test.ts
+++ b/src/lib/userPreferencesStorage.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach } from 'vitest'
 import { getLocalPreferences, setLocalPreferences } from './userPreferencesStorage'
 

--- a/src/lib/userPreferencesStorage.ts
+++ b/src/lib/userPreferencesStorage.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * User Preferences localStorage fallback
  * Used for instant reads and as fallback when user is not authenticated.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 

--- a/src/pages/AdminAllTripsPage.tsx
+++ b/src/pages/AdminAllTripsPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Search, ExternalLink, Calendar, UserCircle, ShieldAlert } from 'lucide-react'

--- a/src/pages/ConditionalHomePage.test.tsx
+++ b/src/pages/ConditionalHomePage.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'

--- a/src/pages/ConditionalHomePage.tsx
+++ b/src/pages/ConditionalHomePage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useRef } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Lightbulb, Receipt, FileDown, Share2, Landmark, X } from 'lucide-react'

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useCallback } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Plus, Search, Receipt, FileDown, SlidersHorizontal, User, Tag } from 'lucide-react'

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { useNavigate } from 'react-router-dom'

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { supabase } from '@/lib/supabase'

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Edit, Trash2, Info, X, Plus, ArrowLeft } from 'lucide-react'

--- a/src/pages/MealsPage.tsx
+++ b/src/pages/MealsPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import { UtensilsCrossed, ChevronsDown, ChevronsUp } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, lazy, Suspense, useCallback } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { CalendarDays, Map } from 'lucide-react'

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { useNavigate, useLocation, Link } from 'react-router-dom'

--- a/src/pages/QuickHistoryPage.tsx
+++ b/src/pages/QuickHistoryPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useMemo } from 'react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMyParticipant } from '@/hooks/useMyParticipant'

--- a/src/pages/RemindPage.tsx
+++ b/src/pages/RemindPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { SignInButton } from '@/components/auth/SignInButton'

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { useMediaQuery } from '@/hooks/useMediaQuery'

--- a/src/pages/ShoppingPage.tsx
+++ b/src/pages/ShoppingPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Plus, ShoppingCart, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'

--- a/src/pages/TripNotFoundPage.tsx
+++ b/src/pages/TripNotFoundPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useParams, useNavigate } from 'react-router-dom'
 import { AlertCircle, Home, Search } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest'
 import {
   convertToBaseCurrency,

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Expense } from '@/types/expense'
 import { Participant } from '@/types/participant'
 import { Settlement } from '@/types/settlement'

--- a/src/services/excelExport.ts
+++ b/src/services/excelExport.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as XLSX from 'xlsx'
 import type { Trip } from '@/types/trip'
 import type { Expense } from '@/types/expense'

--- a/src/services/gradientService.ts
+++ b/src/services/gradientService.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Gradient Service with Food-Themed Patterns
  * Generates deterministic gradient backgrounds with food icon overlays

--- a/src/services/mealExpenseLinkService.test.ts
+++ b/src/services/mealExpenseLinkService.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest'
 import { canLinkExpenseToMeal } from './mealExpenseLinkService'
 import { buildExpense } from '@/test/factories'

--- a/src/services/mealExpenseLinkService.ts
+++ b/src/services/mealExpenseLinkService.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Meal-Expense Linking Service
  * Handles the relationship between restaurant meals and expenses

--- a/src/services/pdfExport.ts
+++ b/src/services/pdfExport.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import type { Trip } from '@/types/trip'

--- a/src/services/settlementOptimizer.test.ts
+++ b/src/services/settlementOptimizer.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest'
 import {
   calculateOptimalSettlement,

--- a/src/services/settlementOptimizer.ts
+++ b/src/services/settlementOptimizer.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { ParticipantBalance } from './balanceCalculator'
 
 export interface SettlementTransaction {

--- a/src/services/transactionHistoryBuilder.test.ts
+++ b/src/services/transactionHistoryBuilder.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest'
 import { buildTransactionHistory } from './transactionHistoryBuilder'
 import { buildParticipant, buildExpense, buildSettlement } from '@/test/factories'

--- a/src/services/transactionHistoryBuilder.ts
+++ b/src/services/transactionHistoryBuilder.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Expense } from '@/types/expense'
 import { Settlement } from '@/types/settlement'
 import { Participant } from '@/types/participant'

--- a/src/services/tripGradientService.ts
+++ b/src/services/tripGradientService.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Trip Gradient Service with Location-Themed Patterns
  * Generates themed gradient backgrounds with location-specific icon overlays

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import type { Participant } from '@/types/participant'
 import type { Expense, ExpenseDistribution } from '@/types/expense'
 import type { Settlement } from '@/types/settlement'

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { vi } from 'vitest'
 
 interface MockResponse {

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { render, RenderOptions } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { ReactElement } from 'react'

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import '@testing-library/jest-dom'
 import { cleanup } from '@testing-library/react'
 import { afterEach, vi } from 'vitest'

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type ActivityTimeSlot = 'morning' | 'afternoon' | 'evening'
 
 export interface Activity {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export interface UserProfile {
   id: string
   display_name: string

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type ExpenseCategory =
   | 'Accommodation'
   | 'Food'

--- a/src/types/meal.ts
+++ b/src/types/meal.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type MealType = 'breakfast' | 'lunch' | 'dinner'
 
 export interface Meal {

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export interface Participant {
   id: string
   trip_id: string

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type ReceiptTaskStatus = 'pending' | 'processing' | 'review' | 'complete' | 'failed';
 
 export interface ExtractedItem {

--- a/src/types/settlement.ts
+++ b/src/types/settlement.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Settlement represents a payment transfer between two participants/families
  * Used to record when someone pays back their debt

--- a/src/types/shopping.ts
+++ b/src/types/shopping.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type ShoppingCategory =
   | 'produce'
   | 'dairy'

--- a/src/types/stay.ts
+++ b/src/types/stay.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export interface Stay {
   id: string
   trip_id: string

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type TrackingMode = 'individuals' | 'families'
 
 export interface Event {


### PR DESCRIPTION
## Summary
- Add Apache License 2.0 `LICENSE` file with copyright 2026 Kristjan Elias
- Add `"license": "Apache-2.0"` to `package.json`
- Update README.md license section from MIT to Apache 2.0
- Add `// SPDX-License-Identifier: Apache-2.0` header to all 213 `.ts`/`.tsx` files in `src/`

## Test plan
- [x] `npm run type-check` passes clean
- [x] `npm test` — all 193 tests pass
- [x] No stale MIT references in `.md` files
- [x] All 213 source files have SPDX header

🤖 Generated with [Claude Code](https://claude.com/claude-code)