### PR TITLE
fix: use bottom Sheet for expense edit mode on mobile

### DIFF
--- a/docs/CARD_SHEET_STANDARD.md
+++ b/docs/CARD_SHEET_STANDARD.md
@@ -373,7 +373,7 @@ Copy-paste this into PR reviews for any new or modified sheet/dialog:
 | Component | File | Opens as | Dual mode | Height | hideClose | Header shrink-0 | IOSScrollFix | pwa-safe-bottom | Keyboard pattern | Issues |
 |-----------|------|----------|-----------|--------|-----------|-----------------|--------------|-----------------|------------------|--------|
 | AppSheet | ui/AppSheet.tsx | Sheet | N/A (base) | 92/75dvh | ✅ | ✅ | ✅ | ✅ footer | **top-based** ✅ | — |
-| MobileWizard | expenses/ExpenseWizard.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
+| MobileWizard | expenses/ExpenseWizard.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | Edit mode also uses Sheet on mobile (MobileEditSheet) |
 | SettlementsPage | pages/SettlementsPage.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
 | QuickSettlementSheet | quick/QuickSettlementSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
 | QuickCreateSheet | quick/QuickCreateSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ❌ | **top-based** ✅ | — |

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useEffect, useRef, useMemo, FormEvent } from 'react'
+import { useState, useEffect, useRef, useMemo, FormEvent, type RefObject } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Lightbulb, ChevronDown, ChevronRight, Users, Check } from 'lucide-react'
 import { CreateExpenseInput, ExpenseCategory, ExpenseDistribution, SplitMode } from '@/types/expense'
@@ -32,6 +32,7 @@ interface ExpenseFormProps {
   initialValues?: Partial<CreateExpenseInput>
   submitLabel?: string
   stickyFooter?: boolean
+  scrollRef?: RefObject<HTMLDivElement>
 }
 
 const CATEGORIES: ExpenseCategory[] = [
@@ -49,6 +50,7 @@ export function ExpenseForm({
   initialValues,
   submitLabel = 'Add Expense',
   stickyFooter = false,
+  scrollRef,
 }: ExpenseFormProps) {
   const { currentTrip } = useCurrentTrip()
   const { participants, getAdultParticipants } = useParticipantContext()
@@ -836,7 +838,7 @@ export function ExpenseForm({
     >
       {stickyFooter ? (
         <>
-          <div className="flex-1 overflow-y-auto overscroll-contain space-y-3 pb-3">
+          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain space-y-3 pb-3">
             {formFields}
           </div>
           {buttons}

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -45,8 +45,8 @@ export function ExpenseWizard({
 }: ExpenseWizardProps) {
   const isMobile = useMediaQuery('(max-width: 768px)')
 
-  // For edit mode or desktop, use the traditional form
-  if (mode === 'edit' || !isMobile) {
+  // Desktop: always use Dialog (both create and edit)
+  if (!isMobile) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col p-0 gap-0" aria-describedby={undefined}>
@@ -67,7 +67,19 @@ export function ExpenseWizard({
     )
   }
 
-  // Mobile wizard implementation
+  // Mobile edit: bottom Sheet with ExpenseForm
+  if (mode === 'edit') {
+    return (
+      <MobileEditSheet
+        open={open}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+      />
+    )
+  }
+
+  // Mobile create: multi-step wizard
   return (
     <MobileWizard
       open={open}
@@ -75,6 +87,62 @@ export function ExpenseWizard({
       onSubmit={onSubmit}
       initialValues={initialValues}
     />
+  )
+}
+
+function MobileEditSheet({
+  open,
+  onOpenChange,
+  onSubmit,
+  initialValues,
+}: Omit<ExpenseWizardProps, 'mode'>) {
+  const keyboard = useKeyboardHeight()
+  const scrollRef = useIOSScrollFix()
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        hideClose
+        className="flex flex-col p-0 rounded-t-2xl"
+        style={{
+          height: keyboard.isVisible
+            ? `${keyboard.availableHeight}px`
+            : '92dvh',
+          ...(keyboard.isVisible && {
+            top: `${keyboard.viewportOffset}px`,
+            bottom: 'auto',
+          }),
+        }}
+      >
+        {/* Sticky header */}
+        <div className="shrink-0 border-b border-border">
+          <div className="flex items-center justify-between px-4 py-3">
+            <div className="w-8" />
+            <SheetTitle className="text-base font-semibold">Edit Expense</SheetTitle>
+            <button
+              onClick={() => onOpenChange(false)}
+              aria-label="Close"
+              className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+            >
+              <X className="w-4 h-4 text-muted-foreground" />
+            </button>
+          </div>
+        </div>
+
+        {/* ExpenseForm with stickyFooter handles scroll + buttons internally */}
+        <div className="flex-1 min-h-0 flex flex-col px-6 py-4 pwa-safe-bottom">
+          <ExpenseForm
+            onSubmit={onSubmit}
+            onCancel={() => onOpenChange(false)}
+            initialValues={initialValues}
+            submitLabel="Update Expense"
+            stickyFooter
+            scrollRef={scrollRef}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
   )
 }
 


### PR DESCRIPTION
## Summary
- **ExpenseWizard**: Edit mode on mobile now renders `ExpenseForm` inside a standard bottom Sheet (`MobileEditSheet`) instead of a centered Dialog
- **ExpenseForm**: Added optional `scrollRef` prop so the iOS scroll fix (`useIOSScrollFix`) can reach the internal scroll container when `stickyFooter` is true
- Desktop behavior unchanged (Dialog for both create and edit)
- Mobile create behavior unchanged (multi-step MobileWizard)

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — all 193 tests pass
- [ ] Mobile viewport: editing an expense opens a bottom Sheet (not centered Dialog)
- [ ] Desktop viewport: editing an expense still opens centered Dialog
- [ ] Mobile viewport: creating an expense still uses multi-step MobileWizard
- [ ] iOS: keyboard opens correctly in edit Sheet, header stays visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)