### PR TITLE
fix: add PWA safe-area padding to toast notifications

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 pwa-safe-top sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Adds `pwa-safe-top` class to `ToastViewport` so toast notifications render below the notch/status bar in PWA standalone mode on iOS
- Only affects PWA mode via `@media (display-mode: standalone)`; on `sm:` breakpoint and up toasts are bottom-positioned so the top padding is irrelevant

## Test plan
- [ ] Install as PWA on iOS, trigger a toast (e.g. save bank details) → toast appears below the notch
- [ ] Browser mode unchanged — toasts still appear at top on mobile, bottom-right on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)