### PR TITLE
Sort active trips first on home page

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -31,7 +31,7 @@ export function TripCard({ trip, balance, isActive, isEnded, onClick, actions }:
     : null
 
   return (
-    <Card className="overflow-hidden relative">
+    <Card className={`overflow-hidden relative ${isActive ? 'ring-1 ring-primary/30' : ''}`}>
       <div
         className="absolute left-0 top-0 bottom-0 w-1 rounded-l-xl"
         style={{ background: pattern.gradient }}
@@ -48,7 +48,11 @@ export function TripCard({ trip, balance, isActive, isEnded, onClick, actions }:
                   {trip.name}
                 </h3>
                 {isActive && (
-                  <span className="flex-shrink-0 text-[10px] font-medium uppercase tracking-wide bg-primary/10 text-primary px-1.5 py-0.5 rounded">
+                  <span className="flex-shrink-0 inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide bg-primary/10 text-primary px-2 py-0.5 rounded-full">
+                    <span className="relative flex h-1.5 w-1.5">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
+                      <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary" />
+                    </span>
                     Active
                   </span>
                 )}

--- a/src/lib/activeTripDetection.test.ts
+++ b/src/lib/activeTripDetection.test.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getActiveTripId, getTripPhase } from './activeTripDetection'
+import { getActiveTripId, getTripPhase, sortTripBalances } from './activeTripDetection'
 import { buildTrip } from '@/test/factories'
+import { ParticipantBalance } from '@/services/balanceCalculator'
+
+function makeBalance(balance: number): ParticipantBalance {
+  return { id: '1', name: 'Test', totalPaid: 0, totalShare: 0, totalSettled: 0, totalSettledSent: 0, totalSettledReceived: 0, balance, isFamily: false }
+}
 
 describe('getActiveTripId', () => {
   beforeEach(() => {
@@ -136,5 +141,72 @@ describe('getTripPhase', () => {
   it('returns "active" for a single-day trip that is today', () => {
     const trip = buildTrip({ start_date: '2025-07-15', end_date: '2025-07-15' })
     expect(getTripPhase(trip)).toBe('active')
+  })
+})
+
+describe('sortTripBalances', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-07-15T12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sorts active before upcoming before ended-unsettled before ended-settled', () => {
+    const active = { trip: buildTrip({ id: 'active', start_date: '2025-07-10', end_date: '2025-07-20' }), myBalance: makeBalance(0) }
+    const upcoming = { trip: buildTrip({ id: 'upcoming', start_date: '2025-07-20', end_date: '2025-07-30' }), myBalance: null }
+    const endedUnsettled = { trip: buildTrip({ id: 'ended-unsettled', start_date: '2025-06-01', end_date: '2025-06-10' }), myBalance: makeBalance(50) }
+    const endedSettled = { trip: buildTrip({ id: 'ended-settled', start_date: '2025-05-01', end_date: '2025-05-10' }), myBalance: makeBalance(0) }
+
+    const result = sortTripBalances([endedSettled, upcoming, endedUnsettled, active])
+    expect(result.map(r => r.trip.id)).toEqual(['active', 'upcoming', 'ended-unsettled', 'ended-settled'])
+  })
+
+  it('sorts active trips by end_date ASC (ending soonest first)', () => {
+    const endsSooner = { trip: buildTrip({ id: 'sooner', start_date: '2025-07-10', end_date: '2025-07-18' }), myBalance: null }
+    const endsLater = { trip: buildTrip({ id: 'later', start_date: '2025-07-01', end_date: '2025-07-25' }), myBalance: null }
+
+    const result = sortTripBalances([endsLater, endsSooner])
+    expect(result.map(r => r.trip.id)).toEqual(['sooner', 'later'])
+  })
+
+  it('sorts upcoming trips by start_date ASC (nearest first)', () => {
+    const far = { trip: buildTrip({ id: 'far', start_date: '2025-08-10', end_date: '2025-08-20' }), myBalance: null }
+    const near = { trip: buildTrip({ id: 'near', start_date: '2025-07-20', end_date: '2025-07-25' }), myBalance: null }
+
+    const result = sortTripBalances([far, near])
+    expect(result.map(r => r.trip.id)).toEqual(['near', 'far'])
+  })
+
+  it('sorts ended trips by end_date DESC (most recent first)', () => {
+    const older = { trip: buildTrip({ id: 'older', start_date: '2025-05-01', end_date: '2025-05-10' }), myBalance: makeBalance(0) }
+    const newer = { trip: buildTrip({ id: 'newer', start_date: '2025-06-01', end_date: '2025-06-10' }), myBalance: makeBalance(0) }
+
+    const result = sortTripBalances([older, newer])
+    expect(result.map(r => r.trip.id)).toEqual(['newer', 'older'])
+  })
+
+  it('treats ended trip with balance below threshold as settled', () => {
+    const belowThreshold = { trip: buildTrip({ id: 'below', start_date: '2025-06-01', end_date: '2025-06-10' }), myBalance: makeBalance(0.03) }
+    const aboveThreshold = { trip: buildTrip({ id: 'above', start_date: '2025-06-01', end_date: '2025-06-10' }), myBalance: makeBalance(5) }
+
+    const result = sortTripBalances([belowThreshold, aboveThreshold])
+    expect(result.map(r => r.trip.id)).toEqual(['above', 'below'])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(sortTripBalances([])).toEqual([])
+  })
+
+  it('does not mutate the original array', () => {
+    const items = [
+      { trip: buildTrip({ id: 'b', start_date: '2025-07-20', end_date: '2025-07-25' }), myBalance: null },
+      { trip: buildTrip({ id: 'a', start_date: '2025-07-10', end_date: '2025-07-20' }), myBalance: null },
+    ]
+    const originalFirst = items[0].trip.id
+    sortTripBalances(items)
+    expect(items[0].trip.id).toBe(originalFirst)
   })
 })

--- a/src/lib/activeTripDetection.ts
+++ b/src/lib/activeTripDetection.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Trip } from '@/types/trip'
+import { ParticipantBalance, SETTLED_THRESHOLD } from '@/services/balanceCalculator'
 
 export type TripPhase = 'upcoming' | 'active' | 'ended'
 
@@ -67,4 +68,45 @@ export function getActiveTripId(trips: Trip[]): string | null {
   }
 
   return null
+}
+
+/**
+ * Sort trip-balance entries by relevance:
+ *   0 – Active (today in start..end), tiebreak: end_date ASC (ending soonest first)
+ *   1 – Upcoming (start > today), tiebreak: start_date ASC (nearest first)
+ *   2 – Ended + unsettled balance, tiebreak: end_date DESC (most recent first)
+ *   3 – Ended + settled / no balance, tiebreak: end_date DESC (most recent first)
+ */
+export function sortTripBalances<T extends { trip: Trip; myBalance: ParticipantBalance | null }>(
+  items: T[]
+): T[] {
+  return [...items].sort((a, b) => {
+    const pa = getSortPriority(a)
+    const pb = getSortPriority(b)
+    if (pa !== pb) return pa - pb
+
+    const phase = getTripPhase(a.trip)
+    if (phase === 'active') {
+      // ending soonest first
+      return new Date(a.trip.end_date).getTime() - new Date(b.trip.end_date).getTime()
+    }
+    if (phase === 'upcoming') {
+      // nearest start first
+      return new Date(a.trip.start_date).getTime() - new Date(b.trip.start_date).getTime()
+    }
+    // ended: most recent first
+    return new Date(b.trip.end_date).getTime() - new Date(a.trip.end_date).getTime()
+  })
+}
+
+function isUnsettled(balance: ParticipantBalance | null): boolean {
+  return balance !== null && Math.abs(balance.balance) > SETTLED_THRESHOLD
+}
+
+function getSortPriority(item: { trip: Trip; myBalance: ParticipantBalance | null }): number {
+  const phase = getTripPhase(item.trip)
+  if (phase === 'active') return 0
+  if (phase === 'upcoming') return 1
+  if (phase === 'ended' && isUnsettled(item.myBalance)) return 2
+  return 3
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { getMyTrips, removeFromMyTrips, type MyTripEntry } from '@/lib/myTripsStorage'
 import { getHiddenTripCodes, showTrip } from '@/lib/mutedTripsStorage'
-import { getActiveTripId, getTripPhase } from '@/lib/activeTripDetection'
+import { getActiveTripId, getTripPhase, sortTripBalances } from '@/lib/activeTripDetection'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
 import { OnboardingPrompts } from '@/components/OnboardingPrompts'
 import { TripCard } from '@/components/TripCard'
@@ -102,6 +102,10 @@ export function HomePage() {
   const visitedTrips = visibleTrips.filter(({ trip, myBalance }) =>
     !emailDiscoveredTripIds.has(trip.id) && trip.created_by !== user?.id && myBalance === null
   )
+
+  const sortedMyTrips = useMemo(() => sortTripBalances(myTrips), [myTrips])
+  const sortedInvitedTrips = useMemo(() => sortTripBalances(invitedTrips), [invitedTrips])
+  const sortedVisitedTrips = useMemo(() => sortTripBalances(visitedTrips), [visitedTrips])
 
   const activeTripId = useMemo(
     () => getActiveTripId(visibleTrips.map(tb => tb.trip)),
@@ -223,29 +227,29 @@ export function HomePage() {
       return renderEmptyState()
     }
 
-    const sectionCount = [myTrips, invitedTrips, visitedTrips].filter(s => s.length > 0).length
+    const sectionCount = [sortedMyTrips, sortedInvitedTrips, sortedVisitedTrips].filter(s => s.length > 0).length
     const showHeadings = sectionCount > 1
 
     return (
       <>
-        {myTrips.length > 0 && (
+        {sortedMyTrips.length > 0 && (
           <>
             {showHeadings && <h2 className="text-sm font-medium text-muted-foreground mb-3">My Trips</h2>}
-            {renderTripGrid(myTrips)}
+            {renderTripGrid(sortedMyTrips)}
           </>
         )}
 
-        {invitedTrips.length > 0 && (
-          <div className={myTrips.length > 0 ? 'mt-8' : ''}>
+        {sortedInvitedTrips.length > 0 && (
+          <div className={sortedMyTrips.length > 0 ? 'mt-8' : ''}>
             {showHeadings && <h2 className="text-sm font-medium text-muted-foreground mb-3">Invited</h2>}
-            {renderTripGrid(invitedTrips)}
+            {renderTripGrid(sortedInvitedTrips)}
           </div>
         )}
 
-        {visitedTrips.length > 0 && (
-          <div className={myTrips.length > 0 || invitedTrips.length > 0 ? 'mt-8' : ''}>
+        {sortedVisitedTrips.length > 0 && (
+          <div className={sortedMyTrips.length > 0 || sortedInvitedTrips.length > 0 ? 'mt-8' : ''}>
             {showHeadings && <h2 className="text-sm font-medium text-muted-foreground mb-3">Visited</h2>}
-            {renderTripGrid(visitedTrips)}
+            {renderTripGrid(sortedVisitedTrips)}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Add `sortTripBalances()` to sort trips by relevance: active > upcoming > ended-unsettled > ended-settled, with contextual tiebreakers (end_date ASC for active, start_date ASC for upcoming, end_date DESC for ended)
- Apply sorting to all three trip sections (My Trips, Invited, Visited) on the home page
- Enhance active trip card with `ring-1 ring-primary/30` highlight and pulsing dot badge indicator

## Test plan
- [x] `npm run type-check` passes clean
- [x] All 207 tests pass (including 7 new `sortTripBalances` tests)
- [ ] Visual: active trip appears first on home page with ring highlight and pulsing dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)