### PR TITLE
fix: PlannerGrid theme switching + split cell stripe bleed

### DIFF
--- a/src/components/PlannerGrid.tsx
+++ b/src/components/PlannerGrid.tsx
@@ -288,9 +288,11 @@ export function PlannerGrid({
                   }
 
                   if (!isSplit && staysOnDate.length === 1 && staysOnDate[0].check_out_date === date) {
+                    // Checkout→Home split: stay top-left, home bottom-right
+                    // Solid stay diagonal covers stripe on left; stripe visible only on home (right) half
                     const departIdx = stayColorMap.get(staysOnDate[0].id) ?? 0
                     splitStyle = {
-                      background: `${homeStripe}, linear-gradient(135deg, ${stayHexBg[departIdx % stayHexBg.length]} 50%, ${homeHexBg} 50%)`,
+                      background: `linear-gradient(135deg, ${stayHexBg[departIdx % stayHexBg.length]} 50%, transparent 50%), ${homeStripe}, ${homeHexBg}`,
                     }
                     splitBorderClass = 'border-border'
                   }
@@ -298,9 +300,10 @@ export function PlannerGrid({
                   // Last trip day: show split to Home if stay extends past the trip
                   const lastTripDate = tripDates[tripDates.length - 1]
                   if (!splitStyle && !isSplit && stay && date === lastTripDate && stay.check_out_date !== date) {
+                    // Checkout→Home split: stay top-left, home bottom-right
                     const stayIdx = stayColorMap.get(stay.id) ?? 0
                     splitStyle = {
-                      background: `${homeStripe}, linear-gradient(135deg, ${stayHexBg[stayIdx % stayHexBg.length]} 50%, ${homeHexBg} 50%)`,
+                      background: `linear-gradient(135deg, ${stayHexBg[stayIdx % stayHexBg.length]} 50%, transparent 50%), ${homeStripe}, ${homeHexBg}`,
                     }
                     splitBorderClass = 'border-border'
                   }
@@ -308,9 +311,11 @@ export function PlannerGrid({
                   // First trip day: show Home→Stay split if stay starts on this day
                   const firstTripDate = tripDates[0]
                   if (!splitStyle && !isSplit && stay && date === firstTripDate && stay.check_in_date === date) {
+                    // Home→Stay split: home top-left, stay bottom-right
+                    // Solid stay diagonal covers stripe on right; stripe visible only on home (left) half
                     const stayIdx = stayColorMap.get(stay.id) ?? 0
                     splitStyle = {
-                      background: `${homeStripe}, linear-gradient(135deg, ${homeHexBg} 50%, ${stayHexBg[stayIdx % stayHexBg.length]} 50%)`,
+                      background: `linear-gradient(135deg, transparent 50%, ${stayHexBg[stayIdx % stayHexBg.length]} 50%), ${homeStripe}, ${homeHexBg}`,
                     }
                     splitBorderClass = 'border-border'
                   }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useEffect, useCallback } from 'react'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
 
 type Theme = 'light' | 'dark' | 'system'
 
 const STORAGE_KEY = 'spl1t:theme'
 const DARK_BG = '#1A1A2E'
 const LIGHT_BG = '#e8613a'
+
+// Module-level shared state
+let currentTheme: Theme = getStoredTheme()
+const listeners = new Set<() => void>()
 
 function getStoredTheme(): Theme {
   try {
@@ -17,6 +21,10 @@ function getStoredTheme(): Theme {
 
 function getSystemPrefersDark(): boolean {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+function resolveTheme(theme: Theme): 'light' | 'dark' {
+  return theme === 'system' ? (getSystemPrefersDark() ? 'dark' : 'light') : theme
 }
 
 function applyTheme(resolved: 'light' | 'dark') {
@@ -38,41 +46,49 @@ function applyTheme(resolved: 'light' | 'dark') {
   })
 }
 
-export function useTheme() {
-  const [theme, setThemeState] = useState<Theme>(getStoredTheme)
+function notifyListeners() {
+  listeners.forEach(listener => listener())
+}
 
-  const resolvedTheme: 'light' | 'dark' =
-    theme === 'system' ? (getSystemPrefersDark() ? 'dark' : 'light') : theme
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot(): Theme {
+  return currentTheme
+}
+
+// Listen for system preference changes (module-level, runs once)
+if (typeof window !== 'undefined') {
+  const mql = window.matchMedia('(prefers-color-scheme: dark)')
+  mql.addEventListener('change', (e) => {
+    if (currentTheme === 'system') {
+      applyTheme(e.matches ? 'dark' : 'light')
+      // Notify listeners to re-render with new resolvedTheme
+      notifyListeners()
+    }
+  })
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot)
+
+  const resolvedTheme = resolveTheme(theme)
 
   const setTheme = useCallback((newTheme: Theme) => {
-    setThemeState(newTheme)
+    currentTheme = newTheme
     try {
       localStorage.setItem(STORAGE_KEY, newTheme)
     } catch {}
-    const resolved = newTheme === 'system'
-      ? (getSystemPrefersDark() ? 'dark' : 'light')
-      : newTheme
-    applyTheme(resolved)
+    applyTheme(resolveTheme(newTheme))
+    notifyListeners()
   }, [])
 
   // Apply on mount
   useEffect(() => {
     applyTheme(resolvedTheme)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Listen for system preference changes when in 'system' mode
-  useEffect(() => {
-    const mql = window.matchMedia('(prefers-color-scheme: dark)')
-    const handler = (e: MediaQueryListEvent) => {
-      if (theme === 'system') {
-        applyTheme(e.matches ? 'dark' : 'light')
-        // Force re-render so resolvedTheme updates
-        setThemeState('system')
-      }
-    }
-    mql.addEventListener('change', handler)
-    return () => mql.removeEventListener('change', handler)
-  }, [theme])
 
   return { theme, setTheme, resolvedTheme }
 }


### PR DESCRIPTION
## Summary
- **useTheme shared state**: Refactored `useTheme()` from independent `useState` per consumer to `useSyncExternalStore` with module-level state. All components using `useTheme()` now re-render instantly when theme changes — fixes stale inline hex colors on PlannerGrid split cells.
- **Split cell stripe fix**: Changed background layering on checkout/first-day split cells so the solid stay color diagonal is painted ON TOP of the home stripe pattern, making the stripe visible only on the Home half. Stay halves now look identical to regular solid stay days.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — all 193 tests pass
- [ ] Manual: open Day Planner with stays → toggle light/dark repeatedly → all cells (split + solid) update instantly
- [ ] Manual: first/last day split cells — stay half matches other solid stay days, stripe only on Home half

🤖 Generated with [Claude Code](https://claude.com/claude-code)