### PR TITLE
feat: post-trip settlement nudging system

### DIFF
--- a/src/components/PostTripNudgeBanner.tsx
+++ b/src/components/PostTripNudgeBanner.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useNavigate } from 'react-router-dom'
+import { HandCoins, X } from 'lucide-react'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { usePostTripNudge } from '@/hooks/usePostTripNudge'
+import { useUserPreferences } from '@/contexts/UserPreferencesContext'
+import { formatBalance } from '@/services/balanceCalculator'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+interface PostTripNudgeBannerProps {
+  /** Quick mode: opens settle-up sheet instead of navigating */
+  onSettleUp?: () => void
+}
+
+export function PostTripNudgeBanner({ onSettleUp }: PostTripNudgeBannerProps) {
+  const navigate = useNavigate()
+  const { currentTrip } = useCurrentTrip()
+  const { mode } = useUserPreferences()
+  const {
+    showCreatorBanner,
+    showDebtorBanner,
+    totalOwed,
+    transactionsNeeded,
+    myBalance,
+    dismiss,
+  } = usePostTripNudge()
+
+  if (!currentTrip) return null
+  if (!showCreatorBanner && !showDebtorBanner) return null
+
+  const currency = currentTrip.default_currency
+
+  const handleAction = () => {
+    if (onSettleUp) {
+      onSettleUp()
+    } else if (mode === 'quick') {
+      navigate(`/t/${currentTrip.trip_code}/quick`)
+    } else {
+      navigate(`/t/${currentTrip.trip_code}/settlements`)
+    }
+  }
+
+  return (
+    <Card className="border-amber-200 bg-amber-50 dark:bg-amber-950/20">
+      <CardContent className="pt-4 pb-4 flex items-center justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <HandCoins size={18} className="text-amber-600 mt-0.5 shrink-0" />
+          <div>
+            {showCreatorBanner ? (
+              <>
+                <p className="font-medium text-sm">
+                  {transactionsNeeded} {transactionsNeeded === 1 ? 'payment' : 'payments'} still outstanding
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {formatBalance(totalOwed, currency).replace('-', '')} to collect
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="font-medium text-sm">
+                  You owe {formatBalance(Math.abs(myBalance!), currency)} from {currentTrip.name}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Trip has ended — time to settle up
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button size="sm" onClick={handleAction}>
+            {showCreatorBanner ? 'View' : 'Settle'}
+          </Button>
+          <button
+            onClick={dismiss}
+            aria-label="Dismiss"
+            className="text-muted-foreground hover:text-foreground transition-colors p-1"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -9,6 +9,7 @@ interface TripCardProps {
   trip: Event
   balance?: ParticipantBalance | null
   isActive?: boolean
+  isEnded?: boolean
   onClick: () => void
   actions?: React.ReactNode
 }
@@ -20,7 +21,7 @@ function formatCardDate(isoDate: string): string {
   })
 }
 
-export function TripCard({ trip, balance, isActive, onClick, actions }: TripCardProps) {
+export function TripCard({ trip, balance, isActive, isEnded, onClick, actions }: TripCardProps) {
   const pattern = getTripGradientPattern(trip.name)
   const hasDate = trip.start_date || trip.end_date
   const dateLabel = hasDate
@@ -49,6 +50,11 @@ export function TripCard({ trip, balance, isActive, onClick, actions }: TripCard
                 {isActive && (
                   <span className="flex-shrink-0 text-[10px] font-medium uppercase tracking-wide bg-primary/10 text-primary px-1.5 py-0.5 rounded">
                     Active
+                  </span>
+                )}
+                {isEnded && balance && Math.abs(balance.balance) > 0.01 && (
+                  <span className="flex-shrink-0 text-[10px] font-medium uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 px-1.5 py-0.5 rounded">
+                    Needs settling
                   </span>
                 )}
               </div>

--- a/src/hooks/usePostTripNudge.ts
+++ b/src/hooks/usePostTripNudge.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState, useCallback, useMemo } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useCurrentTrip } from '@/hooks/useCurrentTrip'
+import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useParticipantContext } from '@/contexts/ParticipantContext'
+import { useExpenseContext } from '@/contexts/ExpenseContext'
+import { useSettlementContext } from '@/contexts/SettlementContext'
+import { calculateBalances, buildEntityMap } from '@/services/balanceCalculator'
+import { calculateOptimalSettlement } from '@/services/settlementOptimizer'
+import { getTripPhase, type TripPhase } from '@/lib/activeTripDetection'
+
+const DISMISS_KEY_PREFIX = 'spl1t:dismiss-settle-nudge:'
+
+export function usePostTripNudge() {
+  const { user } = useAuth()
+  const { currentTrip } = useCurrentTrip()
+  const { myParticipant } = useMyParticipant()
+  const { participants } = useParticipantContext()
+  const { expenses } = useExpenseContext()
+  const { settlements } = useSettlementContext()
+
+  const tripId = currentTrip?.id ?? ''
+  const [dismissed, setDismissed] = useState(
+    () => !!tripId && localStorage.getItem(`${DISMISS_KEY_PREFIX}${tripId}`) === 'true'
+  )
+
+  const dismiss = useCallback(() => {
+    if (tripId) {
+      localStorage.setItem(`${DISMISS_KEY_PREFIX}${tripId}`, 'true')
+    }
+    setDismissed(true)
+  }, [tripId])
+
+  const phase: TripPhase = currentTrip ? getTripPhase(currentTrip) : 'upcoming'
+
+  const balanceCalc = useMemo(() => {
+    if (!currentTrip || phase !== 'ended') return null
+    return calculateBalances(
+      expenses,
+      participants,
+      currentTrip.tracking_mode,
+      settlements,
+      currentTrip.default_currency,
+      currentTrip.exchange_rates
+    )
+  }, [currentTrip, phase, expenses, participants, settlements])
+
+  const hasOutstandingBalances = useMemo(() => {
+    if (!balanceCalc) return false
+    return balanceCalc.balances.some(b => Math.abs(b.balance) > 0.01)
+  }, [balanceCalc])
+
+  const isCreator = !!user && !!currentTrip?.created_by && user.id === currentTrip.created_by
+
+  const myBalance = useMemo(() => {
+    if (!balanceCalc || !myParticipant || !currentTrip) return null
+    const entityMap = buildEntityMap(participants, currentTrip.tracking_mode)
+    const myEntityId = entityMap.participantToEntityId.get(myParticipant.id) ?? myParticipant.id
+    const bal = balanceCalc.balances.find(b => b.id === myEntityId)
+    return bal ? Math.round(bal.balance * 100) / 100 : null
+  }, [balanceCalc, myParticipant, currentTrip, participants])
+
+  const totalOwed = useMemo(() => {
+    if (!balanceCalc) return 0
+    return Math.abs(
+      balanceCalc.balances
+        .filter(b => b.balance < 0)
+        .reduce((sum, b) => sum + b.balance, 0)
+    )
+  }, [balanceCalc])
+
+  const transactionsNeeded = useMemo(() => {
+    if (!balanceCalc || !currentTrip) return 0
+    const plan = calculateOptimalSettlement(
+      balanceCalc.balances,
+      currentTrip.default_currency,
+      'optimal'
+    )
+    return plan.totalTransactions
+  }, [balanceCalc, currentTrip])
+
+  const remindersEnabled = currentTrip?.enable_settlement_reminders !== false
+
+  const showCreatorBanner = phase === 'ended' && isCreator && hasOutstandingBalances && !dismissed && remindersEnabled
+  const showDebtorBanner = phase === 'ended' && myBalance !== null && myBalance < -0.01 && !dismissed && remindersEnabled
+
+  return {
+    phase,
+    hasOutstandingBalances,
+    isCreator,
+    myBalance,
+    totalOwed,
+    transactionsNeeded,
+    dismissed,
+    dismiss,
+    showCreatorBanner,
+    showDebtorBanner,
+  }
+}

--- a/src/lib/activeTripDetection.test.ts
+++ b/src/lib/activeTripDetection.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getActiveTripId } from './activeTripDetection'
+import { getActiveTripId, getTripPhase } from './activeTripDetection'
 import { buildTrip } from '@/test/factories'
 
 describe('getActiveTripId', () => {
@@ -89,5 +89,52 @@ describe('getActiveTripId', () => {
       end_date: '2025-07-15',
     })
     expect(getActiveTripId([trip])).toBe('ends-today')
+  })
+})
+
+describe('getTripPhase', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Set "today" to 2025-07-15
+    vi.setSystemTime(new Date('2025-07-15T12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns "active" for a trip happening today', () => {
+    const trip = buildTrip({ start_date: '2025-07-10', end_date: '2025-07-20' })
+    expect(getTripPhase(trip)).toBe('active')
+  })
+
+  it('returns "active" on start date (inclusive)', () => {
+    const trip = buildTrip({ start_date: '2025-07-15', end_date: '2025-07-20' })
+    expect(getTripPhase(trip)).toBe('active')
+  })
+
+  it('returns "active" on end date (inclusive)', () => {
+    const trip = buildTrip({ start_date: '2025-07-10', end_date: '2025-07-15' })
+    expect(getTripPhase(trip)).toBe('active')
+  })
+
+  it('returns "ended" the day after end date', () => {
+    const trip = buildTrip({ start_date: '2025-07-10', end_date: '2025-07-14' })
+    expect(getTripPhase(trip)).toBe('ended')
+  })
+
+  it('returns "upcoming" for a future trip', () => {
+    const trip = buildTrip({ start_date: '2025-07-20', end_date: '2025-07-25' })
+    expect(getTripPhase(trip)).toBe('upcoming')
+  })
+
+  it('returns "ended" for a single-day trip that was yesterday', () => {
+    const trip = buildTrip({ start_date: '2025-07-14', end_date: '2025-07-14' })
+    expect(getTripPhase(trip)).toBe('ended')
+  })
+
+  it('returns "active" for a single-day trip that is today', () => {
+    const trip = buildTrip({ start_date: '2025-07-15', end_date: '2025-07-15' })
+    expect(getTripPhase(trip)).toBe('active')
   })
 })

--- a/src/lib/activeTripDetection.ts
+++ b/src/lib/activeTripDetection.ts
@@ -1,6 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Trip } from '@/types/trip'
 
+export type TripPhase = 'upcoming' | 'active' | 'ended'
+
+/**
+ * Determine the current phase of a trip based on its dates.
+ * A trip is "active" on both its start_date and end_date (inclusive).
+ * It becomes "ended" the day after end_date.
+ */
+export function getTripPhase(trip: Trip): TripPhase {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const start = new Date(trip.start_date)
+  start.setHours(0, 0, 0, 0)
+
+  const end = new Date(trip.end_date)
+  end.setHours(23, 59, 59, 999)
+
+  if (today > end) return 'ended'
+  if (today >= start) return 'active'
+  return 'upcoming'
+}
+
 /**
  * Auto-detect the "active" trip based on dates:
  * 1. Today falls within start_date..end_date → that trip (if multiple, pick the one ending soonest)

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -20,6 +20,7 @@ import { ShareTripDialog } from '@/components/ShareTripDialog'
 import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
 import { CostBreakdownDialog } from '@/components/CostBreakdownDialog'
 import { OnboardingPrompts } from '@/components/OnboardingPrompts'
+import { PostTripNudgeBanner } from '@/components/PostTripNudgeBanner'
 import { ParticipantBalance } from '@/services/balanceCalculator'
 import type { Participant } from '@/types/participant'
 
@@ -208,6 +209,9 @@ export function DashboardPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Post-trip settlement nudge */}
+      <PostTripNudgeBanner />
 
       {/* Balances */}
       <div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { getMyTrips, removeFromMyTrips, type MyTripEntry } from '@/lib/myTripsStorage'
 import { getHiddenTripCodes, showTrip } from '@/lib/mutedTripsStorage'
-import { getActiveTripId } from '@/lib/activeTripDetection'
+import { getActiveTripId, getTripPhase } from '@/lib/activeTripDetection'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
 import { OnboardingPrompts } from '@/components/OnboardingPrompts'
 import { TripCard } from '@/components/TripCard'
@@ -196,6 +196,7 @@ export function HomePage() {
             trip={trip}
             balance={myBalance}
             isActive={trip.id === activeTripId}
+            isEnded={getTripPhase(trip) === 'ended'}
             onClick={() => handleOpenTrip(trip.trip_code)}
             actions={
               <GroupActions

--- a/src/pages/ManageTripPage.tsx
+++ b/src/pages/ManageTripPage.tsx
@@ -129,9 +129,10 @@ export function ManageTripPage() {
     enable_activities: 'Activity planning',
     enable_shopping: 'Shopping list',
     default_split_all: 'Split between everyone',
+    enable_settlement_reminders: 'Settlement reminders',
   }
 
-  const handleToggleFeature = async (feature: 'enable_meals' | 'enable_activities' | 'enable_shopping' | 'default_split_all', value: boolean) => {
+  const handleToggleFeature = async (feature: 'enable_meals' | 'enable_activities' | 'enable_shopping' | 'default_split_all' | 'enable_settlement_reminders', value: boolean) => {
     setTogglingFeatures(prev => new Set(prev).add(feature))
     try {
       const success = await updateTrip(currentTrip.id, { [feature]: value })
@@ -380,6 +381,17 @@ export function ManageTripPage() {
               checked={currentTrip.default_split_all ?? true}
               onCheckedChange={(checked) => handleToggleFeature('default_split_all', checked)}
               disabled={togglingFeatures.has('default_split_all')}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>Settlement Reminders</Label>
+              <p className="text-xs text-muted-foreground">Show nudges and allow sending payment reminders after the trip ends</p>
+            </div>
+            <Switch
+              checked={currentTrip.enable_settlement_reminders ?? true}
+              onCheckedChange={(checked) => handleToggleFeature('enable_settlement_reminders', checked)}
+              disabled={togglingFeatures.has('enable_settlement_reminders')}
             />
           </div>
         </CardContent>

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -29,6 +29,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useToast } from '@/hooks/use-toast'
 import { useBankDetailsPrompt } from '@/hooks/useBankDetailsPrompt'
 import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
+import { PostTripNudgeBanner } from '@/components/PostTripNudgeBanner'
 import {
   DollarSign, CreditCard, FileText, ScanLine,
   Loader2, Users, Landmark, X
@@ -205,6 +206,9 @@ export function QuickGroupDetailPage() {
               </CardContent>
             </Card>
           )}
+          <div className="mb-4">
+            <PostTripNudgeBanner onSettleUp={() => setSettlementOpen(true)} />
+          </div>
         </div>
       )}
 

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
-import { Receipt, FileDown, Trash2 } from 'lucide-react'
+import { Receipt, FileDown, Trash2, Bell } from 'lucide-react'
+import { useToast } from '@/hooks/use-toast'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { useAuth } from '@/contexts/AuthContext'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
@@ -312,6 +313,44 @@ export function SettlementsPage() {
     exportSettlementPlanToPDF(currentTrip, optimalSettlement, balanceCalculation.balances)
   }
 
+  // Remind All state
+  const { toast } = useToast()
+  const [remindAllOpen, setRemindAllOpen] = useState(false)
+  const [remindAllSending, setRemindAllSending] = useState(false)
+  const remindableTransactions = useMemo(() => {
+    return optimalSettlement.transactions.filter(t => {
+      const emails = fromEmailMap[t.fromId]
+      return emails && emails.length > 0
+    })
+  }, [optimalSettlement.transactions, fromEmailMap])
+
+  const canRemindAll = !!user
+    && currentTrip.enable_settlement_reminders !== false
+    && remindableTransactions.length > 0
+
+  const unreachableCount = optimalSettlement.transactions.length - remindableTransactions.length
+
+  const handleRemindAll = async () => {
+    setRemindAllSending(true)
+    try {
+      const results = await Promise.allSettled(
+        remindableTransactions.map(t => {
+          const emails = fromEmailMap[t.fromId].map(e => e.email)
+          return handleRemind(t, emails)
+        })
+      )
+      const failures = results.filter(r => r.status === 'rejected')
+      if (failures.length === 0) {
+        toast({ title: 'Reminders sent', description: `Sent to ${remindableTransactions.length} ${remindableTransactions.length === 1 ? 'person' : 'people'}.` })
+      } else {
+        toast({ variant: 'destructive', title: 'Some reminders failed', description: `${failures.length} of ${remindableTransactions.length} failed to send.` })
+      }
+    } finally {
+      setRemindAllSending(false)
+      setRemindAllOpen(false)
+    }
+  }
+
   return (
     <>
       <div className="space-y-6">
@@ -323,11 +362,18 @@ export function SettlementsPage() {
               Optimal settlement plan and payment recording for {currentTrip.name}
             </p>
           </div>
-          {expenses.length > 0 && (
-            <Button onClick={handleExportPDF} variant="ghost" size="icon" title="Export PDF">
-              <FileDown size={18} />
-            </Button>
-          )}
+          <div className="flex gap-1">
+            {canRemindAll && (
+              <Button onClick={() => setRemindAllOpen(true)} variant="ghost" size="icon" title="Remind All">
+                <Bell size={18} />
+              </Button>
+            )}
+            {expenses.length > 0 && (
+              <Button onClick={handleExportPDF} variant="ghost" size="icon" title="Export PDF">
+                <FileDown size={18} />
+              </Button>
+            )}
+          </div>
         </div>
 
         {loading ? (
@@ -422,8 +468,8 @@ export function SettlementsPage() {
                 onSettle={handleRecordSettlement}
                 bankDetailsMap={bankDetailsMap}
                 linkedParticipantIds={linkedParticipantIds}
-                fromEmailMap={fromEmailMap}
-                onRemind={user ? handleRemind : undefined}
+                fromEmailMap={currentTrip.enable_settlement_reminders !== false ? fromEmailMap : undefined}
+                onRemind={user && currentTrip.enable_settlement_reminders !== false ? handleRemind : undefined}
                 avatarMap={avatarMap}
               />
             </CardContent>
@@ -569,6 +615,47 @@ export function SettlementsPage() {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={handleDeleteSettlement} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Remind All confirmation */}
+      <AlertDialog open={remindAllOpen} onOpenChange={setRemindAllOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Send reminders to all debtors?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2">
+                <p>Payment reminders will be sent to:</p>
+                <ul className="list-disc pl-5 space-y-1">
+                  {remindableTransactions.map((t, i) => {
+                    const emails = fromEmailMap[t.fromId]
+                    return (
+                      <li key={i} className="text-sm">
+                        <span className="font-medium text-foreground">{t.fromName}</span>
+                        <span className="text-muted-foreground"> — {emails.map(e => e.email).join(', ')}</span>
+                      </li>
+                    )
+                  })}
+                </ul>
+                {unreachableCount > 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    {unreachableCount} {unreachableCount === 1 ? 'participant has' : 'participants have'} no email address and will be skipped.
+                  </p>
+                )}
+                {remindableTransactions.length > 20 && (
+                  <p className="text-xs text-amber-600">
+                    Large batch — this will send {remindableTransactions.length} emails.
+                  </p>
+                )}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={remindAllSending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRemindAll} disabled={remindAllSending}>
+              {remindAllSending ? 'Sending...' : 'Send reminders'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -16,6 +16,7 @@ export interface Event {
   enable_shopping: boolean
   default_split_all: boolean
   account_for_family_size: boolean
+  enable_settlement_reminders?: boolean
   created_by?: string
   created_at: string
 }
@@ -46,6 +47,7 @@ export interface UpdateEventInput {
   enable_shopping?: boolean
   default_split_all?: boolean
   account_for_family_size?: boolean
+  enable_settlement_reminders?: boolean
 }
 
 // Backward-compatible aliases — use Event, CreateEventInput, UpdateEventInput in new code

--- a/supabase/migrations/039_enable_settlement_reminders.sql
+++ b/supabase/migrations/039_enable_settlement_reminders.sql
@@ -1,0 +1,2 @@
+-- Add toggle for settlement reminders (nudge banners + email reminders)
+ALTER TABLE trips ADD COLUMN enable_settlement_reminders BOOLEAN DEFAULT true;


### PR DESCRIPTION
## Summary
- Add `getTripPhase()` utility and `usePostTripNudge` hook to detect ended trips with outstanding balances
- New `PostTripNudgeBanner` component with creator variant ("X payments outstanding") and debtor variant ("You owe X") — rendered on Quick and Dashboard pages
- "Needs settling" amber badge on TripCard for ended trips with non-zero balance
- "Remind All" button on SettlementsPage header sends batch payment reminder emails with confirmation dialog
- `enable_settlement_reminders` toggle on ManageTripPage (migration 039) — when disabled, hides all nudge banners and remind buttons
- 7 new tests for `getTripPhase`; all 200 tests pass, type-check clean

## Test plan
- [ ] Visit a trip with `end_date` in the past → nudge banner appears on Quick and Dashboard
- [ ] Dismiss nudge → stays dismissed on refresh
- [ ] As non-creator debtor → see "You owe X" variant
- [ ] "Remind All" on SettlementsPage sends emails to all debtors with addresses
- [ ] Toggle off "Settlement reminders" on Manage page → nudges and remind buttons disappear
- [ ] TripCard shows "Needs settling" badge for ended trips with balance

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)