### PR TITLE
fix: compact More Details date/comment section

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -753,9 +753,9 @@ export function ExpenseForm({
               transition={{ duration: 0.2 }}
               className="overflow-hidden"
             >
-              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-2">
                 {/* Date */}
-                <div className="space-y-2">
+                <div className="space-y-1">
                   <Label htmlFor="expenseDate">Date</Label>
                   <Input
                     type="date"
@@ -767,14 +767,14 @@ export function ExpenseForm({
                 </div>
 
                 {/* Comment */}
-                <div className="space-y-2">
+                <div className="space-y-1">
                   <Label htmlFor="comment">Comment (Optional)</Label>
                   <Textarea
                     id="comment"
                     value={comment}
                     onChange={e => setComment(e.target.value)}
                     placeholder="Additional notes..."
-                    rows={2}
+                    rows={1}
                     disabled={loading}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- Reduced grid gap from `gap-3` to `gap-2` between date and comment fields
- Tightened label-to-input spacing from `space-y-2` to `space-y-1`
- Changed textarea from `rows={2}` to `rows={1}` (still expands on input)

Follows up on PR #673 which removed the card styling — this trims the remaining vertical bulk.

## Test plan
- [x] `npm run type-check` passes
- [x] All 193 unit tests pass
- [ ] Manual: desktop dialog → expand "More details" → section is visually compact

🤖 Generated with [Claude Code](https://claude.com/claude-code)