### PR TITLE
fix: change email from address to spl1t@xtian.me

### DIFF
--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -13,7 +13,7 @@ const logger = createLogger('send-email')
 const metrics = createMetrics('send-email')
 
 const APP_URL = 'https://split.xtian.me'
-const FROM_ADDRESS = 'Spl1t <noreply@xtian.me>'
+const FROM_ADDRESS = 'Spl1t <spl1t@xtian.me>'
 
 const BRAND = {
   coral:       '#e8613a',


### PR DESCRIPTION
## Summary
- Replace `noreply@xtian.me` with `spl1t@xtian.me` as the email from address
- Improves deliverability trust signals (flagged by Resend dashboard)
- Also added DMARC DNS record (`_dmarc.xtian.me`) via Cloudflare API

## Test plan
- [ ] Send a test invitation or payment reminder email
- [ ] Verify "From" shows `Spl1t <spl1t@xtian.me>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)