### PR TITLE
fix: enable keyboard viewport fix on Android (not just iOS)

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-visual" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Spl1t" />


### PR DESCRIPTION
## Summary
- Add `interactive-widget=resizes-visual` to the viewport meta tag in `index.html`
- This tells Android Chrome to only resize the visual viewport (not the layout viewport) when the keyboard opens, matching iOS Safari's native behavior
- With this change, the existing `useKeyboardHeight` hook and top-based sheet positioning work correctly on Android — no code changes needed

## Why
On Android Chrome, opening a bottom sheet with inputs (expense wizard, settlement form, etc.) caused the keyboard to hide form fields. The layout viewport shrank with the keyboard, making `dvh`-based sheets tiny and preventing keyboard detection (`window.innerHeight` and `visualViewport.height` both shrank together).

## Browser support
- Chrome 108+ (Dec 2022) — covers all modern Android phones
- Older browsers ignore the unknown property gracefully
- iOS Safari ignores it (already uses resizes-visual natively)

## Test plan
- [ ] Android Chrome: open expense wizard → tap description → keyboard opens → form visible above keyboard
- [ ] Android Chrome: tap amount field (numeric keyboard) → same behavior
- [ ] iOS Safari: no regression — existing keyboard handling still works
- [ ] Regular page inputs (trip name, participant name) scroll into view when focused
- [ ] `npm run type-check` passes ✅
- [ ] `npm test` passes (193 tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)