### PR TITLE
feat: colorful participant chips with avatars in expense split pickers

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/select'
 import { fadeInUp } from '@/lib/animations'
 import { buildShortNameMap } from '@/lib/participantUtils'
+import { getParticipantColor } from '@/lib/participantChipColors'
 import { ExpenseSplitPreview } from './ExpenseSplitPreview'
 
 interface ExpenseFormProps {
@@ -382,6 +383,18 @@ export function ExpenseForm({
     return groups
   })()
 
+  // Flat color index for each participant across all groups
+  const participantColorMap = useMemo(() => {
+    const map = new Map<string, number>()
+    let i = 0
+    for (const group of participantGroups) {
+      for (const p of group.members) {
+        map.set(p.id, i++)
+      }
+    }
+    return map
+  }, [participantGroups])
+
   const formFields = (
     <>
       {error && (
@@ -604,6 +617,7 @@ export function ExpenseForm({
                     {group.members.map(participant => {
                       const isSelected = selectedParticipants.includes(participant.id)
                       const isChild = !participant.is_adult
+                      const color = getParticipantColor(participantColorMap.get(participant.id) ?? 0)
                       return (
                         <button
                           key={participant.id}
@@ -612,13 +626,13 @@ export function ExpenseForm({
                           disabled={loading}
                           className={`inline-flex items-center gap-1.5 h-8 pl-1 pr-3 text-sm rounded-full border transition-colors ${
                             isSelected
-                              ? 'bg-primary text-primary-foreground border-primary'
+                              ? color.chip
                               : isChild
                                 ? 'bg-background text-muted-foreground border-dashed border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/20'
                                 : 'bg-background text-muted-foreground border-input hover:border-primary/50'
                           }`}
                         >
-                          <ParticipantAvatar participant={participant} size="sm" forceInitials={isSelected} className={isSelected ? 'bg-primary-foreground/20 text-primary-foreground' : ''} />
+                          <ParticipantAvatar participant={participant} size="sm" className={isSelected ? 'bg-white/20 text-white' : color.avatar} />
                           {shortNames.get(participant.id) || participant.name}
                           {isSelected && <Check className="w-3 h-3" />}
                         </button>

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -9,6 +9,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Checkbox } from '@/components/ui/checkbox'
 import { fadeInUp } from '@/lib/animations'
 import { buildShortNameMap } from '@/lib/participantUtils'
+import { getParticipantColor } from '@/lib/participantChipColors'
 import { ExpenseSplitPreview } from '../ExpenseSplitPreview'
 import type { ExpenseDistribution } from '@/types/expense'
 import type { Participant as FullParticipant } from '@/types/participant'
@@ -100,6 +101,18 @@ export function WizardStep3({
     return groups
   }, [participants])
 
+  // Flat color index for each participant across all groups
+  const participantColorMap = useMemo(() => {
+    const map = new Map<string, number>()
+    let i = 0
+    for (const group of participantGroups) {
+      for (const p of group.members) {
+        map.set(p.id, i++)
+      }
+    }
+    return map
+  }, [participantGroups])
+
   return (
     <motion.div
       className="space-y-5"
@@ -149,6 +162,7 @@ export function WizardStep3({
                   {group.members.map(participant => {
                     const isSelected = selectedParticipants.includes(participant.id)
                     const isChild = !participant.is_adult
+                    const color = getParticipantColor(participantColorMap.get(participant.id) ?? 0)
                     return (
                       <button
                         key={participant.id}
@@ -157,13 +171,13 @@ export function WizardStep3({
                         disabled={disabled}
                         className={`inline-flex items-center gap-1.5 h-8 pl-1 pr-3 text-sm rounded-full border transition-colors ${
                           isSelected
-                            ? 'bg-primary text-primary-foreground border-primary'
+                            ? color.chip
                             : isChild
                               ? 'bg-background text-muted-foreground border-dashed border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/20'
                               : 'bg-background text-muted-foreground border-input hover:border-primary/50'
                         }`}
                       >
-                        <ParticipantAvatar participant={participant} size="sm" forceInitials={isSelected} className={isSelected ? 'bg-primary-foreground/20 text-primary-foreground' : ''} />
+                        <ParticipantAvatar participant={participant} size="sm" className={isSelected ? 'bg-white/20 text-white' : color.avatar} />
                         {shortNames.get(participant.id) || participant.name}
                         {isSelected && <Check className="w-3 h-3" />}
                       </button>

--- a/src/lib/participantChipColors.ts
+++ b/src/lib/participantChipColors.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-participant chip color palette for expense split pickers.
+ * Cycles through 8 colors via index % 8.
+ */
+export const PARTICIPANT_CHIP_COLORS = [
+  { chip: 'bg-blue-500 text-white border-blue-500', avatar: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' },
+  { chip: 'bg-emerald-500 text-white border-emerald-500', avatar: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' },
+  { chip: 'bg-violet-500 text-white border-violet-500', avatar: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300' },
+  { chip: 'bg-amber-500 text-white border-amber-500', avatar: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300' },
+  { chip: 'bg-rose-500 text-white border-rose-500', avatar: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300' },
+  { chip: 'bg-cyan-500 text-white border-cyan-500', avatar: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' },
+  { chip: 'bg-fuchsia-500 text-white border-fuchsia-500', avatar: 'bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/40 dark:text-fuchsia-300' },
+  { chip: 'bg-teal-500 text-white border-teal-500', avatar: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300' },
+] as const
+
+export function getParticipantColor(index: number) {
+  return PARTICIPANT_CHIP_COLORS[index % PARTICIPANT_CHIP_COLORS.length]
+}


### PR DESCRIPTION
## Summary
- Replace uniform coral-colored selected chips with 8 varied per-participant colors (blue, emerald, violet, amber, rose, cyan, fuchsia, teal) cycling via `index % 8`
- Show avatar photos when available on selected chips (removed `forceInitials={isSelected}`)
- Unselected chips get color-tinted initials circles for visual continuity
- New shared color palette in `src/lib/participantChipColors.ts` with dark mode support
- Applied to both desktop `ExpenseForm` and mobile `WizardStep3`

## Test plan
- [ ] Desktop: open expense dialog → "Split Between" shows varied colored chips with photos where available
- [ ] Mobile: wizard step 3 → same varied colors
- [ ] Dark mode: colors render correctly
- [ ] Children still show amber dashed border when unselected
- [ ] Wallet groups: group toggle still works, colors consistent across groups
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (193/193)

🤖 Generated with [Claude Code](https://claude.com/claude-code)