### PR TITLE
fix: guard bank-details deep link behind auth

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { lazy, Suspense, useState, useCallback, useEffect, useMemo } from 'react'
+import { lazy, Suspense, useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { Lightbulb, Receipt, FileDown, Share2, Landmark, X } from 'lucide-react'
 import { useCurrentTrip } from '@/hooks/useCurrentTrip'
@@ -7,6 +7,7 @@ import { useParticipantContext } from '@/contexts/ParticipantContext'
 import { useExpenseContext } from '@/contexts/ExpenseContext'
 import { useSettlementContext } from '@/contexts/SettlementContext'
 import { useMyParticipant } from '@/hooks/useMyParticipant'
+import { useAuth } from '@/contexts/AuthContext'
 import { useBankDetailsPrompt } from '@/hooks/useBankDetailsPrompt'
 import { PageLoadingState } from '@/components/PageLoadingState'
 import { PageErrorState } from '@/components/PageErrorState'
@@ -35,19 +36,24 @@ export function DashboardPage() {
   const { expenses, loading: eLoading, error: eError, refreshExpenses } = useExpenseContext()
   const { settlements, loading: sLoading, error: sError, refreshSettlements } = useSettlementContext()
   const { myParticipant } = useMyParticipant()
+  const { user } = useAuth()
   const bankPrompt = useBankDetailsPrompt()
   const [searchParams, setSearchParams] = useSearchParams()
   const [selectedBalance, setSelectedBalance] = useState<ParticipantBalance | null>(null)
   const [retrying, setRetrying] = useState(false)
+  const bankDetailsHandled = useRef(false)
 
   // Auto-open bank details dialog when linked from email with ?action=bank-details
+  // Waits for user to be authenticated — re-runs after sign-in
   useEffect(() => {
-    if (searchParams.get('action') === 'bank-details') {
-      bankPrompt.setDialogOpen(true)
-      searchParams.delete('action')
-      setSearchParams(searchParams, { replace: true })
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    if (bankDetailsHandled.current) return
+    if (searchParams.get('action') !== 'bank-details') return
+    if (!user) return
+    bankDetailsHandled.current = true
+    bankPrompt.setDialogOpen(true)
+    searchParams.delete('action')
+    setSearchParams(searchParams, { replace: true })
+  }, [user]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRefresh = useCallback(
     () => Promise.all([refreshParticipants(), refreshExpenses(), refreshSettlements()]).then(() => {}),

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRegisterRefresh } from '@/hooks/useRegisterRefresh'
 import { useNavigate, useLocation, useSearchParams, Link } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
@@ -64,15 +64,19 @@ export function QuickGroupDetailPage() {
   const [retrying, setRetrying] = useState(false)
   const bankPrompt = useBankDetailsPrompt()
   const [searchParams, setSearchParams] = useSearchParams()
+  const bankDetailsHandled = useRef(false)
 
   // Auto-open bank details dialog when linked from email with ?action=bank-details
+  // Waits for user to be authenticated — re-runs after sign-in
   useEffect(() => {
-    if (searchParams.get('action') === 'bank-details') {
-      bankPrompt.setDialogOpen(true)
-      searchParams.delete('action')
-      setSearchParams(searchParams, { replace: true })
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    if (bankDetailsHandled.current) return
+    if (searchParams.get('action') !== 'bank-details') return
+    if (!user) return
+    bankDetailsHandled.current = true
+    bankPrompt.setDialogOpen(true)
+    searchParams.delete('action')
+    setSearchParams(searchParams, { replace: true })
+  }, [user]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Open receipt capture sheet when navigated here with openScan state
   useEffect(() => {


### PR DESCRIPTION
## Summary
- `?action=bank-details` now waits for authentication before opening the dialog
- If user lands unauthed, the param is preserved — after sign-in, the effect re-fires and opens the dialog
- Uses a ref guard to prevent double-firing

## Test plan
- [ ] Open `/t/:tripCode?action=bank-details` while signed out — dialog should NOT open
- [ ] Sign in — dialog should auto-open after auth resolves
- [ ] Open the same URL while signed in — dialog opens immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)