### PR TITLE
fix: tone down rainbow chips to uniform slate

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -626,7 +626,7 @@ export function ExpenseForm({
                           disabled={loading}
                           className={`inline-flex items-center gap-1.5 h-8 pl-1 pr-3 text-sm rounded-full border transition-colors ${
                             isSelected
-                              ? color.chip
+                              ? 'bg-slate-700 text-white border-slate-700 dark:bg-slate-500 dark:border-slate-500'
                               : isChild
                                 ? 'bg-background text-muted-foreground border-dashed border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/20'
                                 : 'bg-background text-muted-foreground border-input hover:border-primary/50'

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -171,7 +171,7 @@ export function WizardStep3({
                         disabled={disabled}
                         className={`inline-flex items-center gap-1.5 h-8 pl-1 pr-3 text-sm rounded-full border transition-colors ${
                           isSelected
-                            ? color.chip
+                            ? 'bg-slate-700 text-white border-slate-700 dark:bg-slate-500 dark:border-slate-500'
                             : isChild
                               ? 'bg-background text-muted-foreground border-dashed border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/20'
                               : 'bg-background text-muted-foreground border-input hover:border-primary/50'

--- a/src/lib/participantChipColors.ts
+++ b/src/lib/participantChipColors.ts
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Per-participant chip color palette for expense split pickers.
+ * Per-participant avatar color palette for expense split pickers.
  * Cycles through 8 colors via index % 8.
+ * Selected chips use a uniform slate background; only avatars are colorful.
  */
 export const PARTICIPANT_CHIP_COLORS = [
-  { chip: 'bg-blue-500 text-white border-blue-500', avatar: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' },
-  { chip: 'bg-emerald-500 text-white border-emerald-500', avatar: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' },
-  { chip: 'bg-violet-500 text-white border-violet-500', avatar: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300' },
-  { chip: 'bg-amber-500 text-white border-amber-500', avatar: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300' },
-  { chip: 'bg-rose-500 text-white border-rose-500', avatar: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300' },
-  { chip: 'bg-cyan-500 text-white border-cyan-500', avatar: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' },
-  { chip: 'bg-fuchsia-500 text-white border-fuchsia-500', avatar: 'bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/40 dark:text-fuchsia-300' },
-  { chip: 'bg-teal-500 text-white border-teal-500', avatar: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300' },
+  { avatar: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' },
+  { avatar: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' },
+  { avatar: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300' },
+  { avatar: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300' },
+  { avatar: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300' },
+  { avatar: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' },
+  { avatar: 'bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/40 dark:text-fuchsia-300' },
+  { avatar: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300' },
 ] as const
 
 export function getParticipantColor(index: number) {


### PR DESCRIPTION
## Summary
- Selected participant chips now use uniform slate background instead of per-participant rainbow colors
- Colorful avatar circles still provide visual distinction between participants
- Removed unused `chip` field from `PARTICIPANT_CHIP_COLORS` palette

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` passes (193 tests)
- [ ] Visual: verify selected chips are slate in ExpenseForm (desktop) and MobileWizard step 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)