### PR TITLE
feat: add Kopikas wallet list page at /kopikas

### DIFF
--- a/src/kopikas/components/KopikasHomeSection.tsx
+++ b/src/kopikas/components/KopikasHomeSection.tsx
@@ -52,7 +52,6 @@ export function KopikasHomeSection({ userId }: KopikasHomeSectionProps) {
   }, [userId])
 
   if (loading) return null
-  if (wallets.length === 0) return null  // Don't show section if no wallets
 
   return (
     <div className="mt-8">
@@ -62,18 +61,28 @@ export function KopikasHomeSection({ userId }: KopikasHomeSectionProps) {
           Loo uus
         </Link>
       </div>
-      <div className="space-y-2">
-        {wallets.map(w => (
-          <Link
-            key={w.id}
-            to={`/kopikas/${w.wallet_code}/parent`}
-            className="block p-4 rounded-xl border border-border bg-card hover:bg-muted/50 transition-colors"
-          >
-            <p className="font-medium">{w.name}</p>
-            <p className="text-sm text-muted-foreground">Kopikas rahakott</p>
-          </Link>
-        ))}
-      </div>
+      {wallets.length === 0 ? (
+        <Link
+          to="/kopikas/create"
+          className="block p-6 rounded-xl border border-dashed border-border hover:bg-muted/50 transition-colors text-center"
+        >
+          <span className="text-2xl block mb-2">🫧</span>
+          <p className="text-sm text-muted-foreground">Loo oma lapsele taskuraha rahakott</p>
+        </Link>
+      ) : (
+        <div className="space-y-2">
+          {wallets.map(w => (
+            <Link
+              key={w.id}
+              to={`/kopikas/${w.wallet_code}/parent`}
+              className="block p-4 rounded-xl border border-border bg-card hover:bg-muted/50 transition-colors"
+            >
+              <p className="font-medium">{w.name}</p>
+              <p className="text-sm text-muted-foreground">Kopikas rahakott</p>
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/kopikas/pages/WalletList.tsx
+++ b/src/kopikas/pages/WalletList.tsx
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { supabase } from '@/lib/supabase'
+import { withTimeout } from '@/lib/fetchWithTimeout'
+import { logger } from '@/lib/logger'
+import type { Wallet } from '../types'
+import { ArrowLeft, Loader2, Plus } from 'lucide-react'
+
+export function WalletList() {
+  const { user, loading: authLoading } = useAuth()
+  const navigate = useNavigate()
+  const [wallets, setWallets] = useState<Wallet[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (authLoading) return
+    if (!user) {
+      setLoading(false)
+      return
+    }
+
+    const fetchWallets = async () => {
+      try {
+        const { data: members } = await withTimeout(
+          (supabase.from('wallet_members' as any) as any)
+            .select('wallet_id')
+            .eq('user_id', user.id),
+          15000,
+          'Loading wallets timed out'
+        ) as { data: any[] | null }
+
+        if (!members || members.length === 0) {
+          setWallets([])
+          return
+        }
+
+        const walletIds = members.map((m: any) => m.wallet_id)
+        const { data: walletData } = await withTimeout(
+          (supabase.from('wallets' as any) as any)
+            .select('*')
+            .in('id', walletIds)
+            .order('created_at', { ascending: false }),
+          15000,
+          'Loading wallet details timed out'
+        ) as { data: any[] | null }
+
+        setWallets((walletData as Wallet[]) || [])
+      } catch (error) {
+        logger.error('Failed to fetch wallets', { error: error instanceof Error ? error.message : String(error) })
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchWallets()
+  }, [user?.id, authLoading])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
+        <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => navigate('/')}
+              className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors"
+              aria-label="Tagasi"
+            >
+              <ArrowLeft className="w-5 h-5" />
+            </button>
+            <h1 className="font-semibold text-lg">Kopikas</h1>
+          </div>
+          {user && (
+            <Link
+              to="/kopikas/create"
+              className="rounded-full w-8 h-8 flex items-center justify-center bg-primary text-primary-foreground"
+              aria-label="Loo uus"
+            >
+              <Plus className="w-4 h-4" />
+            </Link>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-lg mx-auto px-4 py-6">
+        {authLoading || loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : !user ? (
+          <div className="text-center py-20">
+            <span className="text-4xl block mb-4">🫧</span>
+            <p className="text-muted-foreground mb-2">Logi sisse, et näha oma rahakotte</p>
+          </div>
+        ) : wallets.length === 0 ? (
+          <div className="text-center py-20">
+            <span className="text-4xl block mb-4">🫧</span>
+            <p className="text-lg font-medium mb-2">Sul pole veel rahakotte</p>
+            <p className="text-sm text-muted-foreground mb-6">Loo oma lapsele taskuraha rahakott</p>
+            <Link
+              to="/kopikas/create"
+              className="inline-block px-6 py-3 rounded-xl bg-primary text-primary-foreground font-medium"
+            >
+              Loo rahakott
+            </Link>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {wallets.map(w => (
+              <div key={w.id} className="rounded-xl border border-border bg-card overflow-hidden">
+                <div className="p-4">
+                  <p className="font-medium text-lg">{w.name}</p>
+                  <p className="text-sm text-muted-foreground mt-0.5">Kopikas rahakott</p>
+                </div>
+                <div className="flex border-t border-border divide-x divide-border">
+                  <Link
+                    to={`/kopikas/${w.wallet_code}`}
+                    className="flex-1 py-2.5 text-center text-sm font-medium text-primary hover:bg-muted/50 transition-colors"
+                  >
+                    Lapse vaade
+                  </Link>
+                  <Link
+                    to={`/kopikas/${w.wallet_code}/parent`}
+                    className="flex-1 py-2.5 text-center text-sm font-medium text-primary hover:bg-muted/50 transition-colors"
+                  >
+                    Vanema vaade
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,6 +26,7 @@ import { PetDetail } from './kopikas/pages/PetDetail'
 import { History } from './kopikas/pages/History'
 import { ParentView } from './kopikas/pages/ParentView'
 import { CreateWallet } from './kopikas/pages/CreateWallet'
+import { WalletList } from './kopikas/pages/WalletList'
 import { useUserPreferences } from './contexts/UserPreferencesContext'
 import { useAuth } from './contexts/AuthContext'
 import { Loader2 } from 'lucide-react'
@@ -71,7 +72,7 @@ export function AppRoutes() {
       </Route>
 
       {/* Kopikas routes — outside Spl1t layouts */}
-      <Route path="kopikas" element={<Navigate to="/" replace />} />
+      <Route path="kopikas" element={<ErrorBoundary><WalletList /></ErrorBoundary>} />
       <Route path="kopikas/create" element={<ErrorBoundary><CreateWallet /></ErrorBoundary>} />
       <Route path="kopikas/:walletCode" element={<KopikasLayout />}>
         <Route index element={<ErrorBoundary><KopikasHome /></ErrorBoundary>} />


### PR DESCRIPTION
## Summary

- `/kopikas` now shows a proper wallet list page instead of redirecting to home
- Each wallet card links to both kid view and parent view
- Empty state with create CTA for users with no wallets
- Login prompt for unauthenticated users
- Home page Kopikas section always visible for auth users (empty state shows dashed create card)

## Test plan

- [ ] Visit `/kopikas` while logged in → see wallet list (or empty state with create button)
- [ ] Visit `/kopikas` while logged out → see login prompt
- [ ] Create a wallet → appears in the list
- [ ] Home page shows Kopikas section with create CTA even with no wallets

🤖 Generated with [Claude Code](https://claude.com/claude-code)