### PR TITLE
fix: desktop expense dialog focus ring clipping and date block height

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -753,7 +753,7 @@ export function ExpenseForm({
               transition={{ duration: 0.2 }}
               className="overflow-hidden"
             >
-              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-3 p-4 bg-accent/5 rounded-lg border border-accent/10">
+              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-3">
                 {/* Date */}
                 <div className="space-y-2">
                   <Label htmlFor="expenseDate">Date</Label>
@@ -819,7 +819,7 @@ export function ExpenseForm({
     >
       {stickyFooter ? (
         <>
-          <div ref={effectiveScrollRef} className="flex-1 overflow-y-auto space-y-3 pb-3">
+          <div ref={effectiveScrollRef} className="flex-1 overflow-y-auto space-y-3 pb-3 px-1 -mx-1">
             {formFields}
           </div>
           {buttons}


### PR DESCRIPTION
## Summary
- Add `px-1 -mx-1` to the desktop expense form scroll container so input focus rings aren't clipped by `overflow-y-auto`
- Remove card styling (`p-4 bg-accent/5 rounded-lg border border-accent/10`) from the "More details" date/comment grid to reduce visual bulk

## Test plan
- [ ] Desktop: open expense dialog → focus Description input → focus ring visible on all edges (not clipped)
- [ ] Desktop: expand "More details" → date + comment fields shown without card border/background
- [ ] Mobile: expense wizard unaffected (separate component path)
- [ ] `npm run type-check` passes
- [ ] `npm test` — all 193 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)