### PR TITLE
fix: platform-specific scroll-lock fix for Android bottom sheets

### DIFF
--- a/src/hooks/useIOSScrollFix.ts
+++ b/src/hooks/useIOSScrollFix.ts
@@ -2,16 +2,19 @@
 import { useRef, useEffect, type RefObject } from 'react'
 
 /**
- * Prevents a scroll-lock bug on touch devices (iOS Safari, Android Chrome)
- * where a scroll container with `overscroll-behavior: contain` becomes
- * unresponsive after the user scrolls to a boundary.
+ * Prevents a scroll-lock bug on touch devices where a scroll container with
+ * `overscroll-behavior: contain` becomes unresponsive after the user scrolls
+ * to a boundary.
  *
- * Fix: on each `touchstart`, nudge `scrollTop` 1px away from the
- * exact top/bottom boundary so the browser never detects the "at boundary"
- * state that triggers the lock.
- *
- * The handler only fires on `touchstart`, so it is naturally a no-op on
- * desktop (mouse/trackpad never triggers `touchstart`).
+ * Platform-specific handling:
+ * - **iOS Safari**: nudge `scrollTop` 1px away from the exact top/bottom
+ *   boundary on each `touchstart` so the browser never detects the "at
+ *   boundary" state that triggers the lock.
+ * - **Android Chrome**: override `overscroll-behavior` to `auto` at runtime.
+ *   The boundary-nudge technique doesn't work on Android (different touch
+ *   gesture evaluation model). Minor scroll chaining is acceptable since
+ *   Android has no rubber-band effect.
+ * - **Desktop**: no-op (mouse/trackpad never triggers the bug).
  *
  * @param externalRef - Optional existing ref to use instead of creating one
  */
@@ -25,17 +28,27 @@ export function useIOSScrollFix<T extends HTMLElement = HTMLDivElement>(
     const el = ref.current
     if (!el) return
 
-    const handler = () => {
-      const { scrollTop, scrollHeight, clientHeight } = el
-      if (scrollTop <= 0) {
-        el.scrollTop = 1
-      } else if (scrollTop + clientHeight >= scrollHeight) {
-        el.scrollTop = scrollHeight - clientHeight - 1
-      }
-    }
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
 
-    el.addEventListener('touchstart', handler, { passive: true })
-    return () => el.removeEventListener('touchstart', handler)
+    if (isIOS) {
+      // iOS Safari: nudge scrollTop 1px from boundaries on touchstart
+      // to prevent overscroll-contain scroll-lock bug
+      const handler = () => {
+        const { scrollTop, scrollHeight, clientHeight } = el
+        if (scrollTop <= 0) {
+          el.scrollTop = 1
+        } else if (scrollTop + clientHeight >= scrollHeight) {
+          el.scrollTop = scrollHeight - clientHeight - 1
+        }
+      }
+      el.addEventListener('touchstart', handler, { passive: true })
+      return () => el.removeEventListener('touchstart', handler)
+    } else if ('ontouchstart' in window) {
+      // Android: overscroll-contain causes scroll-lock; disable it
+      // Minor scroll chaining is acceptable (no rubber-band on Android)
+      el.style.overscrollBehavior = 'auto'
+      return () => { el.style.overscrollBehavior = '' }
+    }
   }, [ref])
 
   return ref


### PR DESCRIPTION
## Summary
- **iOS Safari**: keeps the proven `touchstart` boundary-nudge fix (unchanged)
- **Android Chrome**: overrides `overscroll-behavior` to `auto` at runtime instead — the nudge technique doesn't work on Android's touch gesture model and makes scroll-lock worse
- **Desktop**: no-op (unchanged)

All 6 scroll containers already use the hook via ref, so no other files change.

Supersedes the approach from PR #665 which extended the iOS-specific nudge to Android.

## Test plan
- [ ] Android: open expense edit sheet → scroll to bottom → scroll back up (no lock)
- [ ] iOS: open expense edit sheet → scroll fix still works (no regression)
- [ ] Desktop: no behavior change
- [x] `npm run type-check` passes
- [x] `npm test` passes (193 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)