### PR TITLE
fix: skip trip picker when scanning receipt from within a trip in Full mode

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -62,7 +62,10 @@ export function Layout() {
   const [scanCreateOpen, setScanCreateOpen] = useState(false)
 
   const handleScanTap = () => {
-    if (visibleTrips.length === 0) {
+    if (tripCode) {
+      // Already viewing a trip — go straight to scan without trip picker
+      navigate(`/t/${tripCode}/quick`, { state: { openScan: true, ts: Date.now() } })
+    } else if (visibleTrips.length === 0) {
       setScanCreateOpen(true)
     } else {
       setScanContextOpen(true)


### PR DESCRIPTION
## Summary
- When scanning a receipt from within a trip in Full mode, skip the trip picker and use the current trip directly (matching Quick mode behavior)

## Test plan
- [ ] Open a trip in Full mode, scan a receipt — should not show trip picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)