### PR TITLE
fix: increase content offset to match two-row header height

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ Both layouts use the same responsive header pattern:
 - **Desktop (in-trip):** Single-row header. Back arrow + trip name (clickable `<Link>` to home with `fromTrip` state) on left. Scan button + `ModeToggle` + avatar on right (`hidden lg:flex`).
 - **Home page:** Single-row. Logo on left, avatar on right. No scan/toggle (the page has its own scan CTA).
 
-Header container: `max-w-lg lg:max-w-7xl mx-auto px-4 lg:px-8`. Main content padding: `pt-[108px] lg:pt-16` (two-row) or `pt-16` (single-row).
+Header container: `max-w-lg lg:max-w-7xl mx-auto px-4 lg:px-8`. Main content padding: `pt-[120px] lg:pt-16` (two-row) or `pt-16` (single-row).
 
 Trip gradient pattern: `getTripGradientPattern(trip.name)` returns gradient + decorative icons. Text on gradient uses inline `textShadow: '0 1px 4px rgba(0,0,0,0.9)'` and overlay `from-black/50`.
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -243,7 +243,7 @@ export function Layout() {
       </header>
 
       {/* Main content */}
-      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin pwa-safe-top-offset ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[108px] lg:mt-20' : 'mt-20'}`}>
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin pwa-safe-top-offset ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[120px] lg:mt-20' : 'mt-[88px]'}`}>
         <LayoutPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -185,7 +185,7 @@ export function QuickLayout() {
       </header>
 
       {/* Main content — extra top padding when two-row header is active */}
-      <main className={`pwa-safe-top-offset ${isInTrip && !isSubPage ? 'pt-[108px] lg:pt-16' : 'pt-16'}`}>
+      <main className={`pwa-safe-top-offset ${isInTrip && !isSubPage ? 'pt-[120px] lg:pt-16' : 'pt-16'}`}>
         <QuickPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>


### PR DESCRIPTION
## Summary
- The two-row mobile header (trip name row + action pills row) is ~117px tall, but content offset was only `108px` — causing the top of page content to render behind the header
- Increased in-trip content offset from `108px` to `120px` in both `Layout.tsx` and `QuickLayout.tsx`
- Increased home page offset from `80px` (`mt-20`) to `88px` for more breathing room below the single-row header

Closes #703, closes #704

## Test plan
- [ ] Open dashboard page on mobile — "Total Expenses" / "Participants" labels fully visible below action pills
- [ ] Open home page on mobile — "Hi, [name]" greeting fully visible below header
- [ ] Quick mode trip view — content not clipped by header
- [ ] Desktop layout unchanged (`lg:mt-20` / `lg:pt-16` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)