### PR TITLE
fix: comment textarea height and focus ring clipping

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -760,7 +760,7 @@ export function ExpenseForm({
               transition={{ duration: 0.2 }}
               className="overflow-hidden"
             >
-              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-2 p-px -m-px">
                 {/* Date */}
                 <div className="space-y-1">
                   <Label htmlFor="expenseDate">Date</Label>
@@ -778,6 +778,7 @@ export function ExpenseForm({
                   <Label htmlFor="comment">Comment (Optional)</Label>
                   <Textarea
                     id="comment"
+                    className="min-h-0"
                     value={comment}
                     onChange={e => setComment(e.target.value)}
                     placeholder="Additional notes..."


### PR DESCRIPTION
## Summary
- Override `Textarea` component's `min-h-[60px]` with `min-h-0` so `rows={1}` takes effect, making the Comment field match the Date input height
- Add `p-px -m-px` to the grid container inside `motion.div[overflow-hidden]` to prevent focus ring clipping during expand/collapse animation

## Test plan
- [ ] Desktop: open expense dialog → expand "More details" → Comment textarea matches Date input height
- [ ] Desktop: tab/click into Date and Comment fields → focus ring fully visible (not clipped)
- [ ] `npm run type-check` passes clean
- [ ] `npm test` — all 193 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)