### PR TITLE
fix: skip trip picker when scanning receipt in-trip — closes #714

### DIFF
--- a/src/components/QuickLayout.tsx
+++ b/src/components/QuickLayout.tsx
@@ -43,7 +43,10 @@ export function QuickLayout() {
   const [scanCreateOpen, setScanCreateOpen] = useState(false)
 
   const handleScanTap = () => {
-    if (visibleTrips.length === 0) {
+    if (isInTrip) {
+      // Already viewing a trip — go straight to scan without trip picker
+      navigate(`/t/${tripCode}/quick`, { state: { openScan: true, ts: Date.now() } })
+    } else if (visibleTrips.length === 0) {
       setScanCreateOpen(true)
     } else {
       setScanContextOpen(true)


### PR DESCRIPTION
## Summary
- When scanning a receipt from the header action strip while already inside a trip, the scan now opens directly instead of showing the trip picker sheet
- The trip picker is still shown when scanning from the home page (no trip context)
- Root cause: `handleScanTap()` in `QuickLayout` always showed the trip picker regardless of whether the user was already in a trip

## Test plan
- [ ] Open a trip in Quick mode → tap "Scan Receipt" in header → should open receipt capture directly (no trip picker)
- [ ] From home page with multiple trips → tap Scan → should still show trip picker
- [ ] From home page with zero trips → tap Scan → should still show create flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)