### PR TITLE
fix: dark-mode-aware thin scrollbar styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -107,6 +107,29 @@
 }
 
 @layer base {
+  /* Thin scrollbar — adapts to light/dark via CSS variables */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--border)) transparent;
+  }
+
+  ::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: hsl(var(--border));
+    border-radius: 3px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground));
+  }
+
   * {
     @apply border-border;
   }


### PR DESCRIPTION
## Summary
- Add global thin scrollbar CSS using theme CSS variables (`--border`, `--muted-foreground`)
- Scrollbars automatically adapt to light/dark mode — no `.dark` scoping needed
- Supports both WebKit (`::-webkit-scrollbar`) and Firefox (`scrollbar-width: thin`)
- Fixes bright default scrollbar in dark mode desktop dialogs (e.g. expense form)

## Test plan
- [ ] Desktop expense dialog in dark mode — scrollbar should be thin and dark
- [ ] Same dialog in light mode — scrollbar should be subtle
- [ ] Other scrollable areas (shopping list, planner) still look fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)