### PR TITLE
fix: reduce user menu dropdown width — closes #680

### DIFF
--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -59,7 +59,7 @@ export function UserMenu({ onGradient = false, compact = false }: UserMenuProps)
           </span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuContent align="end" className="w-48">
         <div className="px-2 py-1.5">
           <p className="text-sm font-medium">{displayName}</p>
           {(userProfile?.email || user.email) && (


### PR DESCRIPTION
## Summary
- Reduced `DropdownMenuContent` width from `w-56` (224px) to `w-48` (192px)
- Content (name, email, bank details, theme toggle, sign out) only needs ~160-180px — the extra width made it look disproportionately wide on desktop

## Test plan
- [ ] Open user menu on desktop — verify it looks well-proportioned
- [ ] Verify all content (name, email, bank details, theme toggle, sign out) fits without truncation
- [ ] Check on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)