### PR TITLE
fix: restrict settlement deletion to creator only

### DIFF
--- a/src/contexts/SettlementContext.tsx
+++ b/src/contexts/SettlementContext.tsx
@@ -7,6 +7,7 @@ import {
   UpdateSettlementInput,
 } from '@/types/settlement'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useAuth } from '@/contexts/AuthContext'
 import { withTimeout } from '@/lib/fetchWithTimeout'
 import { logger } from '@/lib/logger'
 import { useAbortController } from '@/hooks/useAbortController'
@@ -31,6 +32,7 @@ export function SettlementProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null)
 
   const { currentTrip, tripCode } = useCurrentTrip()
+  const { user } = useAuth()
   const { newSignal, cancel } = useAbortController()
 
   // Fetch settlements for current trip
@@ -89,6 +91,7 @@ export function SettlementProvider({ children }: { children: ReactNode }) {
         id,
         ...input,
         settlement_date: input.settlement_date || new Date().toISOString().split('T')[0],
+        created_by: user?.id ?? null,
       }
 
       const controller = new AbortController()

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -487,13 +487,15 @@ export function SettlementsPage() {
                           {new Date(settlement.settlement_date).toLocaleDateString()}
                         </div>
                       </div>
-                      <button
-                        onClick={() => setDeletingId(settlement.id)}
-                        aria-label="Delete settlement"
-                        className="shrink-0 p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-                      >
-                        <Trash2 size={15} />
-                      </button>
+                      {(settlement.created_by == null || settlement.created_by === user?.id) && (
+                        <button
+                          onClick={() => setDeletingId(settlement.id)}
+                          aria-label="Delete settlement"
+                          className="shrink-0 p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                        >
+                          <Trash2 size={15} />
+                        </button>
+                      )}
                     </div>
                   )
                 })}

--- a/src/types/settlement.ts
+++ b/src/types/settlement.ts
@@ -13,6 +13,7 @@ export interface Settlement {
   currency: string
   settlement_date: string
   note?: string | null
+  created_by?: string | null
   created_at: string
   updated_at: string
 }

--- a/supabase/migrations/038_settlement_created_by.sql
+++ b/supabase/migrations/038_settlement_created_by.sql
@@ -1,0 +1,6 @@
+-- Add created_by column to settlements so we can gate deletion in the UI
+ALTER TABLE settlements ADD COLUMN created_by UUID REFERENCES auth.users(id);
+
+-- Backfill existing settlements to trip creator
+UPDATE settlements s
+SET created_by = (SELECT created_by FROM trips WHERE id = s.trip_id);


### PR DESCRIPTION
## Summary
- Adds `created_by` UUID column to `settlements` table (migration 038), backfills existing rows with trip creator
- Sets `created_by` from auth context on settlement insert in `SettlementContext`
- Hides delete button in `SettlementsPage` unless user is the settlement creator (or settlement has no creator — legacy/anonymous)

Closes #688

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` — all 193 tests pass
- [ ] Run migration 038 against Supabase
- [ ] Manual: create settlement as user A → user B should not see delete button → user A sees it
- [ ] Manual: anonymous settlements remain deletable by anyone

🤖 Generated with [Claude Code](https://claude.com/claude-code)