### PR TITLE
fix: disambiguate group toggle from top-level toggle in split-between selector

### DIFF
--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -129,7 +129,7 @@ export function WizardStep3({
                         disabled={disabled}
                         className="text-xs text-primary hover:text-primary/80 transition-colors"
                       >
-                        {allGroupSelected ? 'deselect all' : 'select all'}
+                        {allGroupSelected ? `deselect ${group.label}` : `select ${group.label}`}
                       </button>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- Changed group-level toggle text from generic "deselect all"/"select all" to include the group name (e.g. "deselect Junks ja Mannu")
- Distinguishes group-scoped toggle from the top-level "Deselect all" link

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` passes (193 tests)
- [ ] Manual: confirm group toggle text includes group name and reads distinctly from top-level "Deselect all"

🤖 Generated with [Claude Code](https://claude.com/claude-code)