### PR TITLE
fix: redirect bare /kopikas to home page

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -71,6 +71,7 @@ export function AppRoutes() {
       </Route>
 
       {/* Kopikas routes — outside Spl1t layouts */}
+      <Route path="kopikas" element={<Navigate to="/" replace />} />
       <Route path="kopikas/create" element={<ErrorBoundary><CreateWallet /></ErrorBoundary>} />
       <Route path="kopikas/:walletCode" element={<KopikasLayout />}>
         <Route index element={<ErrorBoundary><KopikasHome /></ErrorBoundary>} />


### PR DESCRIPTION
## Summary

- `/kopikas` without a wallet code was showing a blank screen
- Now redirects to `/` (home page)

## Test plan

- [ ] Visit `split.xtian.me/kopikas` → should redirect to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)