### PR TITLE
fix: treat sub-5-cent balances as settled

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { motion } from 'framer-motion'
 import { ArrowDownToLine, ArrowUpFromLine, CheckCircle2 } from 'lucide-react'
-import { ParticipantBalance } from '@/services/balanceCalculator'
-import { formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { ParticipantBalance, formatBalance, getBalanceColorClass, SETTLED_THRESHOLD } from '@/services/balanceCalculator'
 import { Card } from '@/components/ui/card'
 import { ParticipantAvatar } from '@/components/ParticipantAvatar'
 import type { Participant } from '@/types/participant'
@@ -27,14 +26,14 @@ export function BalanceCard({ balance, currency = 'EUR', onClick, groupMembers }
   const hasReceived = balance.totalSettledReceived > 0
 
   const getBalanceStatus = () => {
-    if (balance.balance > 0.01) {
+    if (balance.balance > SETTLED_THRESHOLD) {
       return {
         text: 'To receive',
         icon: <ArrowDownToLine size={16} className="text-positive" />,
         bgClass: 'bg-positive/5',
         borderClass: 'border-positive/20'
       }
-    } else if (balance.balance < -0.01) {
+    } else if (balance.balance < -SETTLED_THRESHOLD) {
       return {
         text: 'To pay',
         icon: <ArrowUpFromLine size={16} className="text-destructive" />,
@@ -127,7 +126,7 @@ export function BalanceCard({ balance, currency = 'EUR', onClick, groupMembers }
           <div className="flex items-center gap-2 text-sm">
             {status.icon}
             <span className="text-muted-foreground">
-              {Math.abs(balance.balance) < 0.01 ? (
+              {Math.abs(balance.balance) <= SETTLED_THRESHOLD ? (
                 'All settled up!'
               ) : balance.balance > 0 ? (
                 <>Others owe <strong className={`${balanceColorClass} tabular-nums`}>{formatBalance(balance.balance, currency)}</strong></>

--- a/src/components/CostBreakdownDialog.tsx
+++ b/src/components/CostBreakdownDialog.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { Receipt, Wallet, Users, Check, ArrowRight } from 'lucide-react'
 import { ResponsiveOverlay } from '@/components/ui/ResponsiveOverlay'
 import { Badge } from '@/components/ui/badge'
-import { ParticipantBalance, formatBalance, getBalanceColorClass, convertToBaseCurrency, calculateExpenseShares, buildEntityMap, calculateWithinGroupBalances } from '@/services/balanceCalculator'
+import { ParticipantBalance, formatBalance, getBalanceColorClass, convertToBaseCurrency, calculateExpenseShares, buildEntityMap, calculateWithinGroupBalances, SETTLED_THRESHOLD } from '@/services/balanceCalculator'
 import { Expense } from '@/types/expense'
 import { Participant } from '@/types/participant'
 import { Settlement } from '@/types/settlement'
@@ -131,7 +131,7 @@ export function CostBreakdownDialog({
               Within-group balances
             </h4>
             {(() => {
-              const allEven = withinGroupBalances.every(b => Math.abs(b.balance) < 0.01)
+              const allEven = withinGroupBalances.every(b => Math.abs(b.balance) <= SETTLED_THRESHOLD)
               const hasActivity = withinGroupBalances.some(b => b.totalPaid > 0 || b.totalShare > 0)
               if (!hasActivity) {
                 return <p className="text-xs text-muted-foreground">No shared expenses yet</p>

--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -2,7 +2,7 @@
 import { Calendar, ChevronRight } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Event } from '@/types/trip'
-import { ParticipantBalance, formatBalance, getBalanceColorClass } from '@/services/balanceCalculator'
+import { ParticipantBalance, formatBalance, getBalanceColorClass, SETTLED_THRESHOLD } from '@/services/balanceCalculator'
 import { getTripGradientPattern } from '@/services/tripGradientService'
 
 interface TripCardProps {
@@ -52,7 +52,7 @@ export function TripCard({ trip, balance, isActive, isEnded, onClick, actions }:
                     Active
                   </span>
                 )}
-                {isEnded && balance && Math.abs(balance.balance) > 0.01 && (
+                {isEnded && balance && Math.abs(balance.balance) > SETTLED_THRESHOLD && (
                   <span className="flex-shrink-0 text-[10px] font-medium uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 px-1.5 py-0.5 rounded">
                     Needs settling
                   </span>
@@ -60,7 +60,7 @@ export function TripCard({ trip, balance, isActive, isEnded, onClick, actions }:
               </div>
               {balance ? (
                 <p className={`text-lg font-bold tabular-nums ${getBalanceColorClass(balance.balance)}`}>
-                  {balance.balance === 0
+                  {Math.abs(balance.balance) <= SETTLED_THRESHOLD
                     ? 'Settled up'
                     : balance.balance > 0
                       ? `You are owed ${formatBalance(balance.balance)}`

--- a/src/components/quick/QuickGroupMembersSheet.tsx
+++ b/src/components/quick/QuickGroupMembersSheet.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
 import { UserCheck, ChevronDown, Check } from 'lucide-react'
-import { ParticipantBalance, formatBalance, getBalanceColorClass, calculateWithinGroupBalances } from '@/services/balanceCalculator'
+import { ParticipantBalance, formatBalance, getBalanceColorClass, calculateWithinGroupBalances, SETTLED_THRESHOLD } from '@/services/balanceCalculator'
 import { Participant } from '@/types/participant'
 import { Expense } from '@/types/expense'
 import { Settlement } from '@/types/settlement'
@@ -38,7 +38,7 @@ export function QuickGroupMembersSheet({
   }
 
   function statusText(balance: number): string {
-    if (Math.abs(balance) < 0.005) return 'Settled up'
+    if (Math.abs(balance) <= SETTLED_THRESHOLD) return 'Settled up'
     const amount = formatBalance(Math.abs(balance), currency)
     return balance > 0 ? `Owed ${amount}` : `Owes ${amount}`
   }
@@ -68,7 +68,7 @@ export function QuickGroupMembersSheet({
       {balances.map((b, i) => {
         const isMe = b.id === myParticipantId
         const linked = isLinked(b.id)
-        const settled = Math.abs(b.balance) < 0.005
+        const settled = Math.abs(b.balance) <= SETTLED_THRESHOLD
         const isExpanded = expandedGroups.has(b.id)
         const groupName = b.isFamily ? getGroupName(b.id) : null
 
@@ -151,7 +151,7 @@ function WithinGroupBreakdown({
   const groupBalances = calculateWithinGroupBalances(
     expenses, participants, groupName, currency, exchangeRates, settlements
   )
-  const allEven = groupBalances.every(b => Math.abs(b.balance) < 0.01)
+  const allEven = groupBalances.every(b => Math.abs(b.balance) <= SETTLED_THRESHOLD)
   const hasGroupExpenses = groupBalances.some(b => b.totalPaid > 0 || b.totalShare > 0)
   const groupMembers = participants.filter(p => p.wallet_group === groupName)
   const hasChildren = groupMembers.some(p => !p.is_adult) && groupMembers.some(p => p.is_adult)

--- a/src/hooks/usePostTripNudge.ts
+++ b/src/hooks/usePostTripNudge.ts
@@ -6,7 +6,7 @@ import { useMyParticipant } from '@/hooks/useMyParticipant'
 import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
-import { calculateBalances, buildEntityMap } from '@/services/balanceCalculator'
+import { calculateBalances, buildEntityMap, SETTLED_THRESHOLD } from '@/services/balanceCalculator'
 import { calculateOptimalSettlement } from '@/services/settlementOptimizer'
 import { getTripPhase, type TripPhase } from '@/lib/activeTripDetection'
 
@@ -48,7 +48,7 @@ export function usePostTripNudge() {
 
   const hasOutstandingBalances = useMemo(() => {
     if (!balanceCalc) return false
-    return balanceCalc.balances.some(b => Math.abs(b.balance) > 0.01)
+    return balanceCalc.balances.some(b => Math.abs(b.balance) > SETTLED_THRESHOLD)
   }, [balanceCalc])
 
   const isCreator = !!user && !!currentTrip?.created_by && user.id === currentTrip.created_by
@@ -83,7 +83,7 @@ export function usePostTripNudge() {
   const remindersEnabled = currentTrip?.enable_settlement_reminders !== false
 
   const showCreatorBanner = phase === 'ended' && isCreator && hasOutstandingBalances && !dismissed && remindersEnabled
-  const showDebtorBanner = phase === 'ended' && myBalance !== null && myBalance < -0.01 && !dismissed && remindersEnabled
+  const showDebtorBanner = phase === 'ended' && myBalance !== null && myBalance < -SETTLED_THRESHOLD && !dismissed && remindersEnabled
 
   return {
     phase,

--- a/src/services/balanceCalculator.test.ts
+++ b/src/services/balanceCalculator.test.ts
@@ -589,7 +589,7 @@ describe('calculateWithinGroupBalances', () => {
       }),
     ]
     const balances = calculateWithinGroupBalances(expenses, allParticipants, 'Smith')
-    const allEven = balances.every(b => Math.abs(b.balance) < 0.01)
+    const allEven = balances.every(b => Math.abs(b.balance) <= 0.05)
     expect(allEven).toBe(true)
   })
 

--- a/src/services/balanceCalculator.ts
+++ b/src/services/balanceCalculator.ts
@@ -4,6 +4,12 @@ import { Participant } from '@/types/participant'
 import { Settlement } from '@/types/settlement'
 import { buildShortNameMap } from '@/lib/participantUtils'
 
+/**
+ * Balances within this threshold of zero are treated as settled.
+ * Covers rounding artifacts from currency conversions and percentage splits.
+ */
+export const SETTLED_THRESHOLD = 0.05
+
 export interface ParticipantBalance {
   id: string
   name: string

--- a/src/services/settlementOptimizer.ts
+++ b/src/services/settlementOptimizer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { ParticipantBalance } from './balanceCalculator'
+import { ParticipantBalance, SETTLED_THRESHOLD } from './balanceCalculator'
 
 export interface SettlementTransaction {
   fromId: string
@@ -29,12 +29,12 @@ function settleGreedy(nonZero: ParticipantBalance[]): SettlementTransaction[] {
 
   const getDebtors = () =>
     working
-      .filter(b => b.balance < -0.01)
+      .filter(b => b.balance < -SETTLED_THRESHOLD)
       .sort((a, b) => a.balance - b.balance)
 
   const getCreditors = () =>
     working
-      .filter(b => b.balance > 0.01)
+      .filter(b => b.balance > SETTLED_THRESHOLD)
       .sort((a, b) => b.balance - a.balance)
 
   let debtors = getDebtors()
@@ -146,7 +146,7 @@ export function calculateOptimalSettlement(
   currency: string = 'EUR',
   mode: SettlementMode = 'optimal'
 ): OptimalSettlementPlan {
-  const nonZero = balances.filter(b => Math.abs(b.balance) > 0.01)
+  const nonZero = balances.filter(b => Math.abs(b.balance) > SETTLED_THRESHOLD)
 
   if (nonZero.length === 0) {
     return { transactions: [], totalTransactions: 0, currency }
@@ -194,7 +194,7 @@ export function formatSettlementTransaction(
  * Check if all balances are settled (within a small tolerance)
  */
 export function areBalancesSettled(balances: ParticipantBalance[]): boolean {
-  return balances.every(b => Math.abs(b.balance) < 0.01)
+  return balances.every(b => Math.abs(b.balance) <= SETTLED_THRESHOLD)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract shared `SETTLED_THRESHOLD = 0.05` constant in `balanceCalculator.ts`
- Update all balance comparison sites (TripCard, BalanceCard, settlementOptimizer, usePostTripNudge, QuickGroupMembersSheet, CostBreakdownDialog) to use the constant
- Tiny rounding artifacts (€0.01–€0.04) from currency conversions / percentage splits no longer show "Needs settling" badges or nudge banners

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — all 200 tests pass
- [ ] Manual: trips with ≤€0.05 balance show "Settled up" with no badge
- [ ] Manual: trips with >€0.05 balance still show badge + amount correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)