### PR TITLE
Fix: show active badge on all concurrent active trips

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { getMyTrips, removeFromMyTrips, type MyTripEntry } from '@/lib/myTripsStorage'
 import { getHiddenTripCodes, showTrip } from '@/lib/mutedTripsStorage'
-import { getActiveTripId, getTripPhase, sortTripBalances } from '@/lib/activeTripDetection'
+import { getTripPhase, sortTripBalances } from '@/lib/activeTripDetection'
 import { ShareTripDialog } from '@/components/ShareTripDialog'
 import { OnboardingPrompts } from '@/components/OnboardingPrompts'
 import { TripCard } from '@/components/TripCard'
@@ -107,11 +107,6 @@ export function HomePage() {
   const sortedInvitedTrips = useMemo(() => sortTripBalances(invitedTrips), [invitedTrips])
   const sortedVisitedTrips = useMemo(() => sortTripBalances(visitedTrips), [visitedTrips])
 
-  const activeTripId = useMemo(
-    () => getActiveTripId(visibleTrips.map(tb => tb.trip)),
-    [visibleTrips]
-  )
-
   const handleHidden = useCallback((tripCode: string) => {
     setHiddenCodes(prev => new Set([...prev, tripCode]))
   }, [])
@@ -199,7 +194,7 @@ export function HomePage() {
           <TripCard
             trip={trip}
             balance={myBalance}
-            isActive={trip.id === activeTripId}
+            isActive={getTripPhase(trip) === 'active'}
             isEnded={getTripPhase(trip) === 'ended'}
             onClick={() => handleOpenTrip(trip.trip_code)}
             actions={


### PR DESCRIPTION
## Summary
- `isActive` was using `getActiveTripId()` which returns only the single best active trip (for redirect logic)
- Changed to `getTripPhase(trip) === 'active'` so all trips whose dates span today get the active badge + ring highlight
- Removed unused `activeTripId` / `getActiveTripId` import from HomePage

## Test plan
- [x] `npm run type-check` passes
- [x] All 207 tests pass
- [ ] Visual: all concurrent active trips show the pulsing dot badge and ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)