### PR TITLE
feat: rich participant chips with avatars

### DIFF
--- a/src/components/ParticipantAvatar.tsx
+++ b/src/components/ParticipantAvatar.tsx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+import { Baby } from 'lucide-react'
 import type { Participant } from '@/types/participant'
 
 interface ParticipantAvatarProps {
-  participant: Pick<Participant, 'name' | 'avatar_url'>
+  participant: Pick<Participant, 'name' | 'avatar_url'> & { is_adult?: boolean }
   size?: 'sm' | 'md'
   forceInitials?: boolean
   className?: string
@@ -11,6 +12,11 @@ interface ParticipantAvatarProps {
 const sizes = {
   sm: 'w-6 h-6 text-[10px]',
   md: 'w-8 h-8 text-xs',
+}
+
+const babyIconSizes = {
+  sm: 'w-3 h-3',
+  md: 'w-4 h-4',
 }
 
 export function ParticipantAvatar({ participant, size = 'md', forceInitials, className }: ParticipantAvatarProps) {
@@ -31,6 +37,14 @@ export function ParticipantAvatar({ participant, size = 'md', forceInitials, cla
         className={`${sizeClass} rounded-full shrink-0 object-cover ${className ?? ''}`}
         referrerPolicy="no-referrer"
       />
+    )
+  }
+
+  if (participant.is_adult === false) {
+    return (
+      <div className={`${sizeClass} rounded-full shrink-0 flex items-center justify-center bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400 ${className ?? ''}`}>
+        <Baby className={babyIconSizes[size]} />
+      </div>
     )
   }
 

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useRef, useMemo, FormEvent, type RefObject } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Lightbulb, ChevronDown, ChevronRight, Check } from 'lucide-react'
+import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 import { CreateExpenseInput, ExpenseCategory, ExpenseDistribution, SplitMode } from '@/types/expense'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -600,23 +601,29 @@ export function ExpenseForm({
                     ? 'border-l-2 border-primary/30 pl-3 flex flex-wrap gap-2'
                     : 'flex flex-wrap gap-2'
                   }>
-                    {group.members.map(participant => (
-                      <button
-                        key={participant.id}
-                        type="button"
-                        onClick={() => handleParticipantToggle(participant.id)}
-                        disabled={loading}
-                        className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
-                          selectedParticipants.includes(participant.id)
-                            ? 'bg-primary text-primary-foreground border-primary'
-                            : 'bg-background text-muted-foreground border-input hover:border-primary/50'
-                        }`}
-                      >
-                        {selectedParticipants.includes(participant.id) && <Check className="w-3 h-3" />}
-                        {shortNames.get(participant.id) || participant.name}
-                        {!participant.is_adult && <span className="text-xs opacity-70">(child)</span>}
-                      </button>
-                    ))}
+                    {group.members.map(participant => {
+                      const isSelected = selectedParticipants.includes(participant.id)
+                      const isChild = !participant.is_adult
+                      return (
+                        <button
+                          key={participant.id}
+                          type="button"
+                          onClick={() => handleParticipantToggle(participant.id)}
+                          disabled={loading}
+                          className={`inline-flex items-center gap-1.5 h-8 pl-1 pr-3 text-sm rounded-full border transition-colors ${
+                            isSelected
+                              ? 'bg-primary text-primary-foreground border-primary'
+                              : isChild
+                                ? 'bg-background text-muted-foreground border-dashed border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/20'
+                                : 'bg-background text-muted-foreground border-input hover:border-primary/50'
+                          }`}
+                        >
+                          <ParticipantAvatar participant={participant} size="sm" forceInitials={isSelected} className={isSelected ? 'bg-primary-foreground/20 text-primary-foreground' : ''} />
+                          {shortNames.get(participant.id) || participant.name}
+                          {isSelected && <Check className="w-3 h-3" />}
+                        </button>
+                      )
+                    })}
                   </div>
                 </div>
               )

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -2,6 +2,7 @@
 import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ChevronDown, ChevronRight, Check } from 'lucide-react'
+import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -145,23 +146,29 @@ export function WizardStep3({
                   ? 'border-l-2 border-primary/30 pl-3 flex flex-wrap gap-2'
                   : 'flex flex-wrap gap-2'
                 }>
-                  {group.members.map(participant => (
-                    <button
-                      key={participant.id}
-                      type="button"
-                      onClick={() => onParticipantToggle(participant.id)}
-                      disabled={disabled}
-                      className={`inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-full border transition-colors ${
-                        selectedParticipants.includes(participant.id)
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-background text-muted-foreground border-input hover:border-primary/50'
-                      }`}
-                    >
-                      {selectedParticipants.includes(participant.id) && <Check className="w-3 h-3" />}
-                      {shortNames.get(participant.id) || participant.name}
-                      {!participant.is_adult && <span className="text-xs opacity-70">(child)</span>}
-                    </button>
-                  ))}
+                  {group.members.map(participant => {
+                    const isSelected = selectedParticipants.includes(participant.id)
+                    const isChild = !participant.is_adult
+                    return (
+                      <button
+                        key={participant.id}
+                        type="button"
+                        onClick={() => onParticipantToggle(participant.id)}
+                        disabled={disabled}
+                        className={`inline-flex items-center gap-1.5 h-8 pl-1 pr-3 text-sm rounded-full border transition-colors ${
+                          isSelected
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : isChild
+                              ? 'bg-background text-muted-foreground border-dashed border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/20'
+                              : 'bg-background text-muted-foreground border-input hover:border-primary/50'
+                        }`}
+                      >
+                        <ParticipantAvatar participant={participant} size="sm" forceInitials={isSelected} className={isSelected ? 'bg-primary-foreground/20 text-primary-foreground' : ''} />
+                        {shortNames.get(participant.id) || participant.name}
+                        {isSelected && <Check className="w-3 h-3" />}
+                      </button>
+                    )
+                  })}
                 </div>
               </div>
             )


### PR DESCRIPTION
## Summary
- Add `ParticipantAvatar` (photo/initials/Baby icon) to equal-split chips in `ExpenseForm` (desktop) and `WizardStep3` (mobile wizard)
- Children render amber Baby icon circle instead of `(child)` text label; unselected children get dashed amber border
- `ParticipantAvatar` extended with optional `is_adult` prop — existing callers unaffected

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — 193 tests pass
- [ ] Visual: desktop expense form with adults + children, selected/unselected states
- [ ] Visual: mobile wizard step 3 with wallet groups and children
- [ ] Dark mode: amber child styling renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)