### PR TITLE
fix: skip body overscroll-behavior-y on Android to prevent scroll-lock

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -121,7 +121,6 @@
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    overscroll-behavior-y: none;
   }
 
   #root {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,6 +30,13 @@ window.addEventListener('unhandledrejection', (event) => {
   }))
 })
 
+// Prevent browser pull-to-refresh on non-Android platforms.
+// On Android Chrome, body overscroll-behavior-y: none causes scroll-lock
+// inside bottom sheets (interaction with react-remove-scroll).
+if (!/Android/i.test(navigator.userAgent)) {
+  document.body.style.overscrollBehaviorY = 'none'
+}
+
 // PWA home screen launch guard
 // Fallback for when the service worker does not intercept the initial
 // navigation (common on iOS). If launched in standalone mode into a


### PR DESCRIPTION
## Summary
- The CSS rule `body { overscroll-behavior-y: none }` in `index.css` interacts with Radix Dialog's `react-remove-scroll` on Android Chrome, causing scroll to lock when users reach the boundary of bottom sheet content
- Removed the CSS rule and re-applied it via JS in `main.tsx` only on non-Android platforms (still needed on iOS/desktop to prevent browser pull-to-refresh)
- Follows up on PR #672 which removed `overscroll-contain` from scroll containers (necessary but insufficient)

## Test plan
- [ ] Android Chrome: open any bottom sheet → scroll to end → scroll back up (no freeze)
- [ ] iOS Safari: pull-to-refresh still prevented on main page
- [ ] Desktop: no behavior change
- [x] `npm run type-check` passes
- [x] `npm test` — 193/193 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)