### PR TITLE
refactor: migrate 12 remaining dual-mode overlays to ResponsiveOverlay

### DIFF
--- a/src/components/DayDetailSheet.tsx
+++ b/src/components/DayDetailSheet.tsx
@@ -1,19 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Building2, X } from 'lucide-react'
+import { Building2 } from 'lucide-react'
 import { getDayNumber, getDayContext } from '@/lib/dateUtils'
 import { Badge } from '@/components/ui/badge'
-import {
-  Sheet,
-  SheetContent,
-  SheetTitle,
-} from '@/components/ui/sheet'
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import { TimeSlotGrid } from './TimeSlotGrid'
 import type { MealWithIngredients } from '@/types/meal'
 import type { Activity } from '@/types/activity'
@@ -55,90 +44,37 @@ export function DayDetailSheet({
   enableMeals = true,
   enableActivities = true,
 }: DayDetailSheetProps) {
-  const scrollRef = useIOSScrollFix()
-  const isMobile = useMediaQuery('(max-width: 767px)')
-
   if (!date) return null
 
   const dayNumber = getDayNumber(date, tripStartDate)
   const context = getDayContext(date)
 
-  const closeBtn = (
-    <button
-      onClick={() => onOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-    >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
-  const badges = (
-    <div className="flex items-center gap-2 flex-wrap px-4 pb-3">
-      <Badge variant="outline" className="bg-primary/10 border-primary/30 text-primary font-bold">
-        Day {dayNumber}
-      </Badge>
-      <Badge
-        variant="outline"
-        className={`${CONTEXT_STYLES[context]} capitalize`}
-      >
-        {context}
-      </Badge>
-      {stayName && (
-        <Badge variant="outline" className="gap-1">
-          <Building2 size={12} />
-          {stayName}
-        </Badge>
-      )}
-    </div>
-  )
-
-  const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
-      <TimeSlotGrid date={date} meals={meals} activities={activities} enableMeals={enableMeals} enableActivities={enableActivities} />
-    </div>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={!!date} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{ height: '75dvh' }}
-        >
-          <div className="shrink-0 border-b border-border">
-            <div className="flex items-center justify-between px-4 py-3">
-              <div className="w-8" />
-              <SheetTitle className="text-base font-semibold">
-                {formatSheetDate(date)}
-              </SheetTitle>
-              {closeBtn}
-            </div>
-            {badges}
-          </div>
-          {scrollContent}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
   return (
-    <Dialog open={!!date} onOpenChange={onOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] max-w-lg p-0 gap-0">
-        <div className="shrink-0 border-b border-border">
-          <div className="flex items-center justify-between px-4 py-3">
-            <div className="w-8" />
-            <DialogTitle className="text-base font-semibold">
-              {formatSheetDate(date)}
-            </DialogTitle>
-            {closeBtn}
-          </div>
-          {badges}
+    <ResponsiveOverlay
+      open={!!date}
+      onClose={() => onOpenChange(false)}
+      title={formatSheetDate(date)}
+      headerExtra={
+        <div className="flex items-center gap-2 flex-wrap px-4 pb-3">
+          <Badge variant="outline" className="bg-primary/10 border-primary/30 text-primary font-bold">
+            Day {dayNumber}
+          </Badge>
+          <Badge
+            variant="outline"
+            className={`${CONTEXT_STYLES[context]} capitalize`}
+          >
+            {context}
+          </Badge>
+          {stayName && (
+            <Badge variant="outline" className="gap-1">
+              <Building2 size={12} />
+              {stayName}
+            </Badge>
+          )}
         </div>
-        {scrollContent}
-      </DialogContent>
-    </Dialog>
+      }
+    >
+      <TimeSlotGrid date={date} meals={meals} activities={activities} enableMeals={enableMeals} enableActivities={enableActivities} />
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/ReportIssueDialog.tsx
+++ b/src/components/ReportIssueDialog.tsx
@@ -1,25 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useRef } from 'react'
-import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useToast } from '@/hooks/use-toast'
 import { useAuth } from '@/contexts/AuthContext'
 import { supabase } from '@/lib/supabase'
 import { withTimeout } from '@/lib/fetchWithTimeout'
 import { logger } from '@/lib/logger'
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog'
-import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Loader2, ImagePlus, X } from 'lucide-react'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface ReportIssueDialogProps {
   open: boolean
@@ -67,9 +58,6 @@ const MAX_SCREENSHOTS = 5
 export function ReportIssueDialog({ open, onOpenChange }: ReportIssueDialogProps) {
   const { toast } = useToast()
   const { user } = useAuth()
-  const keyboard = useKeyboardHeight()
-  const scrollRef = useIOSScrollFix()
-  const isMobile = useMediaQuery('(max-width: 767px)')
   const [subject, setSubject] = useState('')
   const [description, setDescription] = useState('')
   const [screenshots, setScreenshots] = useState<File[]>([])
@@ -185,163 +173,108 @@ export function ReportIssueDialog({ open, onOpenChange }: ReportIssueDialogProps
     }
   }
 
-  const closeBtn = (
-    <button
-      onClick={() => onOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title="Report an Issue"
+      hasInputs
+      maxWidth="max-w-md"
+      headerExtra={
+        <p className="text-sm text-muted-foreground px-4 pb-3 mt-0">
+          Found a bug or have feedback? Let us know and we'll look into it.
+        </p>
+      }
+      scrollClassName="px-6 py-4"
     >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="issue-subject">Subject</Label>
+          <Input
+            id="issue-subject"
+            placeholder="Brief description of the issue"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            required
+          />
+        </div>
 
-  const formContent = (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="issue-subject">Subject</Label>
-        <Input
-          id="issue-subject"
-          placeholder="Brief description of the issue"
-          value={subject}
-          onChange={(e) => setSubject(e.target.value)}
-          required
-        />
-      </div>
+        <div className="space-y-2">
+          <Label htmlFor="issue-description">Details (optional)</Label>
+          <Textarea
+            id="issue-description"
+            placeholder="What happened? What did you expect to happen?"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+          />
+        </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="issue-description">Details (optional)</Label>
-        <Textarea
-          id="issue-description"
-          placeholder="What happened? What did you expect to happen?"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          rows={4}
-        />
-      </div>
+        <div className="space-y-2">
+          <Label>Screenshots (optional)</Label>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            onChange={handleFileChange}
+            className="hidden"
+          />
+          {previews.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {previews.map((url, i) => (
+                <div key={i} className="relative inline-block">
+                  <img
+                    src={url}
+                    alt={`Screenshot ${i + 1}`}
+                    className="h-20 w-20 rounded-md border border-border object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeScreenshot(i)}
+                    className="absolute -top-2 -right-2 p-0.5 rounded-full bg-destructive text-destructive-foreground shadow-sm"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          {screenshots.length < MAX_SCREENSHOTS && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <ImagePlus size={16} />
+              {screenshots.length === 0 ? 'Attach Screenshots' : 'Add More'}
+            </Button>
+          )}
+        </div>
 
-      <div className="space-y-2">
-        <Label>Screenshots (optional)</Label>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          onChange={handleFileChange}
-          className="hidden"
-        />
-        {previews.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {previews.map((url, i) => (
-              <div key={i} className="relative inline-block">
-                <img
-                  src={url}
-                  alt={`Screenshot ${i + 1}`}
-                  className="h-20 w-20 rounded-md border border-border object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() => removeScreenshot(i)}
-                  className="absolute -top-2 -right-2 p-0.5 rounded-full bg-destructive text-destructive-foreground shadow-sm"
-                >
-                  <X size={14} />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-        {screenshots.length < MAX_SCREENSHOTS && (
+        <div className="flex justify-end gap-2">
           <Button
             type="button"
             variant="outline"
-            size="sm"
-            className="gap-2"
-            onClick={() => fileInputRef.current?.click()}
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
           >
-            <ImagePlus size={16} />
-            {screenshots.length === 0 ? 'Attach Screenshots' : 'Add More'}
+            Cancel
           </Button>
-        )}
-      </div>
-
-      <div className="flex justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => onOpenChange(false)}
-          disabled={submitting}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled={submitting || !subject.trim()}>
-          {submitting ? (
-            <>
-              <Loader2 size={16} className="mr-2 animate-spin" />
-              Sending...
-            </>
-          ) : (
-            'Send Report'
-          )}
-        </Button>
-      </div>
-    </form>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{
-            height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-            ...(keyboard.isVisible && {
-              top: `${keyboard.viewportOffset}px`,
-              bottom: 'auto',
-            }),
-          }}
-        >
-          {/* Sticky header */}
-          <div className="shrink-0 border-b border-border">
-            <div className="flex items-center justify-between px-4 py-3">
-              <div className="w-8" />
-              <SheetTitle className="text-base font-semibold">Report an Issue</SheetTitle>
-              {closeBtn}
-            </div>
-            <SheetDescription className="px-4 pb-3 mt-0">
-              Found a bug or have feedback? Let us know and we'll look into it.
-            </SheetDescription>
-          </div>
-
-          {/* Scrollable content */}
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
-            {formContent}
-          </div>
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] max-w-md p-0 gap-0">
-        {/* Sticky header */}
-        <div className="shrink-0 border-b border-border">
-          <div className="flex items-center justify-between px-4 py-3">
-            <div className="w-8" />
-            <DialogTitle className="text-base font-semibold">Report an Issue</DialogTitle>
-            {closeBtn}
-          </div>
-          <DialogDescription className="px-4 pb-3 mt-0">
-            Found a bug or have feedback? Let us know and we'll look into it.
-          </DialogDescription>
+          <Button type="submit" disabled={submitting || !subject.trim()}>
+            {submitting ? (
+              <>
+                <Loader2 size={16} className="mr-2 animate-spin" />
+                Sending...
+              </>
+            ) : (
+              'Send Report'
+            )}
+          </Button>
         </div>
-
-        {/* Scrollable content */}
-        <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
-          {formContent}
-        </div>
-      </DialogContent>
-    </Dialog>
+      </form>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/quick/QuickCreateSheet.tsx
+++ b/src/components/quick/QuickCreateSheet.tsx
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useNavigate } from 'react-router-dom'
-import { X } from 'lucide-react'
 import { useTripContext } from '@/contexts/TripContext'
 import { EventForm } from '@/components/EventForm'
 import { CreateEventInput } from '@/types/trip'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface QuickCreateSheetProps {
   open: boolean
@@ -18,8 +14,6 @@ interface QuickCreateSheetProps {
 export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) {
   const navigate = useNavigate()
   const { createTrip } = useTripContext()
-  const keyboard = useKeyboardHeight()
-  const scrollRef = useIOSScrollFix()
   const isMobile = useMediaQuery('(max-width: 767px)')
 
   const handleCreate = async (input: CreateEventInput) => {
@@ -30,61 +24,18 @@ export function QuickCreateSheet({ open, onOpenChange }: QuickCreateSheetProps) 
     }
   }
 
-  const closeBtn = (
-    <button
-      onClick={() => onOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title="Create New"
+      hasInputs
+      scrollClassName="px-6 py-4"
     >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
-  const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
       <EventForm
         onSubmit={handleCreate}
         onCancel={() => onOpenChange(false)}
       />
-    </div>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{
-            height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-            ...(keyboard.isVisible && {
-              top: `${keyboard.viewportOffset}px`,
-              bottom: 'auto',
-            }),
-          }}
-        >
-          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-            <div className="w-8" />
-            <SheetTitle className="text-base font-semibold">Create New</SheetTitle>
-            {closeBtn}
-          </div>
-          {scrollContent}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] max-w-lg p-0 gap-0">
-        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-          <div className="w-8" />
-          <DialogTitle className="text-base font-semibold">Create New</DialogTitle>
-          {closeBtn}
-        </div>
-        {scrollContent}
-      </DialogContent>
-    </Dialog>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/quick/QuickGroupMembersSheet.tsx
+++ b/src/components/quick/QuickGroupMembersSheet.tsx
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { UserCheck, X, ChevronDown, Check } from 'lucide-react'
+import { UserCheck, ChevronDown, Check } from 'lucide-react'
 import { ParticipantBalance, formatBalance, getBalanceColorClass, calculateWithinGroupBalances } from '@/services/balanceCalculator'
 import { Participant } from '@/types/participant'
 import { Expense } from '@/types/expense'
 import { Settlement } from '@/types/settlement'
 import { ParticipantAvatar } from '@/components/ParticipantAvatar'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface QuickGroupMembersSheetProps {
   open: boolean
@@ -34,9 +31,7 @@ export function QuickGroupMembersSheet({
   exchangeRates = {},
   settlements = [],
 }: QuickGroupMembersSheetProps) {
-  const scrollRef = useIOSScrollFix()
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
-  const isMobile = useMediaQuery('(max-width: 767px)')
 
   function isLinked(balanceId: string): boolean {
     return !!participants.find(p => p.id === balanceId)?.user_id
@@ -63,30 +58,13 @@ export function QuickGroupMembersSheet({
     return participant?.wallet_group ?? null
   }
 
-  const closeBtn = (
-    <button
-      onClick={() => onOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title={`Group (${balances.length} ${balances.length === 1 ? 'member' : 'members'})`}
+      scrollClassName=""
     >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
-  const header = (
-    <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-      <div className="w-8" />
-      {isMobile ? (
-        <SheetTitle className="text-base font-semibold">Group ({balances.length} {balances.length === 1 ? 'member' : 'members'})</SheetTitle>
-      ) : (
-        <DialogTitle className="text-base font-semibold">Group ({balances.length} {balances.length === 1 ? 'member' : 'members'})</DialogTitle>
-      )}
-      {closeBtn}
-    </div>
-  )
-
-  const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
       {balances.map((b, i) => {
         const isMe = b.id === myParticipantId
         const linked = isLinked(b.id)
@@ -151,32 +129,7 @@ export function QuickGroupMembersSheet({
           </div>
         )
       })}
-    </div>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{ height: '75dvh' }}
-        >
-          {header}
-          {scrollContent}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] max-w-lg p-0 gap-0">
-        {header}
-        {scrollContent}
-      </DialogContent>
-    </Dialog>
+    </ResponsiveOverlay>
   )
 }
 

--- a/src/components/quick/QuickHistorySheet.tsx
+++ b/src/components/quick/QuickHistorySheet.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useMemo } from 'react'
-import { X, FileText } from 'lucide-react'
+import { FileText } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -11,10 +11,7 @@ import { TransactionItem } from '@/components/quick/TransactionItem'
 import { PageLoadingState } from '@/components/PageLoadingState'
 import { PageErrorState } from '@/components/PageErrorState'
 import { Card, CardContent } from '@/components/ui/card'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 type FilterType = 'all' | 'expenses' | 'payments'
 
@@ -29,10 +26,8 @@ export function QuickHistorySheet({ open, onOpenChange }: QuickHistorySheetProps
   const { participants, loading: participantsLoading, error: participantError, refreshParticipants } = useParticipantContext()
   const { expenses, loading: expensesLoading, error: expenseError, refreshExpenses } = useExpenseContext()
   const { settlements, loading: settlementsLoading, error: settlementError, refreshSettlements } = useSettlementContext()
-  const scrollRef = useIOSScrollFix()
   const [filter, setFilter] = useState<FilterType>('all')
   const [retrying, setRetrying] = useState(false)
-  const isMobile = useMediaQuery('(max-width: 767px)')
 
   const contextError = participantError || expenseError || settlementError
 
@@ -70,18 +65,12 @@ export function QuickHistorySheet({ open, onOpenChange }: QuickHistorySheetProps
     { key: 'payments', label: 'Payments' },
   ]
 
-  const closeBtn = (
-    <button
-      onClick={() => onOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title="Expenses & Payments"
     >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
-  const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
       {/* Filters */}
       <div className="flex gap-2 mb-4">
         {filterButtons.map(({ key, label }) => (
@@ -132,39 +121,6 @@ export function QuickHistorySheet({ open, onOpenChange }: QuickHistorySheetProps
           ))}
         </div>
       )}
-    </div>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{ height: '75dvh' }}
-        >
-          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-            <div className="w-8" />
-            <SheetTitle className="text-base font-semibold">Expenses & Payments</SheetTitle>
-            {closeBtn}
-          </div>
-          {scrollContent}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
-        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-          <div className="w-8" />
-          <DialogTitle className="text-base font-semibold">Expenses & Payments</DialogTitle>
-          {closeBtn}
-        </div>
-        {scrollContent}
-      </DialogContent>
-    </Dialog>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/quick/QuickParticipantSetupSheet.tsx
+++ b/src/components/quick/QuickParticipantSetupSheet.tsx
@@ -1,13 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-import { X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { ParticipantsSetup } from '@/components/setup/ParticipantsSetup'
-import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface QuickParticipantSetupSheetProps {
   open: boolean
@@ -16,84 +11,26 @@ interface QuickParticipantSetupSheetProps {
 
 export function QuickParticipantSetupSheet({ open, onOpenChange }: QuickParticipantSetupSheetProps) {
   const { currentTrip } = useCurrentTrip()
-  const keyboard = useKeyboardHeight()
-  const scrollRef = useIOSScrollFix()
-  const isMobile = useMediaQuery('(max-width: 767px)')
 
   if (!currentTrip) return null
 
-  const closeBtn = (
-    <button
-      onClick={() => onOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-    >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
-  const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-4 space-y-4">
-      <ParticipantsSetup />
-    </div>
-  )
-
-  const footer = (
-    <div className="shrink-0 px-4 py-3 border-t border-border bg-background pwa-safe-bottom">
-      <Button className="w-full" onClick={() => onOpenChange(false)}>
-        Done
-      </Button>
-    </div>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{
-            height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-            ...(keyboard.isVisible && {
-              top: `${keyboard.viewportOffset}px`,
-              bottom: 'auto',
-            }),
-          }}
-        >
-          {/* Sticky header — never scrolls */}
-          <div className="shrink-0 border-b border-border">
-            <div className="flex items-center justify-between px-4 py-3">
-              <div className="w-8" />
-              <SheetTitle className="text-base font-semibold">Set up your group</SheetTitle>
-              {closeBtn}
-            </div>
-            <SheetDescription className="px-4 pb-3 mt-0">Add the people sharing costs on this trip</SheetDescription>
-          </div>
-
-          {scrollContent}
-          {footer}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] max-w-lg p-0 gap-0">
-        {/* Sticky header */}
-        <div className="shrink-0 border-b border-border">
-          <div className="flex items-center justify-between px-4 py-3">
-            <div className="w-8" />
-            <DialogTitle className="text-base font-semibold">Set up your group</DialogTitle>
-            {closeBtn}
-          </div>
-          <DialogDescription className="px-4 pb-3 mt-0">Add the people sharing costs on this trip</DialogDescription>
-        </div>
-
-        {scrollContent}
-        {footer}
-      </DialogContent>
-    </Dialog>
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title="Set up your group"
+      hasInputs
+      headerExtra={
+        <p className="text-sm text-muted-foreground px-4 pb-3 mt-0">Add the people sharing costs on this trip</p>
+      }
+      footer={
+        <Button className="w-full" onClick={() => onOpenChange(false)}>
+          Done
+        </Button>
+      }
+      scrollClassName="px-6 py-4 space-y-4"
+    >
+      <ParticipantsSetup />
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/quick/QuickScanContextSheet.tsx
+++ b/src/components/quick/QuickScanContextSheet.tsx
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useNavigate } from 'react-router-dom'
-import { Plus, ScanLine, X } from 'lucide-react'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Plus, ScanLine } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import type { Event } from '@/types/trip'
 
 interface QuickScanContextSheetProps {
@@ -21,9 +18,7 @@ export function QuickScanContextSheet({
   trips,
   onNewGroup,
 }: QuickScanContextSheetProps) {
-  const scrollRef = useIOSScrollFix()
   const navigate = useNavigate()
-  const isMobile = useMediaQuery('(max-width: 767px)')
 
   const handleSelectTrip = (tripCode: string) => {
     onOpenChange(false)
@@ -35,91 +30,36 @@ export function QuickScanContextSheet({
     onNewGroup()
   }
 
-  const closeBtn = (
-    <button
-      onClick={() => onOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-    >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
-  const headerSubtitle = (
-    <p className="text-sm text-muted-foreground px-4 pb-3">Which group is this for?</p>
-  )
-
-  const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-4 py-3 space-y-2">
-      {trips.map(trip => (
-        <button
-          key={trip.id}
-          onClick={() => handleSelectTrip(trip.trip_code)}
-          className="w-full text-left px-4 py-3 rounded-xl border border-border hover:bg-accent/40 transition-colors"
-        >
-          <span className="font-medium text-foreground">{trip.name}</span>
-        </button>
-      ))}
-
-      {/* New Group option */}
-      <Button
-        variant="outline"
-        className="w-full gap-2 mt-1"
-        onClick={handleNewGroup}
-      >
-        <Plus size={16} />
-        New Group
-      </Button>
-    </div>
-  )
-
-  const TitleIcon = () => (
-    <span className="flex items-center gap-2">
-      <ScanLine size={20} />
-      Scan a Receipt
-    </span>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{ height: '75dvh' }}
-        >
-          <div className="shrink-0 border-b border-border">
-            <div className="flex items-center justify-between px-4 py-3">
-              <div className="w-8" />
-              <SheetTitle className="text-base font-semibold flex items-center gap-2">
-                <TitleIcon />
-              </SheetTitle>
-              {closeBtn}
-            </div>
-            {headerSubtitle}
-          </div>
-          {scrollContent}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
-        <div className="shrink-0 border-b border-border">
-          <div className="flex items-center justify-between px-4 py-3">
-            <div className="w-8" />
-            <DialogTitle className="text-base font-semibold flex items-center gap-2">
-              <TitleIcon />
-            </DialogTitle>
-            {closeBtn}
-          </div>
-          {headerSubtitle}
-        </div>
-        {scrollContent}
-      </DialogContent>
-    </Dialog>
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title={<span className="flex items-center gap-2"><ScanLine size={20} />Scan a Receipt</span>}
+      headerExtra={
+        <p className="text-sm text-muted-foreground px-4 pb-3">Which group is this for?</p>
+      }
+    >
+      <div className="space-y-2">
+        {trips.map(trip => (
+          <button
+            key={trip.id}
+            onClick={() => handleSelectTrip(trip.trip_code)}
+            className="w-full text-left px-4 py-3 rounded-xl border border-border hover:bg-accent/40 transition-colors"
+          >
+            <span className="font-medium text-foreground">{trip.name}</span>
+          </button>
+        ))}
+
+        {/* New Group option */}
+        <Button
+          variant="outline"
+          className="w-full gap-2 mt-1"
+          onClick={handleNewGroup}
+        >
+          <Plus size={16} />
+          New Group
+        </Button>
+      </div>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/quick/QuickSettlementSheet.tsx
+++ b/src/components/quick/QuickSettlementSheet.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useRef, useMemo, useEffect, useCallback } from 'react'
-import { ArrowRight, ArrowLeft, PartyPopper, Bell, Check, X } from 'lucide-react'
+import { useState, useRef, useMemo, useEffect } from 'react'
+import { ArrowRight, PartyPopper, Bell, Check, X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -11,10 +11,7 @@ import { calculateBalances, buildEntityMap } from '@/services/balanceCalculator'
 import { calculateOptimalSettlement, SettlementTransaction } from '@/services/settlementOptimizer'
 import { SettlementForm, SettlementFormHandle } from '@/components/SettlementForm'
 import { CreateSettlementInput } from '@/types/settlement'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { Button } from '@/components/ui/button'
 import { useToast } from '@/hooks/use-toast'
@@ -62,9 +59,6 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
   const [bankDialogOpen, setBankDialogOpen] = useState(false)
   const isSubmittingRef = useRef(false)
   const formRef = useRef<SettlementFormHandle>(null)
-  const keyboard = useKeyboardHeight()
-  const isMobile = useMediaQuery('(max-width: 767px)')
-  const [isScrolledToBottom, setIsScrolledToBottom] = useState(false)
 
   // Build email map: entity ID → emails (multiple adults in wallet_group)
   const fromEmailMap = useMemo(() => {
@@ -346,41 +340,7 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
     }).format(amount)
   }
 
-  const leftSlot = view === 'form' ? (
-    <button
-      onClick={() => setView('suggestions')}
-      aria-label="Go back"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-    >
-      <ArrowLeft className="w-4 h-4 text-muted-foreground" />
-    </button>
-  ) : (
-    <div className="w-8" />
-  )
-
-  const closeBtn = (
-    <button
-      onClick={() => handleOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-    >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
   const titleText = view === 'suggestions' ? 'Settle up' : 'Settle Up'
-
-  const handleScroll = useCallback(() => {
-    const el = scrollRef.current
-    if (!el) return
-    setIsScrolledToBottom(el.scrollTop + el.clientHeight >= el.scrollHeight - 8)
-  }, [])
-
-  useEffect(() => {
-    setIsScrolledToBottom(false)
-    // Measure after content renders
-    requestAnimationFrame(() => handleScroll())
-  }, [view, handleScroll])
 
   const formContent = (
     <SettlementForm
@@ -397,27 +357,8 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
     />
   )
 
-  const formFooter = (
-    <div className="shrink-0 border-t border-border px-4 py-3 flex gap-3">
-      <Button
-        onClick={() => formRef.current?.submit()}
-        className="flex-1"
-      >
-        Confirm Payment
-      </Button>
-      <Button
-        type="button"
-        onClick={() => setView('suggestions')}
-        variant="outline"
-      >
-        Cancel
-      </Button>
-    </div>
-  )
-
   const scrollContent = (
-    <div className="relative flex-1 min-h-0 flex flex-col overflow-hidden">
-      <div ref={scrollRef} onScroll={handleScroll} className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-6 py-4">
+    <>
       {view === 'suggestions' ? (
         <div className="space-y-4">
           {allSettled ? (
@@ -662,75 +603,40 @@ export function QuickSettlementSheet({ open, onOpenChange }: QuickSettlementShee
           </div>
         </div>
       ) : formContent}
-      </div>
-      {view === 'form' && !isScrolledToBottom && (
-        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-background to-transparent" />
-      )}
-    </div>
+    </>
   )
-
-  const bankDialog = <BankDetailsDialog open={bankDialogOpen} onOpenChange={setBankDialogOpen} />
-
-  if (isMobile) {
-    return (
-      <>
-        <Sheet open={open} onOpenChange={handleOpenChange}>
-          <SheetContent
-            side="bottom"
-            hideClose
-            className="flex flex-col p-0 rounded-t-2xl"
-            style={{
-              height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-              ...(keyboard.isVisible && {
-                top: `${keyboard.viewportOffset}px`,
-                bottom: 'auto',
-              }),
-            }}
-          >
-            <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-              {leftSlot}
-              <SheetTitle className="text-base font-semibold">{titleText}</SheetTitle>
-              {closeBtn}
-            </div>
-            {scrollContent}
-            {view === 'form' && (
-              <div className="shrink-0 border-t border-border px-4 py-3 flex gap-3 pwa-safe-bottom">
-                <Button
-                  onClick={() => formRef.current?.submit()}
-                  className="flex-1"
-                >
-                  Confirm Payment
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => setView('suggestions')}
-                  variant="outline"
-                >
-                  Cancel
-                </Button>
-              </div>
-            )}
-          </SheetContent>
-        </Sheet>
-        {bankDialog}
-      </>
-    )
-  }
 
   return (
     <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
-          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-            {leftSlot}
-            <DialogTitle className="text-base font-semibold">{titleText}</DialogTitle>
-            {closeBtn}
+      <ResponsiveOverlay
+        open={open}
+        onClose={() => handleOpenChange(false)}
+        title={titleText}
+        hasInputs
+        onBack={view === 'form' ? () => setView('suggestions') : undefined}
+        footer={view === 'form' ? (
+          <div className="flex gap-3">
+            <Button
+              onClick={() => formRef.current?.submit()}
+              className="flex-1"
+            >
+              Confirm Payment
+            </Button>
+            <Button
+              type="button"
+              onClick={() => setView('suggestions')}
+              variant="outline"
+            >
+              Cancel
+            </Button>
           </div>
-          {scrollContent}
-          {view === 'form' && formFooter}
-        </DialogContent>
-      </Dialog>
-      {bankDialog}
+        ) : undefined}
+        scrollClassName="px-6 py-4"
+        scrollRef={scrollRef}
+      >
+        {scrollContent}
+      </ResponsiveOverlay>
+      <BankDetailsDialog open={bankDialogOpen} onOpenChange={setBankDialogOpen} />
     </>
   )
 }

--- a/src/components/receipts/ReceiptCaptureSheet.tsx
+++ b/src/components/receipts/ReceiptCaptureSheet.tsx
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useRef } from 'react'
 import { Camera, Upload, Loader2, X, ScanLine } from 'lucide-react'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { supabase } from '@/lib/supabase'
 import { useReceiptContext } from '@/contexts/ReceiptContext'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { logger } from '@/lib/logger'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface ReceiptCaptureSheetProps {
   open: boolean
@@ -73,8 +70,6 @@ export function ReceiptCaptureSheet({ open, onOpenChange, onScanned }: ReceiptCa
   const { createReceiptTask, refreshPendingReceipts } = useReceiptContext()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
-  const isMobile = useMediaQuery('(max-width: 767px)')
-  const scrollRef = useIOSScrollFix()
 
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
@@ -206,18 +201,15 @@ export function ReceiptCaptureSheet({ open, onOpenChange, onScanned }: ReceiptCa
     onOpenChange(nextOpen)
   }
 
-  const closeBtn = (
-    <button
-      onClick={() => handleOpenChange(false)}
-      aria-label="Close"
-      className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => handleOpenChange(false)}
+      title={<span className="flex items-center gap-2"><ScanLine size={20} />Scan Receipt</span>}
+      hasInputs
+      preventOutsideClose={scanning}
+      scrollClassName=""
     >
-      <X className="w-4 h-4 text-muted-foreground" />
-    </button>
-  )
-
-  const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
       {!previewUrl ? (
         /* File selection state */
         <div className="flex-1 flex flex-col items-center justify-center gap-4 py-8 px-4">
@@ -321,45 +313,6 @@ export function ReceiptCaptureSheet({ open, onOpenChange, onScanned }: ReceiptCa
           )}
         </div>
       )}
-    </div>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={handleOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{ height: '92dvh' }}
-        >
-          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-            <div className="w-8" />
-            <SheetTitle className="text-base font-semibold flex items-center gap-2">
-              <ScanLine size={20} />
-              Scan Receipt
-            </SheetTitle>
-            {closeBtn}
-          </div>
-          {scrollContent}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent hideClose className="flex flex-col max-h-[85vh] p-0 gap-0">
-        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-          <div className="w-8" />
-          <DialogTitle className="text-base font-semibold flex items-center gap-2">
-            <ScanLine size={20} />
-            Scan Receipt
-          </DialogTitle>
-          {closeBtn}
-        </div>
-        {scrollContent}
-      </DialogContent>
-    </Dialog>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/receipts/ReceiptDetailsSheet.tsx
+++ b/src/components/receipts/ReceiptDetailsSheet.tsx
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { ScanLine, ChevronDown, ChevronUp, Image, X, Pencil } from 'lucide-react'
+import { ScanLine, ChevronDown, ChevronUp, Image, Pencil } from 'lucide-react'
 import { ReceiptTask } from '@/types/receipt'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/lib/logger'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 
 interface ReceiptDetailsSheetProps {
   open: boolean
@@ -21,8 +18,6 @@ interface ReceiptDetailsSheetProps {
 export function ReceiptDetailsSheet({ open, onOpenChange, task, canReprocess, onReprocess }: ReceiptDetailsSheetProps) {
   const items = task.extracted_items ?? []
   const currency = task.extracted_currency ?? '—'
-  const isMobile = useMediaQuery('(max-width: 767px)')
-  const scrollRef = useIOSScrollFix()
 
   const [receiptImageUrl, setReceiptImageUrl] = useState<string | null>(null)
   const [showThumbnail, setShowThumbnail] = useState(false)
@@ -45,29 +40,26 @@ export function ReceiptDetailsSheet({ open, onOpenChange, task, canReprocess, on
       })
   }, [open, task.receipt_image_path])
 
-  const onClose = () => onOpenChange(false)
+  const footer = canReprocess && onReprocess ? (
+    <Button
+      onClick={onReprocess}
+      variant="outline"
+      className="w-full gap-2"
+    >
+      <Pencil size={16} />
+      Edit mapping
+    </Button>
+  ) : undefined
 
-  const header = (
-    <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-      <div className="w-8" />
-      <SheetTitle className="text-base font-semibold flex items-center gap-2 min-w-0">
-        <ScanLine size={18} className="shrink-0" />
-        <span className="truncate">
-          Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
-        </span>
-      </SheetTitle>
-      <button
-        onClick={onClose}
-        aria-label="Close"
-        className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-      >
-        <X className="w-4 h-4 text-muted-foreground" />
-      </button>
-    </div>
-  )
-
-  const body = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title={<span className="flex items-center gap-2 min-w-0"><ScanLine size={18} className="shrink-0" /><span className="truncate">Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}</span></span>}
+      maxWidth="max-w-2xl"
+      footer={footer}
+      scrollClassName=""
+    >
       <div className="px-4 py-3 space-y-3">
         {/* Receipt image thumbnail (collapsible) */}
         {receiptImageUrl && (
@@ -118,53 +110,6 @@ export function ReceiptDetailsSheet({ open, onOpenChange, task, canReprocess, on
           </div>
         )}
       </div>
-    </div>
-  )
-
-  const footer = canReprocess && onReprocess ? (
-    <div className="shrink-0 px-4 py-3 border-t border-border bg-background pwa-safe-bottom">
-      <Button
-        onClick={onReprocess}
-        variant="outline"
-        className="w-full gap-2"
-      >
-        <Pencil size={16} />
-        Edit mapping
-      </Button>
-    </div>
-  ) : null
-
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{ height: '75dvh' }}
-        >
-          {header}
-          {body}
-          {footer}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        hideClose
-        className="flex flex-col max-w-2xl max-h-[85vh] p-0 gap-0"
-        aria-describedby={undefined}
-      >
-        <DialogTitle className="sr-only">
-          Receipt{task.extracted_merchant ? ` — ${task.extracted_merchant}` : ''}
-        </DialogTitle>
-        {header}
-        {body}
-        {footer}
-      </DialogContent>
-    </Dialog>
+    </ResponsiveOverlay>
   )
 }

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { Loader2, Users, ChevronDown, ChevronUp, AlertCircle, SplitSquareHorizontal, Image, X } from 'lucide-react'
+import { Loader2, Users, ChevronDown, ChevronUp, AlertCircle, SplitSquareHorizontal, Image } from 'lucide-react'
 import { logger } from '@/lib/logger'
 import { supabase } from '@/lib/supabase'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { useScrollIntoView } from '@/hooks/useScrollIntoView'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -148,10 +145,8 @@ export function ReceiptReviewSheet({
   mappedItems,
   onDone,
 }: ReceiptReviewSheetProps) {
-  const isMobile = useMediaQuery('(max-width: 767px)')
   const keyboard = useKeyboardHeight()
   const contentRef = useRef<HTMLDivElement>(null)
-  useIOSScrollFix(contentRef)
   useScrollIntoView(contentRef, { enabled: keyboard.isVisible, offset: 20 })
   const { currentTrip } = useCurrentTrip()
   const { participants, getAdultParticipants } = useParticipantContext()
@@ -417,24 +412,7 @@ export function ReceiptReviewSheet({
     }
   }
 
-  const onClose = () => onOpenChange(false)
-
-  const header = (
-    <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
-      <div className="w-8" />
-      <SheetTitle className="text-base font-semibold">Review Receipt</SheetTitle>
-      <button
-        onClick={onClose}
-        aria-label="Close"
-        className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors"
-      >
-        <X className="w-4 h-4 text-muted-foreground" />
-      </button>
-    </div>
-  )
-
   const body = (
-    <div ref={contentRef} className="flex-1 overflow-y-auto overscroll-contain">
     <div className="px-4 py-3 space-y-4">
       {/* Receipt image thumbnail (collapsible) */}
       {receiptImageUrl && (
@@ -623,11 +601,10 @@ export function ReceiptReviewSheet({
         </div>
       </div>
     </div>
-    </div>
   )
 
-  const footer = (
-    <div className="shrink-0 px-4 py-3 border-t border-border bg-background pwa-safe-bottom">
+  const footerContent = (
+    <>
       <Button
         onClick={handleSubmit}
         disabled={!canSubmit || submitting}
@@ -648,45 +625,22 @@ export function ReceiptReviewSheet({
           Assign all items to submit
         </p>
       )}
-    </div>
+    </>
   )
 
-  if (isMobile) {
-    return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent
-          side="bottom"
-          hideClose
-          className="flex flex-col p-0 rounded-t-2xl"
-          style={{
-            height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-            ...(keyboard.isVisible && {
-              top: `${keyboard.viewportOffset}px`,
-              bottom: 'auto',
-            }),
-          }}
-        >
-          {header}
-          {body}
-          {footer}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        hideClose
-        className="flex flex-col max-w-2xl max-h-[85vh] p-0 gap-0"
-        aria-describedby={undefined}
-      >
-        <DialogTitle className="sr-only">Review Receipt</DialogTitle>
-        {header}
-        {body}
-        {footer}
-      </DialogContent>
-    </Dialog>
+    <ResponsiveOverlay
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title="Review Receipt"
+      hasInputs
+      maxWidth="max-w-2xl"
+      footer={footerContent}
+      scrollRef={contentRef}
+      scrollClassName=""
+    >
+      {body}
+    </ResponsiveOverlay>
   )
 }
 

--- a/src/components/ui/AppSheet.tsx
+++ b/src/components/ui/AppSheet.tsx
@@ -22,7 +22,7 @@
  * Last audited: 2026-02-24
  */
 
-import { ReactNode } from 'react'
+import { ReactNode, RefObject } from 'react'
 import { ArrowLeft, X } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
@@ -31,7 +31,7 @@ import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 interface AppSheetProps {
   open: boolean
   onClose: () => void
-  title: string
+  title: ReactNode
   height?: '92dvh' | '75dvh'
   footer?: ReactNode
   onBack?: () => void
@@ -41,6 +41,10 @@ interface AppSheetProps {
   headerExtra?: ReactNode
   /** Prevent closing when clicking outside (e.g. during submission) */
   preventOutsideClose?: boolean
+  /** External ref for the scroll container — overrides internal useIOSScrollFix ref */
+  scrollRef?: RefObject<HTMLDivElement>
+  /** Override the scroll container className. Default: 'px-4 py-4'. */
+  scrollClassName?: string
 }
 
 function SheetButton({ onClick, label, children }: { onClick: () => void; label: string; children: ReactNode }) {
@@ -66,9 +70,12 @@ export function AppSheet({
   children,
   headerExtra,
   preventOutsideClose = false,
+  scrollRef: externalScrollRef,
+  scrollClassName,
 }: AppSheetProps) {
   const keyboard = hasInputs ? useKeyboardHeight() : null
-  const scrollRef = useIOSScrollFix()
+  const internalScrollRef = useIOSScrollFix()
+  const scrollRef = externalScrollRef ?? internalScrollRef
 
   return (
     <Sheet open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
@@ -105,7 +112,7 @@ export function AppSheet({
         )}
 
         {/* SCROLLABLE CONTENT — only this scrolls */}
-        <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
+        <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${scrollClassName ?? 'px-4 py-4'}`}>
           {children}
         </div>
 

--- a/src/components/ui/ResponsiveOverlay.tsx
+++ b/src/components/ui/ResponsiveOverlay.tsx
@@ -7,7 +7,7 @@
  * Desktop gets a centered dialog with identical header structure.
  */
 
-import { ReactNode } from 'react'
+import { ReactNode, RefObject } from 'react'
 import { X, ArrowLeft } from 'lucide-react'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
@@ -21,7 +21,7 @@ import {
 export interface ResponsiveOverlayProps {
   open: boolean
   onClose: () => void
-  title: string
+  title: ReactNode
   /** true → 92dvh + keyboard hooks (mobile), false → 75dvh fixed (mobile). Default false. */
   hasInputs?: boolean
   /** Desktop dialog max-width class. Default 'max-w-lg'. */
@@ -34,6 +34,10 @@ export interface ResponsiveOverlayProps {
   headerExtra?: ReactNode
   /** Prevent closing when clicking outside. */
   preventOutsideClose?: boolean
+  /** External ref for the scroll container (e.g. for useIOSScrollFix + useScrollIntoView). */
+  scrollRef?: RefObject<HTMLDivElement>
+  /** Override the scroll container className. Default: 'px-4 py-4'. */
+  scrollClassName?: string
   children: ReactNode
 }
 
@@ -59,10 +63,13 @@ export function ResponsiveOverlay({
   onBack,
   headerExtra,
   preventOutsideClose = false,
+  scrollRef: externalScrollRef,
+  scrollClassName,
   children,
 }: ResponsiveOverlayProps) {
   const isMobile = useMediaQuery('(max-width: 767px)')
-  const scrollRef = useIOSScrollFix()
+  const internalScrollRef = useIOSScrollFix()
+  const scrollRef = externalScrollRef ?? internalScrollRef
 
   // Mobile: delegate to AppSheet (single source of truth for sheets)
   if (isMobile) {
@@ -77,6 +84,8 @@ export function ResponsiveOverlay({
         onBack={onBack}
         headerExtra={headerExtra}
         preventOutsideClose={preventOutsideClose}
+        scrollRef={externalScrollRef}
+        scrollClassName={scrollClassName}
       >
         {children}
       </AppSheet>
@@ -111,7 +120,7 @@ export function ResponsiveOverlay({
         )}
 
         {/* SCROLLABLE CONTENT */}
-        <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
+        <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${scrollClassName ?? 'px-4 py-4'}`}>
           {children}
         </div>
 

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -31,13 +31,15 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 export function ExpensesPage() {
   const { currentTrip } = useCurrentTrip()
@@ -366,25 +368,23 @@ export function ExpensesPage() {
         />
       )}
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={!!deletingExpenseId} onOpenChange={(open) => !open && setDeletingExpenseId(null)}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete Expense?</DialogTitle>
-            <DialogDescription>
+      {/* Delete Confirmation */}
+      <AlertDialog open={!!deletingExpenseId} onOpenChange={(open) => !open && setDeletingExpenseId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Expense?</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete this expense? This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button onClick={() => setDeletingExpenseId(null)} variant="outline">
-              Cancel
-            </Button>
-            <Button onClick={handleDeleteExpense} variant="destructive">
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteExpense} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
-import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
-import { Receipt, FileDown, X, Trash2 } from 'lucide-react'
+import { Receipt, FileDown, Trash2 } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -22,8 +19,7 @@ import { SettlementPlan, BankDetails } from '@/components/SettlementPlan'
 import { SettlementForm, SettlementFormHandle } from '@/components/SettlementForm'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -58,10 +54,7 @@ export function SettlementsPage() {
   const [retrying, setRetrying] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
-  const isMobile = useMediaQuery('(max-width: 767px)')
   const formRef = useRef<SettlementFormHandle>(null)
-  const keyboard = useKeyboardHeight()
-  const scrollRef = useIOSScrollFix()
 
   const handleRefresh = useCallback(
     () => Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()]).then(() => {}),
@@ -525,95 +518,41 @@ export function SettlementsPage() {
         </>}
       </div>
 
-      {/* Record Settlement — Sheet on mobile, Dialog on desktop */}
-      {isMobile ? (
-        <Sheet open={showRecordDialog} onOpenChange={(open) => { if (!open) closeDialog() }}>
-          <SheetContent side="bottom" hideClose className="flex flex-col p-0 rounded-t-2xl" style={{
-            height: keyboard.isVisible ? `${keyboard.availableHeight}px` : '92dvh',
-            ...(keyboard.isVisible && {
-              top: `${keyboard.viewportOffset}px`,
-              bottom: 'auto',
-            }),
-            ...(keyboard.viewportOffset > 0 && {
-              paddingBottom: `${keyboard.viewportOffset}px`,
-            }),
-          }}>
-            <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-              <div className="w-8" />
-              <SheetTitle className="text-base font-semibold">Settle Up</SheetTitle>
-              <button onClick={closeDialog} aria-label="Close"
-                className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors">
-                <X className="w-4 h-4 text-muted-foreground" />
-              </button>
-            </div>
-            <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain p-4">
-              <p className="text-sm text-muted-foreground mb-4">
-                Log a payment between participants.
-              </p>
-              <SettlementForm
-                ref={formRef}
-                onSubmit={handleCustomSettlement}
-                initialAmount={prefill?.amount}
-                initialNote={prefill?.note}
-                initialFromId={prefill?.fromId}
-                initialToId={prefill?.toId}
-                recipientBankDetails={prefill?.bankDetails}
-                recipientName={prefill?.recipientName}
-                hideButtons
-              />
-            </div>
-            <div className="shrink-0 border-t border-border px-4 py-3 flex gap-3 pwa-safe-bottom">
-              <Button
-                onClick={() => formRef.current?.submit()}
-                disabled={submitting}
-                className="flex-1"
-              >
-                {submitting ? 'Confirming...' : 'Confirm Payment'}
-              </Button>
-              <Button variant="outline" onClick={closeDialog}>Cancel</Button>
-            </div>
-          </SheetContent>
-        </Sheet>
-      ) : (
-        <Dialog open={showRecordDialog} onOpenChange={(open) => { if (!open) closeDialog() }}>
-          <DialogContent hideClose className="max-w-lg max-h-[85vh] p-0 gap-0 flex flex-col">
-            <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-              <div className="w-8" />
-              <DialogTitle className="text-base font-semibold">Settle Up</DialogTitle>
-              <button onClick={closeDialog} aria-label="Close"
-                className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors">
-                <X className="w-4 h-4 text-muted-foreground" />
-              </button>
-            </div>
-            <div className="flex-1 min-h-0 overflow-y-auto p-4">
-              <p className="text-sm text-muted-foreground mb-4">
-                Log a payment between participants.
-              </p>
-              <SettlementForm
-                ref={formRef}
-                hideButtons
-                onSubmit={handleCustomSettlement}
-                initialAmount={prefill?.amount}
-                initialNote={prefill?.note}
-                initialFromId={prefill?.fromId}
-                initialToId={prefill?.toId}
-                recipientBankDetails={prefill?.bankDetails}
-                recipientName={prefill?.recipientName}
-              />
-            </div>
-            <div className="shrink-0 border-t border-border px-4 py-3 flex gap-3">
-              <Button
-                onClick={() => formRef.current?.submit()}
-                disabled={submitting}
-                className="flex-1"
-              >
-                {submitting ? 'Confirming...' : 'Confirm Payment'}
-              </Button>
-              <Button variant="outline" onClick={closeDialog}>Cancel</Button>
-            </div>
-          </DialogContent>
-        </Dialog>
-      )}
+      {/* Record Settlement overlay */}
+      <ResponsiveOverlay
+        open={showRecordDialog}
+        onClose={closeDialog}
+        title="Settle Up"
+        hasInputs
+        footer={
+          <div className="flex gap-3">
+            <Button
+              onClick={() => formRef.current?.submit()}
+              disabled={submitting}
+              className="flex-1"
+            >
+              {submitting ? 'Confirming...' : 'Confirm Payment'}
+            </Button>
+            <Button variant="outline" onClick={closeDialog}>Cancel</Button>
+          </div>
+        }
+        scrollClassName="p-4"
+      >
+        <p className="text-sm text-muted-foreground mb-4">
+          Log a payment between participants.
+        </p>
+        <SettlementForm
+          ref={formRef}
+          hideButtons
+          onSubmit={handleCustomSettlement}
+          initialAmount={prefill?.amount}
+          initialNote={prefill?.note}
+          initialFromId={prefill?.fromId}
+          initialToId={prefill?.toId}
+          recipientBankDetails={prefill?.bankDetails}
+          recipientName={prefill?.recipientName}
+        />
+      </ResponsiveOverlay>
 
       {/* Delete settlement confirmation */}
       <AlertDialog open={!!deletingId} onOpenChange={(open) => { if (!open) setDeletingId(null) }}>


### PR DESCRIPTION
## Summary

- Migrates all 12 remaining components that manually implemented dual Sheet/Dialog pattern (`if (isMobile) { <Sheet> } else { <Dialog> }`) to use the unified `ResponsiveOverlay` component
- Enhances `ResponsiveOverlay` and `AppSheet` with `scrollRef`, `scrollClassName`, and `ReactNode` title props
- Fixes `ExpensesPage` delete confirmation to use `AlertDialog` instead of `Dialog` for semantic correctness
- **Net -681 lines** of duplicated boilerplate removed across 15 files

### Components migrated

**Tier 1 — Read-only (5):** QuickHistorySheet, QuickScanContextSheet, QuickGroupMembersSheet, DayDetailSheet, ReceiptDetailsSheet

**Tier 1 — Forms (5):** QuickCreateSheet, QuickParticipantSetupSheet, ReceiptCaptureSheet, ReportIssueDialog, ReceiptReviewSheet

**Tier 2 — Complex (2):** SettlementsPage (settlement record overlay), QuickSettlementSheet (dual-view suggestions → form)

### ResponsiveOverlay enhancements
- `scrollRef` prop — external ref for scroll container (used by ReceiptReviewSheet for `useScrollIntoView`)
- `scrollClassName` prop — override default `px-4 py-4` padding on scroll container
- `title` prop now accepts `ReactNode` (supports icon + text titles)

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 193 tests pass
- [x] `npm run test:e2e` — 26 tests pass (both viewports)
- [ ] Manual: verify each migrated overlay opens as bottom sheet on mobile viewport
- [ ] Manual: verify each migrated overlay opens as centered dialog on desktop
- [ ] Manual iPhone test for `hasInputs` overlays — keyboard handling correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)