### PR TITLE
chore: add SPDX license headers and gitignore .playwright-mcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ scripts/migrate.js
 test-results/
 playwright-report/
 /playwright/.cache/
+.playwright-mcp/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { GoogleOAuthProvider } from '@react-oauth/google'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { Layout } from './components/Layout'
 import { QuickLayout } from './components/QuickLayout'

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {


### PR DESCRIPTION
## Summary

- Added `// SPDX-License-Identifier: Apache-2.0` to 4 root source files (App.tsx, main.tsx, routes.tsx, vite-env.d.ts)
- Added `.playwright-mcp/` to `.gitignore`

## Test plan

- [x] No code changes — headers are comments, gitignore is config

🤖 Generated with [Claude Code](https://claude.com/claude-code)