### PR TITLE
fix: redesign split-between participant selector UX

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useRef, useMemo, FormEvent, type RefObject } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Lightbulb, ChevronDown, ChevronRight, Users, Check } from 'lucide-react'
+import { Lightbulb, ChevronDown, ChevronRight, Check } from 'lucide-react'
 import { CreateExpenseInput, ExpenseCategory, ExpenseDistribution, SplitMode } from '@/types/expense'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -555,31 +555,16 @@ export function ExpenseForm({
 
       {/* Split Between */}
       <div className="space-y-2">
-        <Label>Split Between</Label>
-
-        {/* Selection Controls */}
-        <div className="flex items-center gap-2 mb-2">
-          <Button
+        <div className="flex items-baseline justify-between">
+          <Label>Split Between</Label>
+          <button
             type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleSelectAll}
+            onClick={selectedParticipants.length === participants.length ? handleDeselectAll : handleSelectAll}
             disabled={loading}
-            className="h-8 px-2 text-xs"
+            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
           >
-            Select All
-          </Button>
-          <span className="text-muted-foreground">|</span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleDeselectAll}
-            disabled={loading}
-            className="h-8 px-2 text-xs"
-          >
-            Deselect All
-          </Button>
+            {selectedParticipants.length === participants.length ? 'Deselect all' : 'Select all'}
+          </button>
         </div>
 
         {splitMode === 'equal' ? (
@@ -589,43 +574,42 @@ export function ExpenseForm({
               const allGroupSelected = memberIds.every(id => selectedParticipants.includes(id))
 
               return (
-                <div key={group.label ?? `standalone-${gi}`} className={group.label
-                      ? 'border-l-2 border-primary/30 pl-3 flex flex-wrap gap-2'
-                      : 'flex flex-wrap gap-2'
-                    }>
+                <div key={group.label ?? `standalone-${gi}`}>
                   {group.label && (
-                    <button
-                      type="button"
-                      onClick={() => handleGroupToggle(memberIds)}
-                      disabled={loading}
-                      className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
-                        allGroupSelected
-                          ? 'bg-background text-primary border-primary'
-                          : 'bg-muted text-muted-foreground border-input hover:border-primary/50'
-                      }`}
-                    >
-                      <Users size={12} />
-                      {group.label}
-                      <span className="text-xs opacity-70">({memberIds.length})</span>
-                    </button>
+                    <div className="flex items-baseline justify-between mb-2">
+                      <span className="text-xs font-medium text-muted-foreground">{group.label}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleGroupToggle(memberIds)}
+                        disabled={loading}
+                        className="text-xs text-primary hover:text-primary/80 transition-colors"
+                      >
+                        {allGroupSelected ? 'deselect group' : 'select group'}
+                      </button>
+                    </div>
                   )}
-                  {group.members.map(participant => (
-                    <button
-                      key={participant.id}
-                      type="button"
-                      onClick={() => handleParticipantToggle(participant.id)}
-                      disabled={loading}
-                      className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
-                        selectedParticipants.includes(participant.id)
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-background text-muted-foreground border-input hover:border-primary/50'
-                      }`}
-                    >
-                      {selectedParticipants.includes(participant.id) && <Check className="w-3 h-3" />}
-                      {shortNames.get(participant.id) || participant.name}
-                      {!participant.is_adult && <span className="text-xs opacity-70">(child)</span>}
-                    </button>
-                  ))}
+                  <div className={group.label
+                    ? 'border-l-2 border-primary/30 pl-3 flex flex-wrap gap-2'
+                    : 'flex flex-wrap gap-2'
+                  }>
+                    {group.members.map(participant => (
+                      <button
+                        key={participant.id}
+                        type="button"
+                        onClick={() => handleParticipantToggle(participant.id)}
+                        disabled={loading}
+                        className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
+                          selectedParticipants.includes(participant.id)
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : 'bg-background text-muted-foreground border-input hover:border-primary/50'
+                        }`}
+                      >
+                        {selectedParticipants.includes(participant.id) && <Check className="w-3 h-3" />}
+                        {shortNames.get(participant.id) || participant.name}
+                        {!participant.is_adult && <span className="text-xs opacity-70">(child)</span>}
+                      </button>
+                    ))}
+                  </div>
                 </div>
               )
             })}
@@ -634,34 +618,21 @@ export function ExpenseForm({
           <div className="space-y-2 max-h-48 overflow-y-auto rounded-lg border border-input p-3">
             {participantGroups.map((group, gi) => {
               const memberIds = group.members.map(m => m.id)
-              const selectedCount = memberIds.filter(id => selectedParticipants.includes(id)).length
-              const allGroupSelected = selectedCount === memberIds.length
-              const someGroupSelected = selectedCount > 0 && !allGroupSelected
+              const allGroupSelected = memberIds.every(id => selectedParticipants.includes(id))
 
               return (
-                <div
-                  key={group.label ?? `standalone-${gi}`}
-                  className={group.label ? 'rounded-lg bg-muted/40 border border-border/50 p-2 mt-2 first:mt-0' : ''}
-                >
+                <div key={group.label ?? `standalone-${gi}`}>
                   {group.label && (
-                    <div
-                      role="checkbox"
-                      aria-checked={someGroupSelected ? 'mixed' : allGroupSelected}
-                      className="flex items-center space-x-2 min-h-[36px] cursor-pointer"
-                      onClick={() => handleGroupToggle(memberIds)}
-                    >
-                      <span
-                        className={`grid place-content-center h-4 w-4 shrink-0 rounded-sm border border-primary shadow ${allGroupSelected ? 'bg-primary text-primary-foreground' : ''} ${someGroupSelected ? 'opacity-60' : ''}`}
+                    <div className="flex items-baseline justify-between mb-1 mt-2 first:mt-0">
+                      <span className="text-xs font-medium text-muted-foreground">{group.label}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleGroupToggle(memberIds)}
+                        disabled={loading}
+                        className="text-xs text-primary hover:text-primary/80 transition-colors"
                       >
-                        {allGroupSelected && <Check className="h-4 w-4" />}
-                      </span>
-                      <span className="text-xs font-medium text-foreground flex-1 flex items-center gap-1">
-                        <Users size={12} className="text-muted-foreground" />
-                        {group.label}
-                        <span className="text-xs text-muted-foreground font-normal">
-                          ({memberIds.length})
-                        </span>
-                      </span>
+                        {allGroupSelected ? 'deselect group' : 'select group'}
+                      </button>
                     </div>
                   )}
                   {group.members.map(participant => (

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { ChevronDown, ChevronRight, Users, Check } from 'lucide-react'
+import { ChevronDown, ChevronRight, Check } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -101,69 +101,59 @@ export function WizardStep3({
     >
       {/* Participant chips */}
       <div className="space-y-2">
-        <Label className="text-base font-medium">Split between</Label>
+        <div className="flex items-baseline justify-between">
+          <Label className="text-base font-medium">Split between</Label>
+          <button
+            type="button"
+            onClick={allSelected ? onDeselectAll : onSelectAll}
+            disabled={disabled}
+            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            {allSelected ? 'Deselect all' : 'Select all'}
+          </button>
+        </div>
         <div className="rounded-lg border border-input p-3 space-y-3">
           {participantGroups.map((group, gi) => {
             const memberIds = group.members.map(m => m.id)
             const allGroupSelected = memberIds.every(id => selectedParticipants.includes(id))
 
             return (
-              <div
-                key={group.label ?? `standalone-${gi}`}
-                className={group.label
+              <div key={group.label ?? `standalone-${gi}`}>
+                {group.label && (
+                  <div className="flex items-baseline justify-between mb-2">
+                    <span className="text-xs font-medium text-muted-foreground">{group.label}</span>
+                    <button
+                      type="button"
+                      onClick={() => onGroupToggle(memberIds)}
+                      disabled={disabled}
+                      className="text-xs text-primary hover:text-primary/80 transition-colors"
+                    >
+                      {allGroupSelected ? 'deselect group' : 'select group'}
+                    </button>
+                  </div>
+                )}
+                <div className={group.label
                   ? 'border-l-2 border-primary/30 pl-3 flex flex-wrap gap-2'
                   : 'flex flex-wrap gap-2'
-                }
-              >
-                {/* "All" toggle chip — only in the first group */}
-                {gi === 0 && (
-                  <button
-                    type="button"
-                    onClick={allSelected ? onDeselectAll : onSelectAll}
-                    disabled={disabled}
-                    className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
-                      allSelected
-                        ? 'bg-primary text-primary-foreground border-primary'
-                        : 'bg-background text-muted-foreground border-input hover:border-primary/50'
-                    }`}
-                  >
-                    {allSelected && <Check className="w-3 h-3" />}
-                    All
-                  </button>
-                )}
-                {group.label && (
-                  <button
-                    type="button"
-                    onClick={() => onGroupToggle(memberIds)}
-                    disabled={disabled}
-                    className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
-                      allGroupSelected
-                        ? 'bg-background text-primary border-primary'
-                        : 'bg-muted text-muted-foreground border-input hover:border-primary/50'
-                    }`}
-                  >
-                    <Users size={12} />
-                    {group.label}
-                    <span className="text-xs opacity-70">({memberIds.length})</span>
-                  </button>
-                )}
-                {group.members.map(participant => (
-                  <button
-                    key={participant.id}
-                    type="button"
-                    onClick={() => onParticipantToggle(participant.id)}
-                    disabled={disabled}
-                    className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
-                      selectedParticipants.includes(participant.id)
-                        ? 'bg-primary text-primary-foreground border-primary'
-                        : 'bg-background text-muted-foreground border-input hover:border-primary/50'
-                    }`}
-                  >
-                    {selectedParticipants.includes(participant.id) && <Check className="w-3 h-3" />}
-                    {shortNames.get(participant.id) || participant.name}
-                    {!participant.is_adult && <span className="text-xs opacity-70">(child)</span>}
-                  </button>
-                ))}
+                }>
+                  {group.members.map(participant => (
+                    <button
+                      key={participant.id}
+                      type="button"
+                      onClick={() => onParticipantToggle(participant.id)}
+                      disabled={disabled}
+                      className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
+                        selectedParticipants.includes(participant.id)
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'bg-background text-muted-foreground border-input hover:border-primary/50'
+                      }`}
+                    >
+                      {selectedParticipants.includes(participant.id) && <Check className="w-3 h-3" />}
+                      {shortNames.get(participant.id) || participant.name}
+                      {!participant.is_adult && <span className="text-xs opacity-70">(child)</span>}
+                    </button>
+                  ))}
+                </div>
               </div>
             )
           })}


### PR DESCRIPTION
## Summary
- Replace confusing "All" chip (looked like a participant name) with a "Select all / Deselect all" text link at the top-right of the label row
- Replace wallet_group chip (Users icon pill with unclear selected state) with section header rows: group name (left) + "select group / deselect group" text link (right)
- Keep individual participant chips unchanged (checkmark + name + child suffix)
- Applied consistently across mobile wizard (`WizardStep3.tsx`) and desktop form (`ExpenseForm.tsx`) — both equal-split chips and custom-split (By % / By Amount) checkbox sections

## Test plan
- [x] `npm run type-check` passes clean
- [x] `npm test` — all 193 tests pass
- [ ] Manual: mobile wizard step 2 with wallet_group participants — group header visible, "select group" toggles correctly
- [ ] Manual: desktop ExpenseForm equal split — same verification
- [ ] Manual: desktop custom split (By % / By Amount) — group header row replaces old checkbox header
- [ ] Manual: trip with no wallet_groups — no headers shown, "Select all" still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)