### PR TITLE
fix: bank details email links to the actual bank details dialog

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { lazy, Suspense, useState, useCallback, useMemo } from 'react'
+import { lazy, Suspense, useState, useCallback, useEffect, useMemo } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Lightbulb, Receipt, FileDown, Share2, Landmark, X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -15,7 +15,7 @@ import { exportTripSummaryToPDF } from '@/services/pdfExport'
 import { BalanceCard } from '@/components/BalanceCard'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
 import { BankDetailsDialog } from '@/components/auth/BankDetailsDialog'
 import { CostBreakdownDialog } from '@/components/CostBreakdownDialog'
@@ -36,8 +36,18 @@ export function DashboardPage() {
   const { settlements, loading: sLoading, error: sError, refreshSettlements } = useSettlementContext()
   const { myParticipant } = useMyParticipant()
   const bankPrompt = useBankDetailsPrompt()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [selectedBalance, setSelectedBalance] = useState<ParticipantBalance | null>(null)
   const [retrying, setRetrying] = useState(false)
+
+  // Auto-open bank details dialog when linked from email with ?action=bank-details
+  useEffect(() => {
+    if (searchParams.get('action') === 'bank-details') {
+      bankPrompt.setDialogOpen(true)
+      searchParams.delete('action')
+      setSearchParams(searchParams, { replace: true })
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRefresh = useCallback(
     () => Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()]).then(() => {}),

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
-import { useNavigate, useLocation, Link } from 'react-router-dom'
+import { useNavigate, useLocation, useSearchParams, Link } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { SignInButton } from '@/components/auth/SignInButton'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -63,6 +63,17 @@ export function QuickGroupDetailPage() {
   const [receiptReviewData, setReceiptReviewData] = useState<ReceiptReviewData | null>(null)
   const [retrying, setRetrying] = useState(false)
   const bankPrompt = useBankDetailsPrompt()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // Auto-open bank details dialog when linked from email with ?action=bank-details
+  useEffect(() => {
+    if (searchParams.get('action') === 'bank-details') {
+      bankPrompt.setDialogOpen(true)
+      searchParams.delete('action')
+      setSearchParams(searchParams, { replace: true })
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
   // Open receipt capture sheet when navigated here with openScan state
   useEffect(() => {
     if ((location.state as any)?.openScan) {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { Layout } from './components/Layout'
 import { QuickLayout } from './components/QuickLayout'
 import { TripRouteGuard } from './components/TripRouteGuard'
@@ -25,6 +25,7 @@ import { Loader2 } from 'lucide-react'
 function TripModeRedirect() {
   const { mode } = useUserPreferences()
   const { user, loading: authLoading } = useAuth()
+  const { search } = useLocation()
 
   // Wait for auth to resolve before routing — prevents flash where auth users briefly see dashboard
   if (authLoading) {
@@ -37,10 +38,11 @@ function TripModeRedirect() {
 
   // Unauth users always get Full mode — Quick view requires auth + participant linking
   if (!user) {
-    return <Navigate to="dashboard" replace />
+    return <Navigate to={`dashboard${search}`} replace />
   }
 
-  return <Navigate to={mode === 'quick' ? 'quick' : 'dashboard'} replace />
+  const target = mode === 'quick' ? 'quick' : 'dashboard'
+  return <Navigate to={`${target}${search}`} replace />
 }
 
 export function AppRoutes() {

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -527,14 +527,14 @@ Deno.serve(async (req) => {
       tripId = body.trip_id
     } else if (body.type === 'bank_details_nudge') {
       const tripUrl = `${APP_URL}/t/${body.trip_code}/quick`
-      const settlementsUrl = `${APP_URL}/t/${body.trip_code}/settlements`
+      const bankDetailsUrl = `${APP_URL}/t/${body.trip_code}?action=bank-details`
       subject = `Add your bank details for "${body.trip_name}"`
       html = bankDetailsNudgeEmailHtml({
         recipientName: body.recipient_name,
         organiserName: body.organiser_name,
         tripName: body.trip_name,
         tripUrl,
-        settlementsUrl,
+        settlementsUrl: bankDetailsUrl,
       })
       toEmail = body.recipient_email
       toName = body.recipient_name


### PR DESCRIPTION
## Summary
- Bank details nudge email CTA previously linked to `/settlements` — user had no idea where to add bank details
- Now links to `/t/:tripCode?action=bank-details` which auto-opens the `BankDetailsDialog` on arrival
- `TripModeRedirect` preserves query params through the mode-based redirect (quick vs dashboard)
- Both `DashboardPage` and `QuickGroupDetailPage` detect `?action=bank-details` and open the dialog

## Test plan
- [ ] Trigger a bank details nudge email (or inspect the edge function locally)
- [ ] Click the CTA link — should land on trip page with bank details dialog open
- [ ] Verify the `?action=bank-details` param is cleaned from the URL after opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)