### PR TITLE
fix: keep Kopikas back navigation within Kopikas

### DIFF
--- a/src/kopikas/components/KopikasParentLayout.tsx
+++ b/src/kopikas/components/KopikasParentLayout.tsx
@@ -21,7 +21,7 @@ function ParentInner() {
         <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
           <div className="max-w-lg mx-auto px-4 h-14 flex items-center gap-3">
             <button
-              onClick={() => navigate('/', { state: { fromTrip: true } })}
+              onClick={() => navigate('/kopikas')}
               className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors"
               aria-label="Tagasi"
             >

--- a/src/kopikas/pages/WalletList.tsx
+++ b/src/kopikas/pages/WalletList.tsx
@@ -62,7 +62,7 @@ export function WalletList() {
         <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <button
-              onClick={() => navigate('/')}
+              onClick={() => navigate(-1)}
               className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors"
               aria-label="Tagasi"
             >


### PR DESCRIPTION
## Summary

- WalletList back button uses browser history (`navigate(-1)`) instead of hard `/`
- Parent view back button goes to `/kopikas` (wallet list) instead of Spl1t home

## Test plan

- [ ] From `/kopikas` tap back → goes to previous page (home or wherever)
- [ ] From `/kopikas/:code/parent` tap back → goes to `/kopikas` wallet list

🤖 Generated with [Claude Code](https://claude.com/claude-code)