### PR TITLE
fix: remove overscroll-contain CSS class, apply via hook

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -10,6 +10,7 @@ import { useSettlementContext } from '@/contexts/SettlementContext'
 import { useAuth } from '@/contexts/AuthContext'
 import { calculateBalances, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
 import { inferCategory } from '@/lib/categoryInference'
+import { useIOSScrollFix } from '@/hooks/useIOSScrollFix'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -57,6 +58,11 @@ export function ExpenseForm({
   const { expenses } = useExpenseContext()
   const { settlements } = useSettlementContext()
   const { user } = useAuth()
+
+  // When used inside a desktop Dialog (no scrollRef prop), apply useIOSScrollFix
+  // internally so the scroll container still gets overscroll-behavior: contain
+  const internalScrollRef = useIOSScrollFix()
+  const effectiveScrollRef = scrollRef ?? internalScrollRef
 
   const [description, setDescription] = useState(initialValues?.description || '')
   const [amount, setAmount] = useState(initialValues?.amount?.toString() || '')
@@ -813,7 +819,7 @@ export function ExpenseForm({
     >
       {stickyFooter ? (
         <>
-          <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain space-y-3 pb-3">
+          <div ref={effectiveScrollRef} className="flex-1 overflow-y-auto space-y-3 pb-3">
             {formFields}
           </div>
           {buttons}

--- a/src/components/expenses/ExpenseWizard.tsx
+++ b/src/components/expenses/ExpenseWizard.tsx
@@ -505,7 +505,7 @@ function MobileWizard({
         {/* Scrollable content — only this scrolls */}
         <div
           ref={scrollRef}
-          className="flex-1 overflow-y-auto overscroll-contain min-h-0 px-6 py-4"
+          className="flex-1 overflow-y-auto min-h-0 px-6 py-4"
         >
           {error && (
             <div className="mb-4 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">

--- a/src/components/quick/QuickScanCreateFlow.tsx
+++ b/src/components/quick/QuickScanCreateFlow.tsx
@@ -284,7 +284,7 @@ export function QuickScanCreateFlow({ open, onOpenChange }: QuickScanCreateFlowP
   )
 
   const scrollContent = (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
+    <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 py-4">
       {/* Step 1: Camera */}
       {step === 'camera' && (
         <div className="flex flex-col gap-4 h-full">

--- a/src/components/ui/AppSheet.tsx
+++ b/src/components/ui/AppSheet.tsx
@@ -9,7 +9,7 @@
  * Rules:
  * - Height: always h-[Xdvh] — never vh, never h-screen
  * - Header: shrink-0, never scrolls, always visible
- * - Content: flex-1 overflow-y-auto overscroll-contain
+ * - Content: flex-1 overflow-y-auto (overscroll-contain applied by useIOSScrollFix)
  * - Footer/CTA: shrink-0, never scrolls, always visible
  * - Close button: rounded-full w-8 h-8 border border-border
  *   with X w-4 h-4 — identical on every sheet, no exceptions
@@ -112,7 +112,7 @@ export function AppSheet({
         )}
 
         {/* SCROLLABLE CONTENT — only this scrolls */}
-        <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${scrollClassName ?? 'px-4 py-4'}`}>
+        <div ref={scrollRef} className={`flex-1 overflow-y-auto ${scrollClassName ?? 'px-4 py-4'}`}>
           {children}
         </div>
 

--- a/src/components/ui/ResponsiveOverlay.tsx
+++ b/src/components/ui/ResponsiveOverlay.tsx
@@ -120,7 +120,7 @@ export function ResponsiveOverlay({
         )}
 
         {/* SCROLLABLE CONTENT */}
-        <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${scrollClassName ?? 'px-4 py-4'}`}>
+        <div ref={scrollRef} className={`flex-1 overflow-y-auto ${scrollClassName ?? 'px-4 py-4'}`}>
           {children}
         </div>
 

--- a/src/hooks/useIOSScrollFix.ts
+++ b/src/hooks/useIOSScrollFix.ts
@@ -2,19 +2,18 @@
 import { useRef, useEffect, type RefObject } from 'react'
 
 /**
- * Prevents a scroll-lock bug on touch devices where a scroll container with
- * `overscroll-behavior: contain` becomes unresponsive after the user scrolls
- * to a boundary.
+ * Applies `overscroll-behavior: contain` and platform-specific scroll fixes
+ * to prevent scroll chaining in bottom sheets and dialogs.
  *
- * Platform-specific handling:
- * - **iOS Safari**: nudge `scrollTop` 1px away from the exact top/bottom
- *   boundary on each `touchstart` so the browser never detects the "at
- *   boundary" state that triggers the lock.
- * - **Android Chrome**: override `overscroll-behavior` to `auto` at runtime.
- *   The boundary-nudge technique doesn't work on Android (different touch
- *   gesture evaluation model). Minor scroll chaining is acceptable since
- *   Android has no rubber-band effect.
- * - **Desktop**: no-op (mouse/trackpad never triggers the bug).
+ * Instead of applying `overscroll-contain` in CSS (which breaks Android Chrome),
+ * this hook applies it programmatically only where safe:
+ *
+ * - **iOS Safari**: sets `contain` + nudges `scrollTop` 1px from boundaries
+ *   on each `touchstart` to prevent the scroll-lock bug.
+ * - **Desktop** (no touch): sets `contain` to prevent scroll chaining through
+ *   dialogs/sheets.
+ * - **Android**: no-op — never sees `contain`, avoiding the scroll-lock bug
+ *   entirely. Minor scroll chaining is acceptable (no rubber-band on Android).
  *
  * @param externalRef - Optional existing ref to use instead of creating one
  */
@@ -31,8 +30,9 @@ export function useIOSScrollFix<T extends HTMLElement = HTMLDivElement>(
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
 
     if (isIOS) {
-      // iOS Safari: nudge scrollTop 1px from boundaries on touchstart
-      // to prevent overscroll-contain scroll-lock bug
+      // iOS Safari: apply contain + nudge scrollTop 1px from boundaries
+      // on touchstart to prevent overscroll-contain scroll-lock bug
+      el.style.overscrollBehavior = 'contain'
       const handler = () => {
         const { scrollTop, scrollHeight, clientHeight } = el
         if (scrollTop <= 0) {
@@ -42,13 +42,16 @@ export function useIOSScrollFix<T extends HTMLElement = HTMLDivElement>(
         }
       }
       el.addEventListener('touchstart', handler, { passive: true })
-      return () => el.removeEventListener('touchstart', handler)
-    } else if ('ontouchstart' in window) {
-      // Android: overscroll-contain causes scroll-lock; disable it
-      // Minor scroll chaining is acceptable (no rubber-band on Android)
-      el.style.overscrollBehavior = 'auto'
+      return () => {
+        el.style.overscrollBehavior = ''
+        el.removeEventListener('touchstart', handler)
+      }
+    } else if (!('ontouchstart' in window)) {
+      // Desktop: prevent scroll chaining through dialogs
+      el.style.overscrollBehavior = 'contain'
       return () => { el.style.overscrollBehavior = '' }
     }
+    // Android: no-op — leave default 'auto', no scroll-lock
   }, [ref])
 
   return ref


### PR DESCRIPTION
## Summary
- Removes `overscroll-contain` Tailwind class from all 5 scroll containers (AppSheet, ResponsiveOverlay, MobileWizard, ExpenseForm, QuickScanCreateFlow)
- `useIOSScrollFix` hook now applies `overscroll-behavior: contain` programmatically: on iOS (with boundary nudge) and desktop (no touch)
- Android never sees `contain` at all, avoiding the scroll-lock bug entirely
- ExpenseForm gets an internal `useIOSScrollFix` fallback ref for the desktop Dialog path (which doesn't receive `scrollRef` prop)

## Test plan
- [ ] Android Chrome: open expense sheet → scroll to bottom → scroll back up (no freeze)
- [ ] iOS Safari: open MobileWizard → boundary nudge still works, no scroll lock
- [ ] Desktop: open ExpenseForm dialog → scroll doesn't chain to page behind
- [x] `npm run type-check` passes
- [x] `npm test` — 193/193 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)