### PR TITLE
fix: expense card category tag styling on iPhone — closes #683

### DIFF
--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -112,7 +112,7 @@ export function ExpenseCard({ expense, onEdit, onDelete, onViewReceipt }: Expens
                     <span>{formatDate(expense.expense_date)}</span>
                   </div>
                   <span className="text-muted-foreground">•</span>
-                  <Badge variant="outline" className="h-5">
+                  <Badge variant="outline" className="text-xs py-0.5 px-2">
                     <Tag size={10} className="mr-1" />
                     {expense.category}
                   </Badge>


### PR DESCRIPTION
## Summary
- Replaced fixed `h-5` height on the category badge with `py-0.5 px-2` natural padding
- The fixed height conflicted with the icon (`<Tag size={10}>`) inside the badge, causing visual misalignment on iPhone Safari
- This was the only badge in the codebase combining `h-5` + icon

## Test plan
- [ ] View expenses page on iPhone Safari — category tags should look properly aligned
- [ ] View on desktop — verify tags still look correct
- [ ] Check dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)