### PR TITLE
feat: ResponsiveOverlay — convert 13 dialog-only overlays to bottom sheets on mobile

### DIFF
--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -2,13 +2,13 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Trash2, MapPin, User, ExternalLink } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { useActivityContext } from '@/contexts/ActivityContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import type { Activity } from '@/types/activity'
 import { ActivityForm } from './ActivityForm'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
   Dialog,
   DialogContent,
@@ -27,7 +27,6 @@ export function ActivityCard({ activity }: ActivityCardProps) {
   const { participants } = useParticipantContext()
   const [showEditForm, setShowEditForm] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const scrollRef = useIOSScrollFix()
 
   const responsiblePerson = activity.responsible_participant_id
     ? participants.find((p) => p.id === activity.responsible_participant_id)
@@ -96,23 +95,16 @@ export function ActivityCard({ activity }: ActivityCardProps) {
         </Card>
       </motion.div>
 
-      {/* Edit Form Dialog */}
-      <Dialog open={showEditForm} onOpenChange={setShowEditForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>Edit Activity</DialogTitle>
-            </DialogHeader>
-            <ActivityForm
-              activity={activity}
-              date={activity.activity_date}
-              timeSlot={activity.time_slot}
-              onSuccess={() => setShowEditForm(false)}
-              onCancel={() => setShowEditForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Edit Form */}
+      <ResponsiveOverlay open={showEditForm} onClose={() => setShowEditForm(false)} title="Edit Activity" hasInputs>
+        <ActivityForm
+          activity={activity}
+          date={activity.activity_date}
+          timeSlot={activity.time_slot}
+          onSuccess={() => setShowEditForm(false)}
+          onCancel={() => setShowEditForm(false)}
+        />
+      </ResponsiveOverlay>
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>

--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useMemo } from 'react'
 import { Receipt, Wallet, Users, Check, ArrowRight } from 'lucide-react'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import { Badge } from '@/components/ui/badge'
 import { ParticipantBalance, formatBalance, getBalanceColorClass, convertToBaseCurrency, calculateExpenseShares, buildEntityMap, calculateWithinGroupBalances } from '@/services/balanceCalculator'
 import { Expense } from '@/types/expense'
@@ -109,18 +108,20 @@ export function CostBreakdownDialog({
   }, [settlements, groupMembers, groupName])
 
   const participantNameMap = useMemo(() => buildShortNameMap(participants), [participants])
-  const scrollRef = useIOSScrollFix()
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] sm:max-w-xl flex flex-col p-0 gap-0">
-        <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6 space-y-4">
-        <DialogHeader>
-          <DialogTitle>{balance.name}</DialogTitle>
-          <DialogDescription>
-            Balance: <span className={`font-semibold ${balanceColorClass}`}>{formatBalance(balance.balance, defaultCurrency)}</span>
-          </DialogDescription>
-        </DialogHeader>
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title={balance.name}
+      maxWidth="sm:max-w-xl"
+      headerExtra={
+        <p className="text-sm text-muted-foreground px-4 pb-3 text-center">
+          Balance: <span className={`font-semibold ${balanceColorClass}`}>{formatBalance(balance.balance, defaultCurrency)}</span>
+        </p>
+      }
+    >
+      <div className="space-y-4">
 
         {/* Within-group breakdown */}
         {withinGroupBalances && withinGroupBalances.length > 0 && (
@@ -278,8 +279,7 @@ export function CostBreakdownDialog({
             </div>
           )}
         </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/LinkParticipantDialog.tsx
+++ b/src/components/LinkParticipantDialog.tsx
@@ -6,14 +6,7 @@ import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
 import { logger } from '@/lib/logger'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface LinkParticipantDialogProps {
   trigger?: React.ReactNode
@@ -58,29 +51,28 @@ export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDial
   }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
+    <>
+      {/* Trigger button — clicks open the overlay */}
+      <span onClick={() => handleOpenChange(true)}>
         {trigger || (
           <Button variant="outline" size="sm" className="gap-2">
             <UserCheck size={16} />
             This is me
           </Button>
         )}
-      </DialogTrigger>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Which participant are you?</DialogTitle>
-          <DialogDescription>
-            Link yourself to a participant so we can show your personal balance and pre-fill forms.
-          </DialogDescription>
-        </DialogHeader>
+      </span>
+
+      <ResponsiveOverlay open={open} onClose={() => handleOpenChange(false)} title="Which participant are you?" maxWidth="max-w-sm">
+        <p className="text-sm text-muted-foreground mb-4">
+          Link yourself to a participant so we can show your personal balance and pre-fill forms.
+        </p>
         {linkError && (
-          <div className="rounded-lg bg-destructive/10 border border-destructive/20 px-4 py-3 mt-2">
+          <div className="rounded-lg bg-destructive/10 border border-destructive/20 px-4 py-3 mb-4">
             <p className="text-sm font-medium text-destructive">Failed to link — please try again</p>
             <p className="text-xs text-destructive/80 mt-1">{linkError}</p>
           </div>
         )}
-        <div className="space-y-2 mt-4">
+        <div className="space-y-2">
           {adultParticipants.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-4">
               No unlinked participants available. All participants are already claimed.
@@ -103,7 +95,7 @@ export function LinkParticipantDialog({ trigger, onLinked }: LinkParticipantDial
             ))
           )}
         </div>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveOverlay>
+    </>
   )
 }

--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -2,7 +2,6 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { ChefHat, Trash2, ShoppingBasket, Utensils, Home, Receipt } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { useMealContext } from '@/contexts/MealContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
@@ -11,6 +10,7 @@ import { MealForm } from './MealForm'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
   Dialog,
   DialogContent,
@@ -30,7 +30,6 @@ export function MealCard({ meal }: MealCardProps) {
   const { expenses } = useExpenseContext()
   const [showEditForm, setShowEditForm] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const scrollRef = useIOSScrollFix()
 
   const responsiblePerson = meal.responsible_participant_id
     ? participants.find((p) => p.id === meal.responsible_participant_id)
@@ -173,21 +172,14 @@ export function MealCard({ meal }: MealCardProps) {
         </Card>
       </motion.div>
 
-      {/* Edit Form Dialog */}
-      <Dialog open={showEditForm} onOpenChange={setShowEditForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>Edit Meal</DialogTitle>
-            </DialogHeader>
-            <MealForm
-              meal={meal}
-              onSuccess={() => setShowEditForm(false)}
-              onCancel={() => setShowEditForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Edit Form */}
+      <ResponsiveOverlay open={showEditForm} onClose={() => setShowEditForm(false)} title="Edit Meal" hasInputs>
+        <MealForm
+          meal={meal}
+          onSuccess={() => setShowEditForm(false)}
+          onCancel={() => setShowEditForm(false)}
+        />
+      </ResponsiveOverlay>
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>

--- a/src/components/MealGrid.tsx
+++ b/src/components/MealGrid.tsx
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Sunrise, Sun, Moon, Plus } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { MealWithIngredients, MealType, MEAL_TYPE_LABELS } from '@/types/meal'
 import { MealCard } from './MealCard'
 import { MealForm } from './MealForm'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import { Card } from '@/components/ui/card'
 
 export interface MealGridProps {
@@ -39,7 +38,6 @@ const MEAL_HEADER_BG = {
 export function MealGrid({ date, meals }: MealGridProps) {
   const [showAddForm, setShowAddForm] = useState(false)
   const [selectedMealType, setSelectedMealType] = useState<MealType | null>(null)
-  const scrollRef = useIOSScrollFix()
 
   // Helper to get meal for specific slot
   const getMealForSlot = (mealType: MealType): MealWithIngredients | undefined => {
@@ -113,24 +111,20 @@ export function MealGrid({ date, meals }: MealGridProps) {
         {renderMealSlot('dinner')}
       </div>
 
-      {/* Add Meal Form Dialog */}
-      <Dialog open={showAddForm} onOpenChange={setShowAddForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>
-                Add {selectedMealType ? MEAL_TYPE_LABELS[selectedMealType] : 'Meal'} - {formatDialogDate(date)}
-              </DialogTitle>
-            </DialogHeader>
-            <MealForm
-              initialDate={date}
-              initialMealType={selectedMealType || undefined}
-              onSuccess={() => setShowAddForm(false)}
-              onCancel={() => setShowAddForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Add Meal Form */}
+      <ResponsiveOverlay
+        open={showAddForm}
+        onClose={() => setShowAddForm(false)}
+        title={`Add ${selectedMealType ? MEAL_TYPE_LABELS[selectedMealType] : 'Meal'} - ${formatDialogDate(date)}`}
+        hasInputs
+      >
+        <MealForm
+          initialDate={date}
+          initialMealType={selectedMealType || undefined}
+          onSuccess={() => setShowAddForm(false)}
+          onCancel={() => setShowAddForm(false)}
+        />
+      </ResponsiveOverlay>
     </>
   )
 }

--- a/src/components/ShareTripDialog.tsx
+++ b/src/components/ShareTripDialog.tsx
@@ -2,14 +2,7 @@
 import { useState, useEffect } from 'react'
 import QRCode from 'qrcode'
 import { Copy, Share2, Check, Mail, MessageCircle, Send } from 'lucide-react'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useToast } from '@/hooks/use-toast'
@@ -102,22 +95,21 @@ export function ShareTripDialog({ tripCode, tripName, trigger }: ShareTripDialog
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
+    <>
+      {/* Trigger button — clicks open the overlay */}
+      <span onClick={() => setOpen(true)}>
         {trigger || (
           <Button variant="outline" className="gap-2">
             <Share2 size={16} />
             Share Trip
           </Button>
         )}
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Share Trip</DialogTitle>
-          <DialogDescription>
-            Share this link with your group members. Anyone with the link can view and contribute to this trip.
-          </DialogDescription>
-        </DialogHeader>
+      </span>
+
+      <ResponsiveOverlay open={open} onClose={() => setOpen(false)} title="Share Trip" maxWidth="sm:max-w-md">
+        <p className="text-sm text-muted-foreground mb-4">
+          Share this link with your group members. Anyone with the link can view and contribute to this trip.
+        </p>
 
         <div className="space-y-4">
           {/* QR Code */}
@@ -195,7 +187,7 @@ export function ShareTripDialog({ tripCode, tripName, trigger }: ShareTripDialog
             </p>
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveOverlay>
+    </>
   )
 }

--- a/src/components/ShoppingItemCard.tsx
+++ b/src/components/ShoppingItemCard.tsx
@@ -2,7 +2,6 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Edit, Trash2 } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { useShoppingContext } from '@/contexts/ShoppingContext'
 import type { ShoppingItemWithMeals } from '@/types/shopping'
 import { CATEGORY_LABELS } from '@/types/shopping'
@@ -11,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
   Dialog,
   DialogContent,
@@ -29,7 +29,6 @@ export function ShoppingItemCard({ item }: ShoppingItemCardProps) {
   const [showEditForm, setShowEditForm] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [toggling, setToggling] = useState(false)
-  const scrollRef = useIOSScrollFix()
 
   const handleToggle = async () => {
     if (toggling) return
@@ -141,21 +140,14 @@ export function ShoppingItemCard({ item }: ShoppingItemCardProps) {
         </Card>
       </motion.div>
 
-      {/* Edit Form Dialog */}
-      <Dialog open={showEditForm} onOpenChange={setShowEditForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>Edit Item</DialogTitle>
-            </DialogHeader>
-            <ShoppingItemForm
-              item={item}
-              onSuccess={() => setShowEditForm(false)}
-              onCancel={() => setShowEditForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Edit Form */}
+      <ResponsiveOverlay open={showEditForm} onClose={() => setShowEditForm(false)} title="Edit Item" hasInputs>
+        <ShoppingItemForm
+          item={item}
+          onSuccess={() => setShowEditForm(false)}
+          onCancel={() => setShowEditForm(false)}
+        />
+      </ResponsiveOverlay>
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>

--- a/src/components/ShoppingItemRow.tsx
+++ b/src/components/ShoppingItemRow.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Trash2 } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { useShoppingContext } from '@/contexts/ShoppingContext'
 import type { ShoppingItemWithMeals } from '@/types/shopping'
 import { CATEGORY_LABELS } from '@/types/shopping'
@@ -9,6 +8,7 @@ import { ShoppingItemForm } from './ShoppingItemForm'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
   Dialog,
   DialogContent,
@@ -27,7 +27,6 @@ export function ShoppingItemRow({ item }: ShoppingItemRowProps) {
   const [showEditForm, setShowEditForm] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [toggling, setToggling] = useState(false)
-  const scrollRef = useIOSScrollFix()
 
   const handleToggle = async () => {
     if (toggling) return
@@ -122,21 +121,14 @@ export function ShoppingItemRow({ item }: ShoppingItemRowProps) {
         </td>
       </tr>
 
-      {/* Edit Dialog */}
-      <Dialog open={showEditForm} onOpenChange={setShowEditForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>Edit Shopping Item</DialogTitle>
-            </DialogHeader>
-            <ShoppingItemForm
-              item={item}
-              onSuccess={() => setShowEditForm(false)}
-              onCancel={() => setShowEditForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Edit Form */}
+      <ResponsiveOverlay open={showEditForm} onClose={() => setShowEditForm(false)} title="Edit Shopping Item" hasInputs>
+        <ShoppingItemForm
+          item={item}
+          onSuccess={() => setShowEditForm(false)}
+          onCancel={() => setShowEditForm(false)}
+        />
+      </ResponsiveOverlay>
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>

--- a/src/components/StayCard.tsx
+++ b/src/components/StayCard.tsx
@@ -2,13 +2,13 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Trash2, ExternalLink, MessageSquare } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { format } from 'date-fns'
 import { useStayContext } from '@/contexts/StayContext'
 import type { Stay } from '@/types/stay'
 import { StayForm } from './StayForm'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
   Dialog,
   DialogContent,
@@ -26,7 +26,6 @@ export function StayCard({ stay }: StayCardProps) {
   const { deleteStay } = useStayContext()
   const [showEditForm, setShowEditForm] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const scrollRef = useIOSScrollFix()
 
   const handleDelete = async () => {
     const success = await deleteStay(stay.id)
@@ -86,21 +85,14 @@ export function StayCard({ stay }: StayCardProps) {
         </Card>
       </motion.div>
 
-      {/* Edit Form Dialog */}
-      <Dialog open={showEditForm} onOpenChange={setShowEditForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>Edit Accommodation</DialogTitle>
-            </DialogHeader>
-            <StayForm
-              stay={stay}
-              onSuccess={() => setShowEditForm(false)}
-              onCancel={() => setShowEditForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Edit Form */}
+      <ResponsiveOverlay open={showEditForm} onClose={() => setShowEditForm(false)} title="Edit Accommodation" hasInputs>
+        <StayForm
+          stay={stay}
+          onSuccess={() => setShowEditForm(false)}
+          onCancel={() => setShowEditForm(false)}
+        />
+      </ResponsiveOverlay>
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>

--- a/src/components/TimeSlotGrid.tsx
+++ b/src/components/TimeSlotGrid.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { Sunrise, Sun, Moon, Plus } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { MealWithIngredients, MealType, MEAL_TYPE_LABELS } from '@/types/meal'
 import type { Activity, ActivityTimeSlot } from '@/types/activity'
 import { TIME_SLOT_LABELS } from '@/types/activity'
@@ -9,7 +8,7 @@ import { MealCard } from './MealCard'
 import { MealForm } from './MealForm'
 import { ActivityCard } from './ActivityCard'
 import { ActivityForm } from './ActivityForm'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 export interface TimeSlotGridProps {
   date: string
@@ -53,7 +52,6 @@ export function TimeSlotGrid({ date, meals, activities, enableMeals = true, enab
   const [selectedMealType, setSelectedMealType] = useState<MealType | null>(null)
   const [showAddActivityForm, setShowAddActivityForm] = useState(false)
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<ActivityTimeSlot | null>(null)
-  const scrollRef = useIOSScrollFix()
 
   const getMealForSlot = (mealType: MealType): MealWithIngredients | undefined => {
     return meals.find((m) => m.meal_type === mealType)
@@ -150,45 +148,37 @@ export function TimeSlotGrid({ date, meals, activities, enableMeals = true, enab
         {TIME_SLOTS.map((timeSlot) => renderTimeSlotSection(timeSlot))}
       </div>
 
-      {/* Add Meal Form Dialog */}
-      <Dialog open={showAddMealForm} onOpenChange={setShowAddMealForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>
-                Add {selectedMealType ? MEAL_TYPE_LABELS[selectedMealType] : 'Meal'} - {formatDialogDate(date)}
-              </DialogTitle>
-            </DialogHeader>
-            <MealForm
-              initialDate={date}
-              initialMealType={selectedMealType || undefined}
-              onSuccess={() => setShowAddMealForm(false)}
-              onCancel={() => setShowAddMealForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Add Meal Form */}
+      <ResponsiveOverlay
+        open={showAddMealForm}
+        onClose={() => setShowAddMealForm(false)}
+        title={`Add ${selectedMealType ? MEAL_TYPE_LABELS[selectedMealType] : 'Meal'} - ${formatDialogDate(date)}`}
+        hasInputs
+      >
+        <MealForm
+          initialDate={date}
+          initialMealType={selectedMealType || undefined}
+          onSuccess={() => setShowAddMealForm(false)}
+          onCancel={() => setShowAddMealForm(false)}
+        />
+      </ResponsiveOverlay>
 
-      {/* Add Activity Form Dialog */}
-      <Dialog open={showAddActivityForm} onOpenChange={setShowAddActivityForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>
-                Add Activity - {selectedTimeSlot ? TIME_SLOT_LABELS[selectedTimeSlot] : ''} - {formatDialogDate(date)}
-              </DialogTitle>
-            </DialogHeader>
-            {selectedTimeSlot && (
-              <ActivityForm
-                date={date}
-                timeSlot={selectedTimeSlot}
-                onSuccess={() => setShowAddActivityForm(false)}
-                onCancel={() => setShowAddActivityForm(false)}
-              />
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Add Activity Form */}
+      <ResponsiveOverlay
+        open={showAddActivityForm}
+        onClose={() => setShowAddActivityForm(false)}
+        title={`Add Activity - ${selectedTimeSlot ? TIME_SLOT_LABELS[selectedTimeSlot] : ''} - ${formatDialogDate(date)}`}
+        hasInputs
+      >
+        {selectedTimeSlot && (
+          <ActivityForm
+            date={date}
+            timeSlot={selectedTimeSlot}
+            onSuccess={() => setShowAddActivityForm(false)}
+            onCancel={() => setShowAddActivityForm(false)}
+          />
+        )}
+      </ResponsiveOverlay>
     </>
   )
 }

--- a/src/components/auth/BankDetailsDialog.tsx
+++ b/src/components/auth/BankDetailsDialog.tsx
@@ -5,13 +5,7 @@ import { useToast } from '@/hooks/use-toast'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface BankDetailsDialogProps {
   open: boolean
@@ -54,52 +48,53 @@ export function BankDetailsDialog({ open, onOpenChange }: BankDetailsDialogProps
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>Bank Details</DialogTitle>
-          <DialogDescription>
-            Add your bank details so others can see where to send payments in settlement plans.
-          </DialogDescription>
-        </DialogHeader>
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title="Bank Details"
+      hasInputs
+      maxWidth="max-w-md"
+    >
+      <p className="text-sm text-muted-foreground mb-4">
+        Add your bank details so others can see where to send payments in settlement plans.
+      </p>
 
-        <div className="space-y-4 pt-2">
-          <div className="space-y-2">
-            <Label htmlFor="accountHolder">Account Holder Name</Label>
-            <Input
-              id="accountHolder"
-              value={holder}
-              onChange={(e) => setHolder(e.target.value)}
-              placeholder="e.g., John Smith"
-              disabled={saving}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="iban">IBAN</Label>
-            <Input
-              id="iban"
-              value={iban}
-              onChange={(e) => setIban(e.target.value)}
-              placeholder="e.g., DE89 3704 0044 0532 0130 00"
-              disabled={saving}
-            />
-          </div>
-
-          <div className="flex gap-3 pt-2">
-            <Button onClick={handleSave} disabled={saving} className="flex-1">
-              {saving ? 'Saving...' : 'Save'}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={saving}
-            >
-              Cancel
-            </Button>
-          </div>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="accountHolder">Account Holder Name</Label>
+          <Input
+            id="accountHolder"
+            value={holder}
+            onChange={(e) => setHolder(e.target.value)}
+            placeholder="e.g., John Smith"
+            disabled={saving}
+          />
         </div>
-      </DialogContent>
-    </Dialog>
+
+        <div className="space-y-2">
+          <Label htmlFor="iban">IBAN</Label>
+          <Input
+            id="iban"
+            value={iban}
+            onChange={(e) => setIban(e.target.value)}
+            placeholder="e.g., DE89 3704 0044 0532 0130 00"
+            disabled={saving}
+          />
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <Button onClick={handleSave} disabled={saving} className="flex-1">
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/ui/ResponsiveOverlay.tsx
+++ b/src/components/ui/ResponsiveOverlay.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * ResponsiveOverlay — renders AppSheet on mobile, Dialog on desktop.
+ *
+ * Use this for every overlay that appears on both viewports.
+ * Mobile always gets a bottom sheet (project standard).
+ * Desktop gets a centered dialog with identical header structure.
+ */
+
+import { ReactNode } from 'react'
+import { X, ArrowLeft } from 'lucide-react'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
+import { AppSheet } from '@/components/ui/AppSheet'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+export interface ResponsiveOverlayProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  /** true → 92dvh + keyboard hooks (mobile), false → 75dvh fixed (mobile). Default false. */
+  hasInputs?: boolean
+  /** Desktop dialog max-width class. Default 'max-w-lg'. */
+  maxWidth?: string
+  /** Sticky footer rendered below scroll area on both mobile and desktop. */
+  footer?: ReactNode
+  /** Show back arrow (left slot) instead of spacer. */
+  onBack?: () => void
+  /** Extra header content below the title row (e.g. description, progress bar). */
+  headerExtra?: ReactNode
+  /** Prevent closing when clicking outside. */
+  preventOutsideClose?: boolean
+  children: ReactNode
+}
+
+function OverlayButton({ onClick, label, children }: { onClick: () => void; label: string; children: ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={label}
+      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+    >
+      {children}
+    </button>
+  )
+}
+
+export function ResponsiveOverlay({
+  open,
+  onClose,
+  title,
+  hasInputs = false,
+  maxWidth = 'max-w-lg',
+  footer,
+  onBack,
+  headerExtra,
+  preventOutsideClose = false,
+  children,
+}: ResponsiveOverlayProps) {
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  const scrollRef = useIOSScrollFix()
+
+  // Mobile: delegate to AppSheet (single source of truth for sheets)
+  if (isMobile) {
+    return (
+      <AppSheet
+        open={open}
+        onClose={onClose}
+        title={title}
+        height={hasInputs ? '92dvh' : '75dvh'}
+        hasInputs={hasInputs}
+        footer={footer}
+        onBack={onBack}
+        headerExtra={headerExtra}
+        preventOutsideClose={preventOutsideClose}
+      >
+        {children}
+      </AppSheet>
+    )
+  }
+
+  // Desktop: centered Dialog with identical header structure
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
+      <DialogContent
+        hideClose
+        className={`${maxWidth} max-h-[85vh] flex flex-col p-0 gap-0`}
+        onInteractOutside={preventOutsideClose ? (e) => e.preventDefault() : undefined}
+      >
+        {/* STICKY HEADER — matches AppSheet structure */}
+        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+          {onBack ? (
+            <OverlayButton onClick={onBack} label="Go back">
+              <ArrowLeft className="w-4 h-4 text-muted-foreground" />
+            </OverlayButton>
+          ) : (
+            <div className="w-8" />
+          )}
+          <DialogTitle className="text-base font-semibold">{title}</DialogTitle>
+          <OverlayButton onClick={onClose} label="Close">
+            <X className="w-4 h-4 text-muted-foreground" />
+          </OverlayButton>
+        </div>
+
+        {headerExtra && (
+          <div className="shrink-0">{headerExtra}</div>
+        )}
+
+        {/* SCROLLABLE CONTENT */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
+          {children}
+        </div>
+
+        {/* STICKY FOOTER */}
+        {footer && (
+          <div className="shrink-0 px-4 py-3 border-t border-border bg-background">
+            {footer}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -16,13 +16,8 @@ import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
+import { DialogDescription } from '@/components/ui/dialog'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -44,7 +39,6 @@ import { useAuth } from '@/contexts/AuthContext'
 import { usePWAInstall } from '@/hooks/usePWAInstall'
 import { isAdminUser } from '@/lib/adminAuth'
 import { ThemeToggle } from '@/components/ThemeToggle'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 
 export function ManageTripPage() {
   const { currentTrip, tripCode } = useCurrentTrip()
@@ -62,7 +56,6 @@ export function ManageTripPage() {
   const [isUpdating, setIsUpdating] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [retrying, setRetrying] = useState(false)
-  const scrollRef = useIOSScrollFix()
 
   // Currency settings state
   const [currencyDefault, setCurrencyDefault] = useState(currentTrip?.default_currency || 'EUR')
@@ -538,44 +531,45 @@ export function ManageTripPage() {
       )}
 
       {/* Edit Dialog */}
-      <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0 mx-4 sm:mx-auto">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6 space-y-4">
-            <DialogHeader>
-              <DialogTitle>Edit {entityLabel} Details</DialogTitle>
-              <DialogDescription>
-                Update the name, dates, or currency
-              </DialogDescription>
-            </DialogHeader>
+      <ResponsiveOverlay
+        open={showEditDialog}
+        onClose={() => setShowEditDialog(false)}
+        title={`Edit ${entityLabel} Details`}
+        hasInputs
+        headerExtra={
+          <DialogDescription className="px-4 pb-3 mt-0 text-center">
+            Update the name, dates, or currency
+          </DialogDescription>
+        }
+      >
+        <div className="space-y-4">
+          {/* Warning about meals */}
+          {meals.length > 0 && (
+            <Alert>
+              <Info size={16} className="mt-0.5" />
+              <AlertDescription>
+                <strong>Note:</strong> Changing dates may hide meals that fall outside the
+                new date range. Those meals will remain in the database.
+              </AlertDescription>
+            </Alert>
+          )}
 
-            {/* Warning about meals */}
-            {meals.length > 0 && (
-              <Alert>
-                <Info size={16} className="mt-0.5" />
-                <AlertDescription>
-                  <strong>Note:</strong> Changing dates may hide meals that fall outside the
-                  new date range. Those meals will remain in the database.
-                </AlertDescription>
-              </Alert>
-            )}
-
-            <EventForm
-              initialValues={{
-                name: currentTrip.name,
-                start_date: currentTrip.start_date,
-                end_date: currentTrip.end_date,
-                event_type: currentTrip.event_type,
-                default_currency: currentTrip.default_currency,
-              }}
-              onSubmit={handleEditTrip}
-              onCancel={() => setShowEditDialog(false)}
-              submitLabel="Save Changes"
-              isLoading={isUpdating}
-              isEditMode
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+          <EventForm
+            initialValues={{
+              name: currentTrip.name,
+              start_date: currentTrip.start_date,
+              end_date: currentTrip.end_date,
+              event_type: currentTrip.event_type,
+              default_currency: currentTrip.default_currency,
+            }}
+            onSubmit={handleEditTrip}
+            onCancel={() => setShowEditDialog(false)}
+            submitLabel="Save Changes"
+            isLoading={isUpdating}
+            isEditMode
+          />
+        </div>
+      </ResponsiveOverlay>
     </div>
   )
 }

--- a/src/pages/ShoppingPage.tsx
+++ b/src/pages/ShoppingPage.tsx
@@ -2,7 +2,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Plus, ShoppingCart, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useShoppingContext } from '@/contexts/ShoppingContext'
 import { PageLoadingState } from '@/components/PageLoadingState'
@@ -13,12 +12,7 @@ import { ShoppingItemRow } from '@/components/ShoppingItemRow'
 import { ShoppingItemForm } from '@/components/ShoppingItemForm'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 type SortColumn = 'status' | 'name' | 'category'
 type SortDirection = 'asc' | 'desc'
@@ -31,7 +25,6 @@ export function ShoppingPage() {
   const [sortColumn, setSortColumn] = useState<SortColumn>('status')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [retrying, setRetrying] = useState(false)
-  const scrollRef = useIOSScrollFix()
 
   const handleRefresh = useCallback(() => refreshShoppingItems(), [refreshShoppingItems])
   useRegisterRefresh(handleRefresh)
@@ -246,20 +239,13 @@ export function ShoppingPage() {
         )}
       </div>
 
-      {/* Add Shopping Item Form Dialog */}
-      <Dialog open={showAddForm} onOpenChange={setShowAddForm}>
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-6">
-            <DialogHeader>
-              <DialogTitle>Add Shopping Item</DialogTitle>
-            </DialogHeader>
-            <ShoppingItemForm
-              onSuccess={() => setShowAddForm(false)}
-              onCancel={() => setShowAddForm(false)}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Add Shopping Item Form */}
+      <ResponsiveOverlay open={showAddForm} onClose={() => setShowAddForm(false)} title="Add Shopping Item" hasInputs>
+        <ShoppingItemForm
+          onSuccess={() => setShowAddForm(false)}
+          onCancel={() => setShowAddForm(false)}
+        />
+      </ResponsiveOverlay>
     </>
   )
 }


### PR DESCRIPTION
## Summary

- Creates `ResponsiveOverlay` component (`src/components/ui/ResponsiveOverlay.tsx`) that renders `AppSheet` on mobile and `Dialog` on desktop — single source of truth for dual-mode overlays
- Converts all **13 dialog-only components** that violated the project standard ("every mobile overlay must be a bottom sheet") to use `ResponsiveOverlay`
- Net **-97 lines** of boilerplate removed across 13 components

### Components converted

**HIGH — form inputs on mobile (10 components, 11 dialogs):**
1. `ShoppingPage` — add item
2. `ShoppingItemCard` — edit item  
3. `ShoppingItemRow` — edit item
4. `MealGrid` — add meal
5. `TimeSlotGrid` — add meal + add activity (2 dialogs)
6. `ActivityCard` — edit activity
7. `MealCard` — edit meal
8. `StayCard` — edit stay
9. `ManageTripPage` — edit trip details
10. `BankDetailsDialog` — bank details form

**MEDIUM — read-only/no-keyboard (3 components):**
11. `CostBreakdownDialog` — expense breakdown (75dvh)
12. `ShareTripDialog` — share URL/QR (converted from DialogTrigger to internal state)
13. `LinkParticipantDialog` — participant picker (converted from DialogTrigger to internal state)

### Not affected
- Delete confirmations (AlertDialog) — standard exception, fine centered
- Already dual-mode components (ExpenseWizard, QuickSettlementSheet, etc.)

## Test plan
- [x] `npm run type-check` — passes clean
- [x] `npm test` — all 193 tests pass
- [x] `npm run test:e2e` — all 26 E2E tests pass (both viewports)
- [ ] Manual: on mobile viewport, each converted overlay opens as bottom Sheet
- [ ] Manual: on desktop, each converted overlay still opens as centered Dialog
- [ ] Manual iPhone test for `hasInputs` overlays — keyboard opens correctly, header visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)