### PR TITLE
fix: desktop group toggle labels, mobile split preview, date block alignment

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -351,7 +351,7 @@ export function ExpenseForm({
 
   // Group participants by wallet_group for display
   const participantGroups = (() => {
-    const groups: { label: string | null; members: typeof participants }[] = []
+    const groups: { label: string | null; isWalletGroup: boolean; members: typeof participants }[] = []
     const grouped = new Map<string, typeof participants>()
     const standalone: typeof participants = []
 
@@ -366,10 +366,10 @@ export function ExpenseForm({
     }
 
     for (const [label, members] of grouped) {
-      groups.push({ label, members })
+      groups.push({ label, isWalletGroup: true, members })
     }
     if (standalone.length > 0) {
-      groups.push({ label: null, members: standalone })
+      groups.push({ label: grouped.size > 0 ? 'Others' : null, isWalletGroup: false, members: standalone })
     }
 
     return groups
@@ -578,17 +578,19 @@ export function ExpenseForm({
                   {group.label && (
                     <div className="flex items-baseline justify-between mb-2">
                       <span className="text-xs font-medium text-muted-foreground">{group.label}</span>
-                      <button
-                        type="button"
-                        onClick={() => handleGroupToggle(memberIds)}
-                        disabled={loading}
-                        className="text-xs text-primary hover:text-primary/80 transition-colors"
-                      >
-                        {allGroupSelected ? 'deselect group' : 'select group'}
-                      </button>
+                      {group.isWalletGroup && (
+                        <button
+                          type="button"
+                          onClick={() => handleGroupToggle(memberIds)}
+                          disabled={loading}
+                          className="text-xs text-primary hover:text-primary/80 transition-colors"
+                        >
+                          {allGroupSelected ? `deselect ${group.label}` : `select ${group.label}`}
+                        </button>
+                      )}
                     </div>
                   )}
-                  <div className={group.label
+                  <div className={group.isWalletGroup
                     ? 'border-l-2 border-primary/30 pl-3 flex flex-wrap gap-2'
                     : 'flex flex-wrap gap-2'
                   }>
@@ -625,14 +627,16 @@ export function ExpenseForm({
                   {group.label && (
                     <div className="flex items-baseline justify-between mb-1 mt-2 first:mt-0">
                       <span className="text-xs font-medium text-muted-foreground">{group.label}</span>
-                      <button
-                        type="button"
-                        onClick={() => handleGroupToggle(memberIds)}
-                        disabled={loading}
-                        className="text-xs text-primary hover:text-primary/80 transition-colors"
-                      >
-                        {allGroupSelected ? 'deselect group' : 'select group'}
-                      </button>
+                      {group.isWalletGroup && (
+                        <button
+                          type="button"
+                          onClick={() => handleGroupToggle(memberIds)}
+                          disabled={loading}
+                          className="text-xs text-primary hover:text-primary/80 transition-colors"
+                        >
+                          {allGroupSelected ? `deselect ${group.label}` : `select ${group.label}`}
+                        </button>
+                      )}
                     </div>
                   )}
                   {group.members.map(participant => (
@@ -743,7 +747,7 @@ export function ExpenseForm({
               transition={{ duration: 0.2 }}
               className="overflow-hidden"
             >
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 p-4 bg-accent/5 rounded-lg border border-accent/10">
+              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-3 p-4 bg-accent/5 rounded-lg border border-accent/10">
                 {/* Date */}
                 <div className="space-y-2">
                   <Label htmlFor="expenseDate">Date</Label>

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -572,6 +572,8 @@ function MobileWizard({
               comment={comment}
               onCommentChange={setComment}
               disabled={isSubmitting}
+              amount={amount}
+              currency={currency}
             />
           )}
 

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -8,6 +8,9 @@ import { Textarea } from '@/components/ui/textarea'
 import { Checkbox } from '@/components/ui/checkbox'
 import { fadeInUp } from '@/lib/animations'
 import { buildShortNameMap } from '@/lib/participantUtils'
+import { ExpenseSplitPreview } from '../ExpenseSplitPreview'
+import type { ExpenseDistribution } from '@/types/expense'
+import type { Participant as FullParticipant } from '@/types/participant'
 
 type SplitMode = 'equal' | 'percentage' | 'amount'
 
@@ -36,6 +39,8 @@ interface WizardStep2Props {
   comment: string
   onCommentChange: (comment: string) => void
   disabled?: boolean
+  amount?: string
+  currency?: string
 }
 
 export function WizardStep3({
@@ -54,6 +59,8 @@ export function WizardStep3({
   comment,
   onCommentChange,
   disabled = false,
+  amount,
+  currency,
 }: WizardStep2Props) {
   const shortNames = useMemo(() => buildShortNameMap(participants), [participants])
   const [showDetails, setShowDetails] = useState(false)
@@ -201,6 +208,25 @@ export function WizardStep3({
           </div>
         </div>
       )}
+
+      {/* Split Preview */}
+      {amount && currency && parseFloat(amount) > 0 && selectedParticipants.length > 0 && (() => {
+        const previewDistribution: ExpenseDistribution = {
+          type: 'individuals',
+          participants: selectedParticipants,
+          splitMode,
+          accountForFamilySize: hasSelectedGroups ? accountForFamilySize : undefined,
+        }
+
+        return (
+          <ExpenseSplitPreview
+            amount={parseFloat(amount)}
+            currency={currency}
+            distribution={previewDistribution}
+            participants={participants as unknown as FullParticipant[]}
+          />
+        )
+      })()}
 
       {/* Collapsible "More details" */}
       <div className="space-y-3">


### PR DESCRIPTION
## Summary
- **Desktop group toggles**: Use actual group name (e.g. "deselect Junks ja Mannu") instead of generic "deselect group". Only show toggle for wallet groups, not "Others" label.
- **Mobile split preview**: Port `ExpenseSplitPreview` to mobile wizard step 3, showing per-person breakdown when amount > 0
- **Desktop date block**: Add `items-start` to More Details grid so date field doesn't stretch to match comment textarea height

## Test plan
- [ ] Desktop: open expense form with wallet groups → toggle says "deselect {group name}"
- [ ] Desktop: "Others" group label has no toggle button
- [ ] Desktop: "More details" → date input doesn't have extra vertical space
- [ ] Mobile: open wizard → enter amount → step 2 → split preview appears below the group toggle
- [ ] Mobile: toggle "Split equally between groups" → preview updates
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — all 193 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)