### PR TITLE
fix: top bar overlapping iOS status bar in PWA mode

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -132,7 +132,7 @@ export function Layout() {
     <PullToRefreshProvider>
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className={`fixed top-0 left-0 right-0 z-50 ${pattern ? 'bg-black' : 'bg-card border-b border-border soft-shadow-sm'}`}>
+      <header className={`fixed top-0 left-0 right-0 z-50 pwa-safe-top ${pattern ? 'bg-black' : 'bg-card border-b border-border soft-shadow-sm'}`}>
         {/* Gradient background when in a trip */}
         {pattern && (
           <>
@@ -243,7 +243,7 @@ export function Layout() {
       </header>
 
       {/* Main content */}
-      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin pwa-safe-top-offset ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
         <LayoutPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -59,7 +59,7 @@ export function QuickLayout() {
     <PullToRefreshProvider>
     <div className="min-h-screen bg-background">
       {/* Simplified header */}
-      <header className={`fixed top-0 left-0 right-0 z-50 ${pattern ? 'bg-black' : 'bg-card border-b border-border soft-shadow-sm'}`}>
+      <header className={`fixed top-0 left-0 right-0 z-50 pwa-safe-top ${pattern ? 'bg-black' : 'bg-card border-b border-border soft-shadow-sm'}`}>
         {/* Gradient background when in a trip */}
         {pattern && (
           <>
@@ -185,7 +185,7 @@ export function QuickLayout() {
       </header>
 
       {/* Main content — extra top padding when two-row header is active */}
-      <main className={isInTrip && !isSubPage ? 'pt-[108px] lg:pt-16' : 'pt-16'}>
+      <main className={`pwa-safe-top-offset ${isInTrip && !isSubPage ? 'pt-[108px] lg:pt-16' : 'pt-16'}`}>
         <QuickPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -213,6 +213,14 @@
 
   /* PWA standalone: add safe-area padding to bottom nav for iPhone home indicator */
   @media (display-mode: standalone) {
+    .pwa-safe-top {
+      padding-top: env(safe-area-inset-top, 0px);
+    }
+
+    .pwa-safe-top-offset {
+      margin-top: env(safe-area-inset-top, 0px);
+    }
+
     .pwa-safe-bottom {
       padding-bottom: env(safe-area-inset-bottom, 0px);
     }


### PR DESCRIPTION
## Summary
- Add `pwa-safe-top` CSS class (mirrors existing `pwa-safe-bottom`) using `env(safe-area-inset-top)` in `@media (display-mode: standalone)`
- Add `pwa-safe-top-offset` CSS class to push main content down by the safe area inset
- Apply both classes to `Layout.tsx` and `QuickLayout.tsx` headers and main content areas

Closes #699

## Test plan
- [ ] Build and deploy to Cloudflare Pages
- [ ] Install as PWA on iOS (Safari "Add to Home Screen")
- [ ] Verify header content (trip name, back arrow, avatar) sits below the iOS status bar
- [ ] Verify main content is not hidden behind the header
- [ ] Verify no visual change on non-PWA browser usage (classes are scoped to `display-mode: standalone`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)