### PR TITLE
fix: use colorful avatars on selected chips

### DIFF
--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -632,7 +632,7 @@ export function ExpenseForm({
                                 : 'bg-background text-muted-foreground border-input hover:border-primary/50'
                           }`}
                         >
-                          <ParticipantAvatar participant={participant} size="sm" className={isSelected ? 'bg-white/20 text-white' : color.avatar} />
+                          <ParticipantAvatar participant={participant} size="sm" className={color.avatar} />
                           {shortNames.get(participant.id) || participant.name}
                           {isSelected && <Check className="w-3 h-3" />}
                         </button>

--- a/src/components/expenses/wizard/WizardStep3.tsx
+++ b/src/components/expenses/wizard/WizardStep3.tsx
@@ -177,7 +177,7 @@ export function WizardStep3({
                               : 'bg-background text-muted-foreground border-input hover:border-primary/50'
                         }`}
                       >
-                        <ParticipantAvatar participant={participant} size="sm" className={isSelected ? 'bg-white/20 text-white' : color.avatar} />
+                        <ParticipantAvatar participant={participant} size="sm" className={color.avatar} />
                         {shortNames.get(participant.id) || participant.name}
                         {isSelected && <Check className="w-3 h-3" />}
                       </button>


### PR DESCRIPTION
## Summary
- PR #681 toned down rainbow chips to uniform slate but made all selected avatars `bg-white/20 text-white`, causing every selected chip's initials circle to look identical
- Changed avatar className to always use `color.avatar` regardless of selection state, keeping distinct per-participant colors on the dark slate chip background
- Applied to both `ExpenseForm.tsx` (desktop) and `WizardStep3.tsx` (mobile wizard)

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` passes (193 tests)
- [ ] Visual: selected chips show distinct colorful avatar circles per participant

🤖 Generated with [Claude Code](https://claude.com/claude-code)