### PR TITLE
feat: sync theme preference for auth users — closes #684

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Sun, Monitor, Moon } from 'lucide-react'
 import { useTheme } from '@/hooks/useTheme'
+import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 
 const options = [
   { value: 'light' as const, icon: Sun, label: 'Light' },
@@ -15,6 +16,7 @@ interface ThemeToggleProps {
 
 export function ThemeToggle({ size = 'default', iconOnly = false }: ThemeToggleProps) {
   const { theme, setTheme } = useTheme()
+  const { saveThemePreference } = useUserPreferences()
 
   const isCompact = size === 'compact'
 
@@ -23,7 +25,7 @@ export function ThemeToggle({ size = 'default', iconOnly = false }: ThemeToggleP
       {options.map(({ value, icon: Icon, label }) => (
         <button
           key={value}
-          onClick={() => setTheme(value)}
+          onClick={() => { setTheme(value); saveThemePreference(value) }}
           aria-label={label}
           title={label}
           className={`flex items-center gap-1.5 rounded-md transition-colors ${

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -8,12 +8,16 @@ import {
   setLocalPreferences,
 } from '@/lib/userPreferencesStorage'
 import { withTimeout } from '@/lib/fetchWithTimeout'
+import { applyThemeFromServer } from '@/hooks/useTheme'
+
+type Theme = 'light' | 'dark' | 'system'
 
 interface UserPreferencesContextType {
   mode: AppMode
   defaultTripId: string | null
   setMode: (mode: AppMode) => Promise<void>
   setDefaultTripId: (tripId: string | null) => Promise<void>
+  saveThemePreference: (theme: Theme) => Promise<void>
   loading: boolean
 }
 
@@ -77,6 +81,12 @@ export function UserPreferencesProvider({ children }: { children: ReactNode }) {
         setModeState(serverMode)
         setDefaultTripIdState(serverTripId)
         setLocalPreferences({ preferredMode: serverMode, defaultTripId: serverTripId })
+
+        // Sync theme from server if set
+        const serverTheme = data.theme_preference as Theme | null
+        if (serverTheme) {
+          applyThemeFromServer(serverTheme)
+        }
       }
       hasInitialized.current = true
       setLoading(false)
@@ -112,8 +122,12 @@ export function UserPreferencesProvider({ children }: { children: ReactNode }) {
     await upsertPreferences({ default_trip_id: tripId })
   }, [upsertPreferences])
 
+  const saveThemePreference = useCallback(async (theme: Theme) => {
+    await upsertPreferences({ theme_preference: theme })
+  }, [upsertPreferences])
+
   return (
-    <UserPreferencesContext.Provider value={{ mode, defaultTripId, setMode, setDefaultTripId, loading }}>
+    <UserPreferencesContext.Provider value={{ mode, defaultTripId, setMode, setDefaultTripId, saveThemePreference, loading }}>
       {children}
     </UserPreferencesContext.Provider>
   )

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -71,6 +71,19 @@ if (typeof window !== 'undefined') {
   })
 }
 
+/**
+ * Apply a theme to localStorage and DOM without triggering external sync.
+ * Used by UserPreferencesContext to apply server-side theme on sign-in.
+ */
+export function applyThemeFromServer(newTheme: Theme) {
+  currentTheme = newTheme
+  try {
+    localStorage.setItem(STORAGE_KEY, newTheme)
+  } catch {}
+  applyTheme(resolveTheme(newTheme))
+  notifyListeners()
+}
+
 export function useTheme() {
   const theme = useSyncExternalStore(subscribe, getSnapshot)
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -28,6 +28,18 @@ const sessionStorageMock = createStorage()
 vi.stubGlobal('localStorage', localStorageMock)
 vi.stubGlobal('sessionStorage', sessionStorageMock)
 
+// Stub matchMedia (used by useTheme module-level code)
+vi.stubGlobal('matchMedia', (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+}))
+
 // Cleanup after each test
 afterEach(() => {
   cleanup()

--- a/supabase/migrations/037_user_preferences_theme.sql
+++ b/supabase/migrations/037_user_preferences_theme.sql
@@ -1,0 +1,4 @@
+-- Add theme preference to user_preferences
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS theme_preference TEXT DEFAULT NULL
+  CHECK (theme_preference IS NULL OR theme_preference IN ('light', 'dark', 'system'));


### PR DESCRIPTION
## Summary
- Added `theme_preference` column to `user_preferences` table (migration 037)
- On sign-in, theme is loaded from Supabase and applied (via `applyThemeFromServer`)
- When user changes theme via `ThemeToggle`, it's saved to both localStorage (instant) and Supabase (cross-device sync)
- localStorage remains the fast local source of truth; Supabase is the cross-device sync layer

## Test plan
- [ ] Sign in → change theme to dark → sign out → sign in on different browser/incognito → verify dark theme is applied
- [ ] Change theme while signed out → verify it still works via localStorage
- [ ] Run migration 037 against Supabase
- [ ] All 193 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)