### PR TITLE
feat: Remind All discoverability, deduplication & multi-payment emails

### DIFF
--- a/src/components/PostTripNudgeBanner.tsx
+++ b/src/components/PostTripNudgeBanner.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useNavigate } from 'react-router-dom'
-import { HandCoins, X } from 'lucide-react'
+import { HandCoins, X, Bell } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
 import { usePostTripNudge } from '@/hooks/usePostTripNudge'
 import { useUserPreferences } from '@/contexts/UserPreferencesContext'
@@ -11,9 +11,11 @@ import { Button } from '@/components/ui/button'
 interface PostTripNudgeBannerProps {
   /** Quick mode: opens settle-up sheet instead of navigating */
   onSettleUp?: () => void
+  /** Creator: triggers batch remind-all flow */
+  onRemindAll?: () => void
 }
 
-export function PostTripNudgeBanner({ onSettleUp }: PostTripNudgeBannerProps) {
+export function PostTripNudgeBanner({ onSettleUp, onRemindAll }: PostTripNudgeBannerProps) {
   const navigate = useNavigate()
   const { currentTrip } = useCurrentTrip()
   const { mode } = useUserPreferences()
@@ -69,6 +71,12 @@ export function PostTripNudgeBanner({ onSettleUp }: PostTripNudgeBannerProps) {
           </div>
         </div>
         <div className="flex items-center gap-1">
+          {showCreatorBanner && onRemindAll && (
+            <Button size="sm" variant="outline" onClick={onRemindAll}>
+              <Bell size={14} className="mr-1" />
+              Remind
+            </Button>
+          )}
           <Button size="sm" onClick={handleAction}>
             {showCreatorBanner ? 'View' : 'Settle'}
           </Button>

--- a/src/components/SettlementPlan.tsx
+++ b/src/components/SettlementPlan.tsx
@@ -18,11 +18,13 @@ interface SettlementPlanProps {
   bankDetailsMap?: Record<string, BankDetails>
   linkedParticipantIds?: Set<string>
   fromEmailMap?: Record<string, { name: string; email: string }[]>
+  toEmailMap?: Record<string, { name: string; email: string }[]>
   onRemind?: (transaction: SettlementTransaction, emails: string[]) => Promise<void>
+  onNudgeBankDetails?: (entityId: string, emails: string[]) => Promise<void>
   avatarMap?: Record<string, string | null>
 }
 
-export function SettlementPlan({ plan, greedyPlan, onSettle, bankDetailsMap, linkedParticipantIds, fromEmailMap, onRemind, avatarMap }: SettlementPlanProps) {
+export function SettlementPlan({ plan, greedyPlan, onSettle, bankDetailsMap, linkedParticipantIds, fromEmailMap, toEmailMap, onRemind, onNudgeBankDetails, avatarMap }: SettlementPlanProps) {
   const [mode, setMode] = useState<'optimal' | 'greedy'>('optimal')
   const showToggle = greedyPlan && greedyPlan.totalTransactions !== plan.totalTransactions
   const activePlan = mode === 'greedy' && greedyPlan ? greedyPlan : plan
@@ -101,7 +103,9 @@ export function SettlementPlan({ plan, greedyPlan, onSettle, bankDetailsMap, lin
             bankDetails={bankDetailsMap?.[transaction.toId]}
             linkedParticipantIds={linkedParticipantIds}
             fromEmails={fromEmailMap?.[transaction.fromId]}
+            toEmails={toEmailMap?.[transaction.toId]}
             onRemind={onRemind ? (emails) => onRemind(transaction, emails) : undefined}
+            onNudgeBankDetails={onNudgeBankDetails}
             avatarMap={avatarMap}
           />
         ))}
@@ -118,7 +122,9 @@ interface SettlementTransactionCardProps {
   bankDetails?: BankDetails
   linkedParticipantIds?: Set<string>
   fromEmails?: { name: string; email: string }[]
+  toEmails?: { name: string; email: string }[]
   onRemind?: (emails: string[]) => Promise<void>
+  onNudgeBankDetails?: (entityId: string, emails: string[]) => Promise<void>
   avatarMap?: Record<string, string | null>
 }
 
@@ -130,13 +136,17 @@ function SettlementTransactionCard({
   bankDetails,
   linkedParticipantIds,
   fromEmails,
+  toEmails,
   onRemind,
+  onNudgeBankDetails,
   avatarMap,
 }: SettlementTransactionCardProps) {
   const [confirmingRemind, setConfirmingRemind] = useState(false)
   const [sending, setSending] = useState(false)
   const [remindResult, setRemindResult] = useState<'sent' | 'error' | null>(null)
   const [checkedEmails, setCheckedEmails] = useState<Record<string, boolean>>({})
+  const [nudgeSending, setNudgeSending] = useState(false)
+  const [nudgeResult, setNudgeResult] = useState<'sent' | 'error' | null>(null)
 
   const formattedAmount = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -273,9 +283,41 @@ function SettlementTransactionCard({
           </div>
         )}
         {!bankDetails && linkedParticipantIds?.has(transaction.toId) && (
-          <p className="text-xs text-muted-foreground italic pl-5">
-            Ask {transaction.toName} to add their bank details
-          </p>
+          <div className="pl-5">
+            {toEmails && toEmails.length > 0 && onNudgeBankDetails && nudgeResult !== 'sent' ? (
+              <button
+                onClick={async () => {
+                  setNudgeSending(true)
+                  setNudgeResult(null)
+                  try {
+                    await onNudgeBankDetails(transaction.toId, toEmails.map(e => e.email))
+                    setNudgeResult('sent')
+                  } catch {
+                    setNudgeResult('error')
+                  } finally {
+                    setNudgeSending(false)
+                  }
+                }}
+                disabled={nudgeSending}
+                className="text-xs text-accent hover:underline disabled:opacity-50"
+              >
+                {nudgeSending ? 'Sending…' : `Nudge ${transaction.toName} to add bank details`}
+              </button>
+            ) : nudgeResult === 'sent' ? (
+              <p className="text-xs text-positive flex items-center gap-1">
+                <Check size={12} />
+                Nudge sent to {transaction.toName}
+              </p>
+            ) : nudgeResult === 'error' ? (
+              <p className="text-xs text-destructive">
+                Failed to send nudge. Please try again.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground italic">
+                Ask {transaction.toName} to add their bank details
+              </p>
+            )}
+          </div>
         )}
 
         {/* Remind confirmation inline */}

--- a/src/pages/SettlementsPage.tsx
+++ b/src/pages/SettlementsPage.tsx
@@ -84,9 +84,9 @@ export function SettlementsPage() {
     return map
   }, [participants])
 
-  // Build a map of entity ID → emails for the "from" side of transactions
-  const fromEmailMap = useMemo(() => {
-    if (!currentTrip) return {}
+  // Build maps of entity ID → emails for "from" and "to" sides of transactions
+  const { fromEmailMap, toEmailMap } = useMemo(() => {
+    if (!currentTrip) return { fromEmailMap: {}, toEmailMap: {} }
     const entityMap = buildEntityMap(participants, currentTrip.tracking_mode)
     const map: Record<string, { name: string; email: string }[]> = {}
     for (const p of participants) {
@@ -95,7 +95,8 @@ export function SettlementsPage() {
       if (!map[entityId]) map[entityId] = []
       map[entityId].push({ name: p.name, email: p.email })
     }
-    return map
+    // Both from and to use the same underlying map — all participants with emails
+    return { fromEmailMap: map, toEmailMap: map }
   }, [participants, currentTrip])
 
   if (!currentTrip) {
@@ -317,37 +318,107 @@ export function SettlementsPage() {
   const { toast } = useToast()
   const [remindAllOpen, setRemindAllOpen] = useState(false)
   const [remindAllSending, setRemindAllSending] = useState(false)
-  const remindableTransactions = useMemo(() => {
-    return optimalSettlement.transactions.filter(t => {
+  // Deduplicate remindable transactions by debtor entity ID
+  const remindableDebtors = useMemo(() => {
+    const map = new Map<string, {
+      name: string
+      emails: string[]
+      payments: Array<{ amount: number; toName: string }>
+    }>()
+    for (const t of optimalSettlement.transactions) {
       const emails = fromEmailMap[t.fromId]
-      return emails && emails.length > 0
-    })
+      if (!emails || emails.length === 0) continue
+      const existing = map.get(t.fromId)
+      if (existing) {
+        existing.payments.push({ amount: t.amount, toName: t.toName })
+      } else {
+        map.set(t.fromId, {
+          name: t.fromName,
+          emails: emails.map(e => e.email),
+          payments: [{ amount: t.amount, toName: t.toName }],
+        })
+      }
+    }
+    return map
   }, [optimalSettlement.transactions, fromEmailMap])
 
   const canRemindAll = !!user
     && currentTrip.enable_settlement_reminders !== false
-    && remindableTransactions.length > 0
+    && remindableDebtors.size > 0
 
-  const unreachableCount = optimalSettlement.transactions.length - remindableTransactions.length
+  const unreachableCount = optimalSettlement.transactions.length
+    - Array.from(remindableDebtors.values()).reduce((sum, d) => sum + d.payments.length, 0)
 
   const handleRemindAll = async () => {
+    if (!currentTrip || !user) return
     setRemindAllSending(true)
+    const organiserName = userProfile?.display_name || user.email?.split('@')[0] || 'Organiser'
     try {
+      const entries = Array.from(remindableDebtors.entries())
       const results = await Promise.allSettled(
-        remindableTransactions.map(t => {
-          const emails = fromEmailMap[t.fromId].map(e => e.email)
-          return handleRemind(t, emails)
-        })
+        entries.map(([, debtor]) =>
+          Promise.allSettled(
+            debtor.emails.map(email =>
+              supabase.functions.invoke('send-email', {
+                body: {
+                  type: 'payment_reminder',
+                  trip_id: currentTrip.id,
+                  trip_name: currentTrip.name,
+                  trip_code: currentTrip.trip_code,
+                  recipient_name: debtor.name,
+                  recipient_email: email,
+                  currency: currentTrip.default_currency,
+                  payments: debtor.payments.map(p => ({
+                    amount: p.amount,
+                    pay_to_name: p.toName,
+                  })),
+                  organiser_name: organiserName,
+                },
+              })
+            )
+          )
+        )
       )
       const failures = results.filter(r => r.status === 'rejected')
+      const debtorCount = remindableDebtors.size
       if (failures.length === 0) {
-        toast({ title: 'Reminders sent', description: `Sent to ${remindableTransactions.length} ${remindableTransactions.length === 1 ? 'person' : 'people'}.` })
+        toast({ title: 'Reminders sent', description: `Sent to ${debtorCount} ${debtorCount === 1 ? 'person' : 'people'}.` })
       } else {
-        toast({ variant: 'destructive', title: 'Some reminders failed', description: `${failures.length} of ${remindableTransactions.length} failed to send.` })
+        toast({ variant: 'destructive', title: 'Some reminders failed', description: `${failures.length} of ${debtorCount} failed to send.` })
       }
     } finally {
       setRemindAllSending(false)
       setRemindAllOpen(false)
+    }
+  }
+
+  const handleNudgeBankDetails = async (entityId: string, emails: string[]): Promise<void> => {
+    if (!currentTrip || !user) return
+    const organiserName = userProfile?.display_name || user.email?.split('@')[0] || 'Organiser'
+    const participant = participants.find(p => {
+      const entityMap = buildEntityMap(participants, currentTrip.tracking_mode)
+      return (entityMap.participantToEntityId.get(p.id) ?? p.id) === entityId
+    })
+    const recipientName = participant?.name || 'there'
+
+    const results = await Promise.allSettled(
+      emails.map(email =>
+        supabase.functions.invoke('send-email', {
+          body: {
+            type: 'bank_details_nudge',
+            trip_id: currentTrip.id,
+            trip_name: currentTrip.name,
+            trip_code: currentTrip.trip_code,
+            recipient_name: recipientName,
+            recipient_email: email,
+            organiser_name: organiserName,
+          },
+        })
+      )
+    )
+    const failures = results.filter(r => r.status === 'rejected' || (r.status === 'fulfilled' && r.value.error))
+    if (failures.length === emails.length) {
+      throw new Error('Failed to send bank details nudge')
     }
   }
 
@@ -363,11 +434,6 @@ export function SettlementsPage() {
             </p>
           </div>
           <div className="flex gap-1">
-            {canRemindAll && (
-              <Button onClick={() => setRemindAllOpen(true)} variant="ghost" size="icon" title="Remind All">
-                <Bell size={18} />
-              </Button>
-            )}
             {expenses.length > 0 && (
               <Button onClick={handleExportPDF} variant="ghost" size="icon" title="Export PDF">
                 <FileDown size={18} />
@@ -469,16 +535,18 @@ export function SettlementsPage() {
                 bankDetailsMap={bankDetailsMap}
                 linkedParticipantIds={linkedParticipantIds}
                 fromEmailMap={currentTrip.enable_settlement_reminders !== false ? fromEmailMap : undefined}
+                toEmailMap={currentTrip.enable_settlement_reminders !== false ? toEmailMap : undefined}
                 onRemind={user && currentTrip.enable_settlement_reminders !== false ? handleRemind : undefined}
+                onNudgeBankDetails={user && currentTrip.enable_settlement_reminders !== false ? handleNudgeBankDetails : undefined}
                 avatarMap={avatarMap}
               />
             </CardContent>
           </Card>
         )}
 
-        {/* Record a payment button */}
+        {/* Action buttons below settlement plan */}
         {participants.length > 0 && (
-          <div className="flex justify-center">
+          <div className="flex justify-center gap-2">
             <Button
               onClick={() => { setPrefill(null); setShowRecordDialog(true) }}
               variant="outline"
@@ -486,6 +554,16 @@ export function SettlementsPage() {
             >
               Log a custom payment
             </Button>
+            {canRemindAll && (
+              <Button
+                onClick={() => setRemindAllOpen(true)}
+                variant="outline"
+                size="sm"
+              >
+                <Bell size={14} className="mr-1.5" />
+                Remind All
+              </Button>
+            )}
           </div>
         )}
 
@@ -627,26 +705,26 @@ export function SettlementsPage() {
             <AlertDialogTitle>Send reminders to all debtors?</AlertDialogTitle>
             <AlertDialogDescription asChild>
               <div className="space-y-2">
-                <p>Payment reminders will be sent to:</p>
+                <p>One email per person with all their outstanding payments:</p>
                 <ul className="list-disc pl-5 space-y-1">
-                  {remindableTransactions.map((t, i) => {
-                    const emails = fromEmailMap[t.fromId]
-                    return (
-                      <li key={i} className="text-sm">
-                        <span className="font-medium text-foreground">{t.fromName}</span>
-                        <span className="text-muted-foreground"> — {emails.map(e => e.email).join(', ')}</span>
-                      </li>
-                    )
-                  })}
+                  {Array.from(remindableDebtors.entries()).map(([id, debtor]) => (
+                    <li key={id} className="text-sm">
+                      <span className="font-medium text-foreground">{debtor.name}</span>
+                      <span className="text-muted-foreground"> — {debtor.emails.join(', ')}</span>
+                      {debtor.payments.length > 1 && (
+                        <span className="text-muted-foreground"> ({debtor.payments.length} payments)</span>
+                      )}
+                    </li>
+                  ))}
                 </ul>
                 {unreachableCount > 0 && (
                   <p className="text-xs text-muted-foreground">
                     {unreachableCount} {unreachableCount === 1 ? 'participant has' : 'participants have'} no email address and will be skipped.
                   </p>
                 )}
-                {remindableTransactions.length > 20 && (
+                {remindableDebtors.size > 20 && (
                   <p className="text-xs text-amber-600">
-                    Large batch — this will send {remindableTransactions.length} emails.
+                    Large batch — this will send {remindableDebtors.size} emails.
                   </p>
                 )}
               </div>

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -127,12 +127,22 @@ type SendEmailBody =
       trip_code: string
       recipient_name: string
       recipient_email: string
-      amount: number
+      amount?: number
       currency: string
-      pay_to_name: string
+      pay_to_name?: string
+      payments?: Array<{ amount: number; pay_to_name: string }>
       organiser_name: string
       receipts?: ReceiptEmailData[]
       expense_count?: number
+    }
+  | {
+      type: 'bank_details_nudge'
+      trip_id: string
+      trip_name: string
+      trip_code: string
+      recipient_name: string
+      recipient_email: string
+      organiser_name: string
     }
   | {
       type: 'issue_report'
@@ -252,14 +262,16 @@ function paymentReminderEmailHtml(params: {
   recipientName: string
   organiserName: string
   tripName: string
-  formattedAmount: string
-  payToName: string
+  formattedAmount?: string
+  payToName?: string
+  payments?: Array<{ formattedAmount: string; payToName: string; rawAmount: number }>
+  currency: string
   tripUrl: string
   settlementsUrl: string
   receipts?: ReceiptEmailData[]
   expenseCount?: number
 }): string {
-  const { recipientName, organiserName, tripName, formattedAmount, payToName, tripUrl, settlementsUrl, receipts, expenseCount } = params
+  const { recipientName, organiserName, tripName, formattedAmount, payToName, payments, currency, tripUrl, settlementsUrl, receipts, expenseCount } = params
   const hasReceipts = receipts && receipts.length > 0
   let receiptSection = ''
   if (hasReceipts) {
@@ -290,11 +302,23 @@ function paymentReminderEmailHtml(params: {
                 This is a friendly reminder from <strong style="color:${BRAND.textPrimary};">${escapeHtml(organiserName)}</strong> about an outstanding balance from <strong style="color:${BRAND.textPrimary};">${escapeHtml(tripName)}</strong>.
               </p>
               <!-- Amount Box — coral tint -->
+              ${payments && payments.length > 1 ? `
+              <div style="background:${BRAND.coralLight};border:2px solid ${BRAND.coral};border-radius:12px;padding:24px;margin-bottom:24px;">
+                <p style="margin:0 0 16px;color:${BRAND.coral};font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;text-align:center;">Outstanding balances</p>
+                ${payments.map(p => `
+                <div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0;">
+                  <span style="color:${BRAND.textPrimary};font-size:18px;font-weight:700;">${escapeHtml(p.formattedAmount)}</span>
+                  <span style="color:${BRAND.textMuted};font-size:14px;">&rarr; ${escapeHtml(p.payToName)}</span>
+                </div>`).join('')}
+                <div style="border-top:1px solid ${BRAND.coral};margin-top:8px;padding-top:8px;display:flex;justify-content:space-between;align-items:center;">
+                  <span style="color:${BRAND.textPrimary};font-size:18px;font-weight:700;">${escapeHtml(formatPrice(payments.reduce((sum, p) => sum + p.rawAmount, 0), currency))} total</span>
+                </div>
+              </div>` : `
               <div style="background:${BRAND.coralLight};border:2px solid ${BRAND.coral};border-radius:12px;padding:24px;text-align:center;margin-bottom:24px;">
                 <p style="margin:0 0 4px;color:${BRAND.coral};font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">You owe</p>
-                <p style="margin:0 0 4px;color:${BRAND.textPrimary};font-size:36px;font-weight:700;">${escapeHtml(formattedAmount)}</p>
-                <p style="margin:0;color:${BRAND.textMuted};font-size:14px;">to <strong style="color:${BRAND.textPrimary};">${escapeHtml(payToName)}</strong></p>
-              </div>
+                <p style="margin:0 0 4px;color:${BRAND.textPrimary};font-size:36px;font-weight:700;">${escapeHtml(formattedAmount || '')}</p>
+                <p style="margin:0;color:${BRAND.textMuted};font-size:14px;">to <strong style="color:${BRAND.textPrimary};">${escapeHtml(payToName || '')}</strong></p>
+              </div>`}
               ${receiptSection}
               <!-- CTA Button -->
               <table width="100%" cellpadding="0" cellspacing="0">
@@ -347,6 +371,41 @@ function issueReportEmailHtml(params: {
     subtitle: 'New Issue Report',
     bodyContent,
     footerHtml: `<p style="margin:0;color:${BRAND.textMuted};font-size:12px;">Spl<span style="color:${BRAND.coral};">1</span>t &middot; Issue tracking</p>`,
+  })
+}
+
+function bankDetailsNudgeEmailHtml(params: {
+  recipientName: string
+  organiserName: string
+  tripName: string
+  tripUrl: string
+  settlementsUrl: string
+}): string {
+  const { recipientName, organiserName, tripName, tripUrl, settlementsUrl } = params
+  const bodyContent = `
+              <h2 style="margin:0 0 8px;color:${BRAND.textPrimary};font-size:20px;font-weight:600;">Hey ${escapeHtml(recipientName)}!</h2>
+              <p style="margin:0 0 24px;color:${BRAND.textMuted};font-size:15px;line-height:1.6;">
+                People from <strong style="color:${BRAND.textPrimary};">${escapeHtml(tripName)}</strong> want to pay you, but they need your bank details.
+              </p>
+              <p style="margin:0 0 28px;color:${BRAND.textMuted};font-size:15px;line-height:1.6;">
+                Sign in and add your bank account details so everyone knows where to send payments.
+              </p>
+              <!-- CTA Button -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding:0 0 24px;">
+                    <a href="${settlementsUrl}" style="display:inline-block;background:${BRAND.coral};color:${BRAND.white};font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:8px;">
+                      Add bank details &rarr;
+                    </a>
+                  </td>
+                </tr>
+              </table>`
+  return baseEmailHtml({
+    title: `Add your bank details for ${escapeHtml(tripName)}`,
+    subtitle: 'Bank Details Request',
+    bodyContent,
+    footerOrganiser: escapeHtml(organiserName),
+    tripUrl,
   })
 }
 
@@ -418,16 +477,32 @@ Deno.serve(async (req) => {
         .single()
       tripId = inv?.trip_id ?? null
     } else if (body.type === 'payment_reminder') {
-      const formattedAmount = new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: body.currency,
-      }).format(body.amount)
       const tripUrl = `${APP_URL}/t/${body.trip_code}/quick`
+
+      // Build formatted payments array for multi-payment or single-payment
+      let formattedPayments: Array<{ formattedAmount: string; payToName: string; rawAmount: number }> | undefined
+      let formattedAmount: string | undefined
+      let payToName: string | undefined
+
+      if (body.payments && body.payments.length > 0) {
+        formattedPayments = body.payments.map(p => ({
+          formattedAmount: new Intl.NumberFormat('en-US', { style: 'currency', currency: body.currency }).format(p.amount),
+          payToName: p.pay_to_name,
+          rawAmount: p.amount,
+        }))
+        // For remind URL, use first payment as primary
+        formattedAmount = formattedPayments[0].formattedAmount
+        payToName = body.payments[0].pay_to_name
+      } else if (body.amount != null && body.pay_to_name) {
+        formattedAmount = new Intl.NumberFormat('en-US', { style: 'currency', currency: body.currency }).format(body.amount)
+        payToName = body.pay_to_name
+      }
+
       const remindParams = new URLSearchParams({
         name: body.recipient_name,
-        amount: String(body.amount),
+        amount: String(body.payments?.[0]?.amount ?? body.amount ?? 0),
         currency: body.currency,
-        to: body.pay_to_name,
+        to: payToName ?? '',
         trip: body.trip_name,
       })
       const settlementsUrl = `${APP_URL}/remind/${body.trip_code}?${remindParams.toString()}`
@@ -438,7 +513,9 @@ Deno.serve(async (req) => {
         organiserName: body.organiser_name,
         tripName: body.trip_name,
         formattedAmount,
-        payToName: body.pay_to_name,
+        payToName,
+        payments: formattedPayments,
+        currency: body.currency,
         tripUrl,
         settlementsUrl,
         receipts: body.receipts,
@@ -447,6 +524,21 @@ Deno.serve(async (req) => {
       toEmail = body.recipient_email
       toName = body.recipient_name
       emailType = 'payment_reminder'
+      tripId = body.trip_id
+    } else if (body.type === 'bank_details_nudge') {
+      const tripUrl = `${APP_URL}/t/${body.trip_code}/quick`
+      const settlementsUrl = `${APP_URL}/t/${body.trip_code}/settlements`
+      subject = `Add your bank details for "${body.trip_name}"`
+      html = bankDetailsNudgeEmailHtml({
+        recipientName: body.recipient_name,
+        organiserName: body.organiser_name,
+        tripName: body.trip_name,
+        tripUrl,
+        settlementsUrl,
+      })
+      toEmail = body.recipient_email
+      toName = body.recipient_name
+      emailType = 'bank_details_nudge'
       tripId = body.trip_id
     } else if (body.type === 'issue_report') {
       const adminEmail = Deno.env.get('ADMIN_NOTIFICATION_EMAIL')


### PR DESCRIPTION
## Summary
- **Remind All moved** from a hidden header icon to a visible labeled button below the settlement plan card
- **Deduplicated by debtor** — each person receives one email listing all their outstanding payments (e.g. Vahid owes Kristjan + Immi → one email with both lines)
- **Multi-payment email template** — when a debtor has multiple payments, the email shows a table of balances with a formatted total instead of a single amount box
- **"Ask X to add bank details" → actionable nudge** — recipients with an email get a clickable "Nudge" button that sends a branded email asking them to add bank details
- **PostTripNudgeBanner** gains an optional "Remind" button for the creator variant

## Test plan
- [ ] SettlementsPage shows "Remind All" button below settlement plan (not icon in header)
- [ ] "Remind All" dialog shows deduplicated debtor list (person appearing in 2 transactions shows once with "(2 payments)")
- [ ] Debtor receives one email with multi-payment table when they owe multiple people
- [ ] Individual "Remind" button still sends single-payment email (backward compat)
- [ ] "Ask X to add bank details" shows clickable "Nudge" button when recipient has email
- [ ] Nudge sends bank_details_nudge email with correct template
- [ ] `npm run type-check` clean, `npm test` all 200 pass
- [ ] Deploy `supabase functions deploy send-email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)