### PR TITLE
fix: migrate console.error calls to logger for Grafana observability

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { Component, ErrorInfo, ReactNode } from 'react'
 import { AlertTriangle, Home, RefreshCw } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { logger } from '@/lib/logger'
 
 const CHUNK_RELOAD_KEY = 'spl1t:chunk-reload'
 
@@ -38,7 +39,11 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo)
+    logger.error('ErrorBoundary caught an error', {
+      errorMessage: error.message,
+      errorName: error.name,
+      componentStack: errorInfo.componentStack?.slice(0, 1000) ?? '',
+    })
 
     // Auto-reload once for stale chunk errors (new deploy invalidated cached JS)
     if (isStaleChunkError(error)) {
@@ -49,14 +54,6 @@ export class ErrorBoundary extends Component<Props, State> {
         return
       }
     }
-
-    import('@/lib/logger').then(({ logger }) => {
-      logger.error('React ErrorBoundary caught error', {
-        errorMessage: error.message,
-        errorName: error.name,
-        componentStack: errorInfo.componentStack?.slice(0, 1000) ?? '',
-      })
-    }).catch(() => {})
   }
 
   private handleReset = () => {

--- a/src/components/auth/SignInButton.tsx
+++ b/src/components/auth/SignInButton.tsx
@@ -19,7 +19,6 @@ export function SignInButton({ type = 'icon' }: SignInButtonProps) {
       }}
       onError={() => {
         logger.error('Google Sign-In failed')
-        console.error('Google Sign-In failed')
       }}
       size="medium"
       type={type}

--- a/src/contexts/MealContext.tsx
+++ b/src/contexts/MealContext.tsx
@@ -236,7 +236,7 @@ export function MealProvider({ children }: { children: ReactNode }) {
       )
 
       if (error) {
-        console.error('Error fetching meal ingredients:', error)
+        logger.error('Error fetching meal ingredients', { error: String(error) })
         return meals.map(meal => ({
           ...meal,
           shopping_items: [],
@@ -270,7 +270,7 @@ export function MealProvider({ children }: { children: ReactNode }) {
         }
       })
     } catch (error) {
-      console.error('Error fetching meals with ingredients:', error)
+      logger.error('Error fetching meals with ingredients', { error: String(error) })
       return meals.map(meal => ({
         ...meal,
         shopping_items: [],
@@ -294,13 +294,13 @@ export function MealProvider({ children }: { children: ReactNode }) {
       )
 
       if (error) {
-        console.error('Error linking meal to shopping item:', error)
+        logger.error('Error linking meal to shopping item', { error: String(error) })
         return false
       }
 
       return true
     } catch (error) {
-      console.error('Error linking meal to shopping item:', error)
+      logger.error('Error linking meal to shopping item', { error: String(error) })
       return false
     }
   }
@@ -321,13 +321,13 @@ export function MealProvider({ children }: { children: ReactNode }) {
       )
 
       if (error) {
-        console.error('Error unlinking meal from shopping item:', error)
+        logger.error('Error unlinking meal from shopping item', { error: String(error) })
         return false
       }
 
       return true
     } catch (error) {
-      console.error('Error unlinking meal from shopping item:', error)
+      logger.error('Error unlinking meal from shopping item', { error: String(error) })
       return false
     }
   }

--- a/src/contexts/ParticipantContext.tsx
+++ b/src/contexts/ParticipantContext.tsx
@@ -88,7 +88,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       if (signal.aborted) return
       setError(err instanceof Error ? err.message : 'Failed to fetch data')
-      console.error('Error fetching participants:', err)
+      logger.error('Error fetching participants', { error: String(err) })
     } finally {
       if (!signal.aborted) {
         setLoading(false)
@@ -123,7 +123,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       return newParticipant
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create participant')
-      console.error('Error creating participant:', err)
+      logger.error('Error creating participant', { error: String(err) })
       return null
     }
   }
@@ -154,7 +154,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       return true
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update participant')
-      console.error('Error updating participant:', err)
+      logger.error('Error updating participant', { error: String(err) })
       return false
     }
   }
@@ -183,7 +183,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       return true
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete participant')
-      console.error('Error deleting participant:', err)
+      logger.error('Error deleting participant', { error: String(err) })
       return false
     }
   }
@@ -269,7 +269,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       const msg = err instanceof Error ? err.message : 'Failed to link user to participant'
       setError(msg)
       logger.error('linkUserToParticipant failed', { participantId, userId, error: msg })
-      console.error('Error linking user to participant:', err)
+      logger.error('Error linking user to participant', { error: String(err) })
       return false
     }
   }
@@ -300,7 +300,7 @@ export function ParticipantProvider({ children }: { children: ReactNode }) {
       return true
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to unlink user from participant')
-      console.error('Error unlinking user from participant:', err)
+      logger.error('Error unlinking user from participant', { error: String(err) })
       return false
     }
   }

--- a/src/contexts/ShoppingContext.tsx
+++ b/src/contexts/ShoppingContext.tsx
@@ -364,7 +364,7 @@ export function ShoppingProvider({ children }: { children: ReactNode }) {
       )
 
       if (error) {
-        console.error('Error fetching shopping item meals:', error)
+        logger.error('Error fetching shopping item meals', { error: String(error) })
         return shoppingItems.map(item => ({
           ...item,
           meal_ids: [],
@@ -399,7 +399,7 @@ export function ShoppingProvider({ children }: { children: ReactNode }) {
         }
       })
     } catch (error) {
-      console.error('Error fetching shopping items with meals:', error)
+      logger.error('Error fetching shopping items with meals', { error: String(error) })
       return shoppingItems.map(item => ({
         ...item,
         meal_ids: [],
@@ -423,13 +423,13 @@ export function ShoppingProvider({ children }: { children: ReactNode }) {
       )
 
       if (error) {
-        console.error('Error linking shopping item to meal:', error)
+        logger.error('Error linking shopping item to meal', { error: String(error) })
         return false
       }
 
       return true
     } catch (error) {
-      console.error('Error linking shopping item to meal:', error)
+      logger.error('Error linking shopping item to meal', { error: String(error) })
       return false
     }
   }
@@ -450,13 +450,13 @@ export function ShoppingProvider({ children }: { children: ReactNode }) {
       )
 
       if (error) {
-        console.error('Error unlinking shopping item from meal:', error)
+        logger.error('Error unlinking shopping item from meal', { error: String(error) })
         return false
       }
 
       return true
     } catch (error) {
-      console.error('Error unlinking shopping item from meal:', error)
+      logger.error('Error unlinking shopping item from meal', { error: String(error) })
       return false
     }
   }

--- a/src/hooks/useMyTripBalances.ts
+++ b/src/hooks/useMyTripBalances.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
+import { logger } from '@/lib/logger'
 import { withTimeout } from '@/lib/fetchWithTimeout'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripContext } from '@/contexts/TripContext'
@@ -99,7 +100,7 @@ export function useMyTripBalances() {
             return { trip, myBalance, totalExpenses: calc.totalExpenses, loading: false }
           } catch (error) {
             if (cancelled) return { trip, myBalance: null, totalExpenses: 0, loading: false }
-            console.error(`Error fetching balance for trip ${trip.id}:`, error)
+            logger.error('Error fetching balance for trip', { trip_id: trip.id, error: String(error) })
             return { trip, myBalance: null, totalExpenses: 0, loading: false }
           }
         })

--- a/src/lib/mutedTripsStorage.ts
+++ b/src/lib/mutedTripsStorage.ts
@@ -8,6 +8,8 @@
  * as the user hides trips again.
  */
 
+import { logger } from '@/lib/logger'
+
 const STORAGE_KEY = 'trip-splitter:hidden-trips'
 const MAX_MUTED = 200
 const SCHEMA_VERSION = 1
@@ -51,7 +53,7 @@ export function hideTrip(tripCode: string): void {
     const trimmed = hidden.slice(-MAX_MUTED)
     saveHiddenTrips(trimmed)
   } catch (error) {
-    console.error('Error hiding trip:', error)
+    logger.error('Error hiding trip', { error: String(error) })
   }
 }
 
@@ -60,6 +62,6 @@ export function showTrip(tripCode: string): void {
     const hidden = getHiddenTripCodes().filter(c => c !== tripCode)
     saveHiddenTrips(hidden)
   } catch (error) {
-    console.error('Error showing trip:', error)
+    logger.error('Error showing trip', { error: String(error) })
   }
 }

--- a/src/lib/myTripsStorage.ts
+++ b/src/lib/myTripsStorage.ts
@@ -10,6 +10,8 @@
  * This is acceptable — myTrips is a UI convenience cache, not a source of truth.
  */
 
+import { logger } from '@/lib/logger'
+
 const MY_TRIPS_KEY = 'trip-splitter:my-trips'
 const MAX_ENTRIES = 100
 const SCHEMA_VERSION = 1
@@ -88,7 +90,7 @@ export function addToMyTrips(tripCode: string, tripName: string): void {
 
     saveMyTrips(trimmed)
   } catch (error) {
-    console.error('Error adding trip to My Trips:', error)
+    logger.error('Error adding trip to My Trips', { error: String(error) })
   }
 }
 
@@ -101,7 +103,7 @@ export function removeFromMyTrips(tripCode: string): void {
     const filtered = trips.filter(t => t.tripCode !== tripCode)
     saveMyTrips(filtered)
   } catch (error) {
-    console.error('Error removing trip from My Trips:', error)
+    logger.error('Error removing trip from My Trips', { error: String(error) })
   }
 }
 
@@ -121,7 +123,7 @@ export function clearMyTrips(): void {
   try {
     localStorage.removeItem(MY_TRIPS_KEY)
   } catch (error) {
-    console.error('Error clearing My Trips:', error)
+    logger.error('Error clearing My Trips', { error: String(error) })
   }
 }
 

--- a/src/lib/userPreferencesStorage.ts
+++ b/src/lib/userPreferencesStorage.ts
@@ -8,6 +8,8 @@
  * preferences are re-synced from Supabase on next sign-in.
  */
 
+import { logger } from '@/lib/logger'
+
 const PREFERENCES_KEY = 'spl1t:user-preferences'
 const OLD_PREFERENCES_KEY = 'trip-splitter:user-preferences'
 const SCHEMA_VERSION = 1
@@ -67,6 +69,6 @@ export function setLocalPreferences(prefs: Partial<UserPreferencesLocal>): void 
     const updated: StoredPreferences = { ...current, ...prefs, version: SCHEMA_VERSION }
     localStorage.setItem(PREFERENCES_KEY, JSON.stringify(updated))
   } catch (error) {
-    console.error('Error saving preferences to localStorage:', error)
+    logger.error('Error saving preferences to localStorage', { error: String(error) })
   }
 }

--- a/src/services/mealExpenseLinkService.ts
+++ b/src/services/mealExpenseLinkService.ts
@@ -5,6 +5,7 @@
  */
 
 import { supabase } from '@/lib/supabase'
+import { logger } from '@/lib/logger'
 import { Expense } from '@/types/expense'
 import { Meal } from '@/types/meal'
 
@@ -25,13 +26,13 @@ export async function linkMealToExpense(
       .eq('id', expenseId)
 
     if (error) {
-      console.error('Error linking meal to expense:', error)
+      logger.error('Error linking meal to expense', { error: String(error) })
       return false
     }
 
     return true
   } catch (err) {
-    console.error('Error linking meal to expense:', err)
+    logger.error('Error linking meal to expense', { error: String(err) })
     return false
   }
 }
@@ -49,13 +50,13 @@ export async function unlinkMealFromExpense(mealId: string): Promise<boolean> {
       .eq('meal_id', mealId)
 
     if (error) {
-      console.error('Error unlinking meal from expense:', error)
+      logger.error('Error unlinking meal from expense', { error: String(error) })
       return false
     }
 
     return true
   } catch (err) {
-    console.error('Error unlinking meal from expense:', err)
+    logger.error('Error unlinking meal from expense', { error: String(err) })
     return false
   }
 }
@@ -80,13 +81,13 @@ export async function getExpenseForMeal(
       if (error.code === 'PGRST116') {
         return null
       }
-      console.error('Error fetching expense for meal:', error)
+      logger.error('Error fetching expense for meal', { error: String(error) })
       return null
     }
 
     return data as unknown as Expense
   } catch (err) {
-    console.error('Error fetching expense for meal:', err)
+    logger.error('Error fetching expense for meal', { error: String(err) })
     return null
   }
 }
@@ -119,13 +120,13 @@ export async function getMealsForExpense(
       .eq('id', expense.meal_id)
 
     if (error) {
-      console.error('Error fetching meals for expense:', error)
+      logger.error('Error fetching meals for expense', { error: String(error) })
       return []
     }
 
     return (data as unknown as Meal[]) || []
   } catch (err) {
-    console.error('Error fetching meals for expense:', err)
+    logger.error('Error fetching meals for expense', { error: String(err) })
     return []
   }
 }


### PR DESCRIPTION
## Summary
- Migrated 29 `console.error` calls across 10 files to `logger.error` so errors reach Grafana Loki
- Added `import { logger }` to 6 files that were missing it (Group B: mealExpenseLinkService, useMyTripBalances, myTripsStorage, mutedTripsStorage, userPreferencesStorage, ErrorBoundary)
- Removed duplicate `console.error` in SignInButton (already had `logger.error` on the line above)
- Consolidated ErrorBoundary from lazy `import('@/lib/logger')` to direct import
- All error values wrapped with `String(error)` for clean JSON serialization to Loki
- Excluded: 3 `console.log` calls in `debugLogger.ts` (intentional browser debug helper)

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — all 193 tests pass
- [ ] `npm run test:e2e` — no behavioral changes expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)