### PR TITLE
fix: use calc() for safe-area-inset-top content offset in PWA

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -243,7 +243,7 @@ export function Layout() {
       </header>
 
       {/* Main content */}
-      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin pwa-safe-top-offset ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[120px] lg:mt-20' : 'mt-[88px]'}`}>
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 pb-24 lg:pb-6 pwa-safe-bottom-margin ${tripCode ? 'lg:ml-64' : ''} ${tripCode && currentTrip ? 'mt-[calc(120px+var(--safe-area-top))] lg:mt-20' : 'mt-[calc(88px+var(--safe-area-top))]'}`}>
         <LayoutPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>

--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -185,7 +185,7 @@ export function QuickLayout() {
       </header>
 
       {/* Main content — extra top padding when two-row header is active */}
-      <main className={`pwa-safe-top-offset ${isInTrip && !isSubPage ? 'pt-[120px] lg:pt-16' : 'pt-16'}`}>
+      <main className={`${isInTrip && !isSubPage ? 'pt-[calc(120px+var(--safe-area-top))] lg:pt-16' : 'pt-[calc(64px+var(--safe-area-top))]'}`}>
         <QuickPullIndicator />
         <ParticipantProvider>
           <ExpenseProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,8 @@
 
 @layer base {
   :root {
+    --safe-area-top: env(safe-area-inset-top, 0px);
+
     /* Warm & Earthy Design System - Light Mode */
     --background: 30 17% 98%; /* Warm cream #FAF8F5 */
     --foreground: 225 15% 20%; /* Deep charcoal #2D3142 */
@@ -211,16 +213,13 @@
     }
   }
 
-  /* PWA standalone: add safe-area padding to bottom nav for iPhone home indicator */
+  /* Safe-area padding for notch/Dynamic Island — always applied (no-op when inset is 0) */
+  .pwa-safe-top {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+
+  /* Bottom safe-area only in PWA standalone (home indicator) */
   @media (display-mode: standalone) {
-    .pwa-safe-top {
-      padding-top: env(safe-area-inset-top, 0px);
-    }
-
-    .pwa-safe-top-offset {
-      margin-top: env(safe-area-inset-top, 0px);
-    }
-
     .pwa-safe-bottom {
       padding-bottom: env(safe-area-inset-bottom, 0px);
     }


### PR DESCRIPTION
## Summary
- **Root cause:** `pwa-safe-top-offset` class set `margin-top: env(safe-area-inset-top)` in `@layer base`, but Tailwind's `mt-[88px]`/`mt-[120px]` utilities (in `@layer utilities`) silently overrode it — the safe-area offset was never applied to `<main>` content
- **Fix:** Added `--safe-area-top` CSS custom property and replaced hardcoded offsets with `calc(offset + var(--safe-area-top))` so the safe-area inset is always included
- Also moved `pwa-safe-top` (header padding) outside the standalone media query so it applies in regular Safari too (no-op on devices without a notch)

Closes #703, closes #704

## Test plan
- [ ] On iPhone PWA: "Hi, Kristjan" greeting fully visible below header (not clipped by notch/Dynamic Island)
- [ ] On iPhone Safari: same — header content below status bar
- [ ] On desktop browser: no visual change (env returns 0px)
- [ ] Quick mode layout also correct on iPhone PWA

🤖 Generated with [Claude Code](https://claude.com/claude-code)