### PR TITLE
fix: frontend standardization — AlertDialog, breakpoint, logger + docs update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ On mobile (< 768 px), renders `MobileWizard` (bottom Sheet, 3–4 step wizard). 
 **Important behaviours:**
 - `paidBy` is pre-filled with the auth user's linked adult participant (`participant.user_id === user.id && is_adult`) via a `useEffect` that fires when the form opens and the field is still empty
 - `suggestedPayer` banner still shows the balance-based suggestion; tapping it overrides `paidBy`
-- `useMediaQuery('(max-width: 768px)')` initialises as `false` on first render, then updates — this is expected behaviour
+- `useMediaQuery('(max-width: 767px)')` initialises as `false` on first render, then updates — this is expected behaviour
 - Sheet height: `keyboard.isVisible ? availableHeight : 92dvh`
 - Sheet bottom: `keyboard.isVisible ? Math.max(0, keyboardHeight - viewportOffset) : undefined` — **critical for iOS** (see iOS section)
 - Sheet paddingBottom: `viewportOffset > 0 ? viewportOffset : undefined` — keeps content above keyboard overlap zone when iOS scrolls the visual viewport
@@ -278,6 +278,16 @@ Always `dvh`. **Never** `vh`. **Never** `100vh`. **Never** `h-screen`.
 - Never show two buttons that both close the sheet.
 
 **Full spec and audit log:** `docs/SHEET_AUDIT.md`
+
+### ResponsiveOverlay (`src/components/ui/ResponsiveOverlay.tsx`)
+
+Use `ResponsiveOverlay` for **every overlay** that needs Sheet on mobile / Dialog on desktop. Handles breakpoint detection (`767px`), keyboard handling, and iOS scroll fixes internally. Props: `hasInputs`, `footer`, `headerExtra`, `scrollRef`, `scrollClassName`, `maxWidth`, `onBack`, `preventOutsideClose`.
+
+**Exceptions (raw Sheet/Dialog):** `ExpenseWizard` (multi-step wizard with step navigation) and `QuickScanCreateFlow` (3-step flow with trip creation mid-flow).
+
+**AlertDialog rule:** Delete/destructive confirmations use `AlertDialog` (not `Dialog` or `ResponsiveOverlay`). Small, centered, same on all viewports.
+
+**Breakpoint standard:** Mobile detection uses `useMediaQuery('(max-width: 767px)')` — all components use `767px`, not `768px`.
 
 ### Quick Actions Standard (QuickGroupDetailPage)
 

--- a/docs/CARD_SHEET_STANDARD.md
+++ b/docs/CARD_SHEET_STANDARD.md
@@ -9,26 +9,21 @@
 
 ```
 Is this an overlay that blocks interaction with the page?
-├── YES → Does it contain form inputs or require keyboard?
-│   ├── YES → Is the user on mobile (< 768px)?
-│   │   ├── YES → Bottom Sheet (92dvh, keyboard-aware)
-│   │   └── NO  → Centered Dialog (max-h-[85vh], flex column)
-│   └── NO  → Is it a read-only detail view or picker?
-│       ├── YES → Is the user on mobile (< 768px)?
-│       │   ├── YES → Bottom Sheet (75dvh, no keyboard hook)
-│       │   └── NO  → Centered Dialog (max-h-[85vh])
-│       └── NO  → Small confirmation / action?
-│           └── YES → AlertDialog (same on all viewports)
+├── YES → Is it a delete / destructive confirmation?
+│   └── YES → AlertDialog (same on all viewports, no Sheet needed)
+├── YES → Is it a multi-step wizard with step navigation?
+│   └── YES → Raw Sheet + Dialog (see ExpenseWizard / QuickScanCreateFlow)
+├── YES → Any other overlay (form, picker, detail view)?
+│   └── YES → ResponsiveOverlay (hasInputs=true for forms, false for read-only)
 └── NO → Inline card or section (not covered here)
 ```
 
 **Rules:**
-- Every overlay that appears on mobile MUST be a bottom Sheet. No centered dialogs on phones.
-- Every overlay that appears on desktop MUST be a centered Dialog. No bottom sheets on desktop.
-- Detection: `useMediaQuery('(max-width: 767px)')` — never `window.innerWidth`.
-- Multi-step wizards: Sheet on mobile (MobileWizard pattern), Dialog on desktop.
-- Delete confirmations: AlertDialog (small, centered, same on all viewports). These are the one exception to the Sheet-on-mobile rule — they're short enough that centering is fine.
-- The **same content JSX** should be extracted into a variable and rendered inside both Sheet and Dialog to avoid duplication.
+- **Default choice: `ResponsiveOverlay`** (`src/components/ui/ResponsiveOverlay.tsx`). It renders `AppSheet` on mobile (< 768px) and `Dialog` on desktop, handling breakpoint detection, keyboard, and iOS scroll fixes internally.
+- Detection: `useMediaQuery('(max-width: 767px)')` — never `window.innerWidth`, never `768px`.
+- **Delete confirmations:** `AlertDialog` (small, centered, same on all viewports). The one exception to the Sheet-on-mobile rule — they're short enough that centering is fine.
+- **Multi-step wizards:** Use raw `Sheet` + `Dialog` directly (see §4). Only `ExpenseWizard` and `QuickScanCreateFlow` need this.
+- **Never** use raw `Sheet`/`Dialog` for simple single-screen overlays — use `ResponsiveOverlay` instead.
 
 ---
 
@@ -215,6 +210,97 @@ For simple dialogs that are small enough to work on all viewports (confirmations
 
 ---
 
+## 3c. ResponsiveOverlay — Standard Wrapper (preferred)
+
+**Use `ResponsiveOverlay` for every new overlay.** It renders `AppSheet` on mobile and `Dialog` on desktop, sharing the same header structure. You don't need to manage breakpoint detection, keyboard, or iOS scroll fixes manually.
+
+```tsx
+import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
+
+function MyOverlay({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onClose={onClose}
+      title="Title"
+      hasInputs           // true → 92dvh + keyboard hooks (mobile); false → 75dvh (default)
+      maxWidth="max-w-lg"  // desktop Dialog max-width (default: 'max-w-lg')
+      footer={<Button>Save</Button>}  // optional sticky footer
+    >
+      {/* content */}
+    </ResponsiveOverlay>
+  )
+}
+```
+
+**Props reference:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | — | Controls visibility |
+| `onClose` | `() => void` | — | Called on close (both mobile swipe and desktop overlay click) |
+| `title` | `ReactNode` | — | Shown in sticky header center slot |
+| `hasInputs` | `boolean` | `false` | `true` → 92dvh + keyboard handling; `false` → 75dvh read-only |
+| `maxWidth` | `string` | `'max-w-lg'` | Desktop dialog max-width class |
+| `footer` | `ReactNode` | — | Sticky footer below scroll area |
+| `onBack` | `() => void` | — | Shows ← back arrow in left slot |
+| `headerExtra` | `ReactNode` | — | Content below title row (e.g. description, progress bar) |
+| `preventOutsideClose` | `boolean` | `false` | Block overlay click during submission |
+| `scrollRef` | `RefObject<HTMLDivElement>` | — | External scroll ref (e.g. for `useScrollIntoView`) |
+| `scrollClassName` | `string` | `'px-4 py-4'` | Override scroll container className |
+
+---
+
+## 3d. AlertDialog — Delete / Destructive Confirmations
+
+**All delete confirmations MUST use `AlertDialog`, not `Dialog` or `ResponsiveOverlay`.** AlertDialog prevents closing by clicking outside (user must explicitly cancel or confirm), which is the correct UX for destructive actions.
+
+```tsx
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+<AlertDialog open={showDelete} onOpenChange={setShowDelete}>
+  <AlertDialogContent className="max-w-sm">
+    <AlertDialogHeader>
+      <AlertDialogTitle>Delete Item?</AlertDialogTitle>
+      <AlertDialogDescription>
+        Are you sure? This action cannot be undone.
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction
+        onClick={handleDelete}
+        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      >
+        Delete
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+**Key differences from Dialog:**
+- `AlertDialogCancel` auto-closes (no need for manual `onClick`)
+- `AlertDialogAction` styled as primary by default — override with destructive classes
+- No outside-click dismiss (safe for destructive actions)
+- Same on all viewports (small centered modal)
+
+---
+
+## 3e. Documented Exceptions (raw Sheet/Dialog)
+
+Two components intentionally bypass `ResponsiveOverlay` and manage their own `Sheet`/`Dialog` rendering:
+
+1. **`ExpenseWizard`** (`src/components/expenses/ExpenseWizard.tsx`) — Multi-step wizard with step navigation, custom progress bar, and separate MobileWizard/MobileEditSheet/Desktop paths.
+2. **`QuickScanCreateFlow`** (`src/components/quick/QuickScanCreateFlow.tsx`) — 3-step flow (camera → scanning → participants) with trip creation mid-flow and close-prevention during scanning.
+
+These are the only components that should use raw `Sheet`/`Dialog`. All other overlays should use `ResponsiveOverlay`.
+
+---
+
 ## 4. MobileWizard Rules
 
 The MobileWizard (in `ExpenseWizard.tsx`) is a special multi-step sheet pattern.
@@ -366,70 +452,54 @@ Copy-paste this into PR reviews for any new or modified sheet/dialog:
 
 ---
 
-## Appendix A — Existing Component Audit (2026-03-08)
+## Appendix A — Existing Component Audit (2026-03-08, updated 2026-03-08 post-PR #661)
 
 ### Audit Table
 
-| Component | File | Opens as | Dual mode | Height | hideClose | Header shrink-0 | IOSScrollFix | pwa-safe-bottom | Keyboard pattern | Issues |
-|-----------|------|----------|-----------|--------|-----------|-----------------|--------------|-----------------|------------------|--------|
-| AppSheet | ui/AppSheet.tsx | Sheet | N/A (base) | 92/75dvh | ✅ | ✅ | ✅ | ✅ footer | **top-based** ✅ | — |
-| MobileWizard | expenses/ExpenseWizard.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | Edit mode also uses Sheet on mobile (MobileEditSheet) |
-| SettlementsPage | pages/SettlementsPage.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
-| QuickSettlementSheet | quick/QuickSettlementSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
-| QuickCreateSheet | quick/QuickCreateSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ❌ | **top-based** ✅ | — |
-| QuickScanCreateFlow | quick/QuickScanCreateFlow.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
-| QuickParticipantSetupSheet | quick/QuickParticipantSetupSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
-| ReceiptReviewSheet | receipts/ReceiptReviewSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ✅ | **top-based** ✅ | — |
-| ReceiptCaptureSheet | receipts/ReceiptCaptureSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ❌ | N/A (no inputs) | P3: no pwa-safe |
-| ReceiptDetailsSheet | receipts/ReceiptDetailsSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 75dvh | ✅ | ✅ | ✅ | ✅ | N/A (read-only) | — |
-| QuickHistorySheet | quick/QuickHistorySheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 75dvh | ✅ | ✅ | ✅ | ❌ | N/A (read-only) | P3: no pwa-safe |
-| QuickScanContextSheet | quick/QuickScanContextSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 75dvh | ✅ | ✅ | ✅ | ❌ | N/A (read-only) | P3: no pwa-safe |
-| QuickGroupMembersSheet | quick/QuickGroupMembersSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 75dvh | ✅ | ✅ | ✅ | ❌ | N/A (read-only) | — |
-| DayDetailSheet | DayDetailSheet.tsx | Sheet+Dialog | ✅ useMediaQuery | 75dvh | ✅ | ✅ | ✅ | ❌ | N/A (read-only) | P3: no pwa-safe |
-| CostBreakdownDialog | CostBreakdownDialog.tsx | Dialog only | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| ReportIssueDialog | ReportIssueDialog.tsx | Sheet+Dialog | ✅ useMediaQuery | 92dvh | ✅ | ✅ | ✅ | ❌ | **top-based** ✅ | — |
-| ShareTripDialog | ShareTripDialog.tsx | Dialog only | ❌ | default | ❌ | ✅ | ❌ | ❌ | N/A | P3: no sheet on mobile |
-| LinkParticipantDialog | LinkParticipantDialog.tsx | Dialog only | ❌ | default | ❌ | ✅ | ❌ | ❌ | N/A | P3: no sheet on mobile |
-| BankDetailsDialog | auth/BankDetailsDialog.tsx | Dialog only | ❌ | default | ❌ | ✅ | ❌ | ❌ | N/A | P3: no sheet on mobile |
-| ManageTripPage edit | pages/ManageTripPage.tsx | Dialog only | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| ShoppingPage add | pages/ShoppingPage.tsx | Dialog only | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| ExpensesPage delete | pages/ExpensesPage.tsx | AlertDialog | N/A | default | ❌ | ✅ | ❌ | ❌ | N/A | — (correct for confirmation) |
-| ActivityCard edit/delete | ActivityCard.tsx | Dialog/AlertDialog | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| MealCard edit/delete | MealCard.tsx | Dialog/AlertDialog | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| MealGrid add | MealGrid.tsx | Dialog only | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| TimeSlotGrid add | TimeSlotGrid.tsx | Dialog only | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| ShoppingItemCard edit/delete | ShoppingItemCard.tsx | Dialog/AlertDialog | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| ShoppingItemRow edit/delete | ShoppingItemRow.tsx | Dialog/AlertDialog | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
-| StayCard edit/delete | StayCard.tsx | Dialog/AlertDialog | ❌ | max-h-[85vh] | ❌ | ✅ | ✅ | ❌ | N/A | — |
+**Legend:** RO = `ResponsiveOverlay`, Raw = raw Sheet+Dialog, AD = AlertDialog
 
-### Prioritised Issue List
+| Component | File | Wrapper | Notes |
+|-----------|------|---------|-------|
+| **ResponsiveOverlay consumers (25)** | | | |
+| SettlementsPage form | pages/SettlementsPage.tsx | RO | hasInputs, keyboard ✅ |
+| QuickSettlementSheet | quick/QuickSettlementSheet.tsx | RO | hasInputs, keyboard ✅ |
+| QuickCreateSheet | quick/QuickCreateSheet.tsx | RO | hasInputs, keyboard ✅ |
+| QuickParticipantSetupSheet | quick/QuickParticipantSetupSheet.tsx | RO | hasInputs, keyboard ✅ |
+| ReceiptReviewSheet | receipts/ReceiptReviewSheet.tsx | RO | hasInputs, keyboard ✅ |
+| ReceiptCaptureSheet | receipts/ReceiptCaptureSheet.tsx | RO | no inputs |
+| ReceiptDetailsSheet | receipts/ReceiptDetailsSheet.tsx | RO | read-only 75dvh |
+| QuickHistorySheet | quick/QuickHistorySheet.tsx | RO | read-only 75dvh |
+| QuickScanContextSheet | quick/QuickScanContextSheet.tsx | RO | read-only 75dvh |
+| QuickGroupMembersSheet | quick/QuickGroupMembersSheet.tsx | RO | read-only 75dvh |
+| DayDetailSheet | DayDetailSheet.tsx | RO | read-only 75dvh |
+| ReportIssueDialog | ReportIssueDialog.tsx | RO | hasInputs, keyboard ✅ |
+| ShareTripDialog | ShareTripDialog.tsx | RO | no inputs |
+| LinkParticipantDialog | LinkParticipantDialog.tsx | RO | hasInputs |
+| BankDetailsDialog | auth/BankDetailsDialog.tsx | RO | hasInputs |
+| MealCard edit | MealCard.tsx | RO | hasInputs |
+| ActivityCard edit | ActivityCard.tsx | RO | hasInputs |
+| StayCard edit | StayCard.tsx | RO | hasInputs |
+| ShoppingItemCard edit | ShoppingItemCard.tsx | RO | hasInputs |
+| ShoppingItemRow edit | ShoppingItemRow.tsx | RO | hasInputs |
+| ManageTripPage edit | pages/ManageTripPage.tsx | RO | hasInputs |
+| ShoppingPage add | pages/ShoppingPage.tsx | RO | hasInputs |
+| MealGrid add | MealGrid.tsx | RO | hasInputs |
+| TimeSlotGrid add | TimeSlotGrid.tsx | RO | hasInputs |
+| CostBreakdownDialog | CostBreakdownDialog.tsx | RO | read-only |
+| **Raw Sheet+Dialog (2 exceptions)** | | | |
+| ExpenseWizard | expenses/ExpenseWizard.tsx | Raw | Multi-step wizard, custom progress bar |
+| QuickScanCreateFlow | quick/QuickScanCreateFlow.tsx | Raw | 3-step flow with trip creation mid-flow |
+| **AlertDialog (delete confirmations)** | | | |
+| ExpensesPage delete | pages/ExpensesPage.tsx | AD | — |
+| SettlementsPage delete | pages/SettlementsPage.tsx | AD | — |
+| ManageTripPage delete | pages/ManageTripPage.tsx | AD | — |
+| MealCard delete | MealCard.tsx | AD | — |
+| ActivityCard delete | ActivityCard.tsx | AD | — |
+| StayCard delete | StayCard.tsx | AD | — |
+| ShoppingItemCard delete | ShoppingItemCard.tsx | AD | — |
+| ShoppingItemRow delete | ShoppingItemRow.tsx | AD | — |
+| GroupActions delete | quick/GroupActions.tsx | AD | — |
 
-#### P1 — Broken on device (keyboard positioning)
+### Issue History (all resolved)
 
-1–6. ✅ **All 6 sheets migrated to top-based keyboard positioning** (`top: viewportOffset`, `bottom: 'auto'`, `height: availableHeight`) — PR #653
-   - AppSheet, QuickSettlementSheet, QuickCreateSheet, QuickScanCreateFlow, ReceiptReviewSheet, QuickParticipantSetupSheet
-
-#### P2 — Visual bug
-
-7. ✅ **ReportIssueDialog converted to dual Sheet/Dialog** — PR #656
-   - Mobile: bottom Sheet with standard pattern (92dvh, top-based keyboard, hideClose, 3-slot header, useIOSScrollFix)
-   - Desktop: Dialog with `max-h-[85vh]`, same header/content pattern
-   - Removed `transform: translateY()` hack entirely
-
-#### P3 — Inconsistency (not visibly broken)
-
-8. ✅ **AppSheet footer** now has `pwa-safe-bottom` (cascades to all AppSheet consumers) — PR #653
-   - Remaining sheets without footer (QuickCreateSheet, QuickHistorySheet, QuickScanContextSheet, ReceiptCaptureSheet, QuickGroupMembersSheet, DayDetailSheet) have no footer, so no `pwa-safe-bottom` needed. Closed.
-
-9. ✅ **Sheet-only components converted to dual Sheet/Dialog** — PR #656
-   - QuickParticipantSetupSheet — now renders Dialog on desktop
-   - QuickGroupMembersSheet — now renders Dialog on desktop
-
-10. ✅ **Dialog-only components — closed as acceptable** — PR #656
-    - Remaining ~14 dialog-only components (ShareTripDialog, LinkParticipantDialog, BankDetailsDialog, ActivityCard, MealCard, MealGrid, TimeSlotGrid, ShoppingItemCard, ShoppingItemRow, StayCard, ManageTripPage edit, ShoppingPage add, CostBreakdownDialog) are small forms (2–4 fields) or confirmations. Centered dialogs work fine on mobile. Converting each adds ~50 lines of boilerplate for marginal UX gain. Revisit only if users report friction.
-
-11. ✅ **Max-height standardized** — All dialogs now use `max-h-[85vh]` — PR #653
-
-12. ✅ **`useIOSScrollFix` added to all dialogs with `overflow-y-auto`** — PR #656
-    - CostBreakdownDialog, ActivityCard, MealCard, MealGrid, TimeSlotGrid, ShoppingItemCard, ShoppingItemRow, StayCard, ManageTripPage edit, ShoppingPage add
-    - ShareTripDialog, LinkParticipantDialog, BankDetailsDialog have no `overflow-y-auto`, so no fix needed.
+All P1–P3 issues from the original audit are resolved. See git history for PRs #653, #656, #658, #659, #661.

--- a/docs/SHEET_AUDIT.md
+++ b/docs/SHEET_AUDIT.md
@@ -1,15 +1,15 @@
 # Sheet / Dialog Audit
 
 > Started: 2026-02-24
-> Status: IN PROGRESS
+> Status: COMPLETE
 > Purpose: Document every sheet and dialog in the app,
 >   define the standard, record every gap found, and
 >   track every fix applied.
-> This file is the source of truth for this session.
-> Update it continuously — after every step, after every
-> finding, after every fix. Never let it go stale.
-> If context is lost and this session is resumed, read
-> this file first to understand exactly where things stand.
+>
+> **As of PR #659:** All sheets use `AppSheet` (via `ResponsiveOverlay`) except
+> `ExpenseWizard` and `QuickScanCreateFlow` (multi-step wizards that manage
+> their own Sheet/Dialog rendering). All delete confirmations use `AlertDialog`.
+> New overlays should use `ResponsiveOverlay` — see `docs/CARD_SHEET_STANDARD.md`.
 
 ---
 

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -10,13 +10,15 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 interface ActivityCardProps {
   activity: Activity
@@ -106,31 +108,23 @@ export function ActivityCard({ activity }: ActivityCardProps) {
         />
       </ResponsiveOverlay>
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete Activity?</DialogTitle>
-            <DialogDescription>
+      {/* Delete Confirmation */}
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent className="max-w-sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Activity?</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete "{activity.title}"?
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              onClick={() => setShowDeleteConfirm(false)}
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleDelete}
-              variant="destructive"
-            >
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/src/components/ActivityForm.tsx
+++ b/src/components/ActivityForm.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
+import { logger } from '@/lib/logger'
 
 interface ActivityFormProps {
   activity?: Activity
@@ -123,7 +124,7 @@ export function ActivityForm({
         }
       }
     } catch (error) {
-      console.error('Error saving activity:', error)
+      logger.error('Error saving activity:', { error: String(error) })
       setError('An error occurred while saving')
     } finally {
       setSubmitting(false)

--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -12,13 +12,15 @@ import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 interface MealCardProps {
   meal: MealWithIngredients
@@ -181,31 +183,23 @@ export function MealCard({ meal }: MealCardProps) {
         />
       </ResponsiveOverlay>
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete Meal?</DialogTitle>
-            <DialogDescription>
+      {/* Delete Confirmation */}
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent className="max-w-sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Meal?</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete "{meal.title}"? The linked shopping items will remain in your shopping list.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              onClick={() => setShowDeleteConfirm(false)}
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleDelete}
-              variant="destructive"
-            >
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
     </>
   )

--- a/src/components/MealForm.tsx
+++ b/src/components/MealForm.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select"
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fadeInUp } from '@/lib/animations'
+import { logger } from '@/lib/logger'
 
 interface IngredientInput {
   name: string
@@ -162,7 +163,7 @@ export function MealForm({
           }
         }
       } catch (error) {
-        console.error('Error loading ingredients:', error)
+        logger.error('Error loading ingredients:', { error: String(error) })
       } finally {
         setLoadingIngredients(false)
       }
@@ -303,7 +304,7 @@ export function MealForm({
         }
       }
     } catch (error) {
-      console.error('Error saving meal:', error)
+      logger.error('Error saving meal:', { error: String(error) })
       setError('An error occurred while saving')
     } finally {
       setSubmitting(false)

--- a/src/components/ReportIssueDialog.tsx
+++ b/src/components/ReportIssueDialog.tsx
@@ -162,7 +162,7 @@ export function ReportIssueDialog({ open, onOpenChange }: ReportIssueDialogProps
       resetForm()
       onOpenChange(false)
     } catch (err) {
-      console.error('Error submitting issue:', err)
+      logger.error('Error submitting issue:', { error: String(err) })
       toast({
         title: 'Failed to send feedback',
         description: 'Please try again later.',

--- a/src/components/ShareTripDialog.tsx
+++ b/src/components/ShareTripDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useToast } from '@/hooks/use-toast'
 import { generateShareableUrl } from '@/lib/tripCodeGenerator'
+import { logger } from '@/lib/logger'
 
 interface ShareTripDialogProps {
   tripCode: string
@@ -34,7 +35,7 @@ export function ShareTripDialog({ tripCode, tripName, trigger }: ShareTripDialog
         },
       })
         .then(url => setQrCodeUrl(url))
-        .catch(err => console.error('Error generating QR code:', err))
+        .catch(err => logger.error('Error generating QR code:', { error: String(err) }))
     }
   }, [open, shareUrl, qrCodeUrl])
 
@@ -48,7 +49,7 @@ export function ShareTripDialog({ tripCode, tripName, trigger }: ShareTripDialog
       })
       setTimeout(() => setCopied(false), 2000)
     } catch (err) {
-      console.error('Error copying to clipboard:', err)
+      logger.error('Error copying to clipboard:', { error: String(err) })
       toast({
         title: 'Copy failed',
         description: 'Please copy the link manually',
@@ -86,7 +87,7 @@ export function ShareTripDialog({ tripCode, tripName, trigger }: ShareTripDialog
         })
       } catch (err) {
         // User cancelled or error occurred
-        console.log('Share cancelled or failed:', err)
+        logger.info('Share cancelled or failed:', { error: String(err) })
       }
     } else {
       // Fallback to copy

--- a/src/components/ShoppingItemCard.tsx
+++ b/src/components/ShoppingItemCard.tsx
@@ -12,13 +12,15 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
 import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 interface ShoppingItemCardProps {
   item: ShoppingItemWithMeals
@@ -149,36 +151,28 @@ export function ShoppingItemCard({ item }: ShoppingItemCardProps) {
         />
       </ResponsiveOverlay>
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete Item?</DialogTitle>
-            <DialogDescription>
+      {/* Delete Confirmation */}
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent className="max-w-sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Item?</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete "{item.name}"?
               {item.meal_ids.length > 0 && (
                 <span className="block mt-2">
                   This item is linked to {item.meal_ids.length} meal(s).
                 </span>
               )}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              onClick={() => setShowDeleteConfirm(false)}
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleDelete}
-              variant="destructive"
-            >
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/src/components/ShoppingItemRow.tsx
+++ b/src/components/ShoppingItemRow.tsx
@@ -10,13 +10,15 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
 import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 interface ShoppingItemRowProps {
   item: ShoppingItemWithMeals
@@ -130,33 +132,28 @@ export function ShoppingItemRow({ item }: ShoppingItemRowProps) {
         />
       </ResponsiveOverlay>
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Shopping Item</DialogTitle>
-            <DialogDescription>
+      {/* Delete Confirmation */}
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Shopping Item</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete "{item.name}"?
               {item.meal_ids.length > 0 && (
                 <span className="block mt-2">
                   This item is linked to {item.meal_ids.length} meal(s).
                 </span>
               )}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setShowDeleteConfirm(false)}
-            >
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleDelete}>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/src/components/StayCard.tsx
+++ b/src/components/StayCard.tsx
@@ -10,13 +10,15 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 interface StayCardProps {
   stay: Stay
@@ -94,31 +96,23 @@ export function StayCard({ stay }: StayCardProps) {
         />
       </ResponsiveOverlay>
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete Accommodation?</DialogTitle>
-            <DialogDescription>
+      {/* Delete Confirmation */}
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent className="max-w-sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Accommodation?</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete "{stay.name}"?
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              onClick={() => setShowDeleteConfirm(false)}
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleDelete}
-              variant="destructive"
-            >
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/src/components/StayForm.tsx
+++ b/src/components/StayForm.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { fadeInUp } from '@/lib/animations'
+import { logger } from '@/lib/logger'
 
 interface StayFormProps {
   stay?: Stay
@@ -97,7 +98,7 @@ export function StayForm({ stay, onSuccess, onCancel }: StayFormProps) {
         }
       }
     } catch (error) {
-      console.error('Error saving stay:', error)
+      logger.error('Error saving stay:', { error: String(error) })
       setError('An error occurred while saving')
     } finally {
       setSubmitting(false)

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -43,7 +43,7 @@ export function ExpenseWizard({
   initialValues,
   mode = 'create',
 }: ExpenseWizardProps) {
-  const isMobile = useMediaQuery('(max-width: 768px)')
+  const isMobile = useMediaQuery('(max-width: 767px)')
 
   // Desktop: always use Dialog (both create and edit)
   if (!isMobile) {


### PR DESCRIPTION
## Summary

- **Dialog → AlertDialog** for 5 delete confirmations (MealCard, ActivityCard, StayCard, ShoppingItemCard, ShoppingItemRow) — prevents accidental close-by-clicking-outside on destructive actions
- **Breakpoint fix**: ExpenseWizard `768px` → `767px` to match project standard
- **console.error → logger.error** in 5 files (ActivityForm, StayForm, MealForm, ShareTripDialog, ReportIssueDialog) so errors appear in Grafana
- **CARD_SHEET_STANDARD.md**: Updated decision tree to recommend `ResponsiveOverlay` as default, added AlertDialog section + template, documented 2 intentional exceptions, refreshed audit table (25 RO + 2 raw + 9 AD)
- **CLAUDE.md**: Added ResponsiveOverlay, AlertDialog rule, and `767px` breakpoint standard
- **SHEET_AUDIT.md**: Marked status COMPLETE with ResponsiveOverlay note

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 193 tests pass
- [x] `npm run test:e2e` — 26 tests pass
- [ ] Manual: verify delete confirmations still work on mobile + desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)