### PR TITLE
fix: replace Kopikas emoji icons with lucide-react SVGs

### DIFF
--- a/src/kopikas/components/KopikasTabBar.tsx
+++ b/src/kopikas/components/KopikasTabBar.tsx
@@ -1,37 +1,37 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NavLink, useParams } from 'react-router-dom'
 import { usePet } from '../hooks/usePet'
+import { Home, BarChart3, Heart, type LucideIcon } from 'lucide-react'
 
 export function KopikasTabBar() {
   const { walletCode } = useParams<{ walletCode: string }>()
   const { pet } = usePet()
   const base = `/kopikas/${walletCode}`
   const petLabel = pet?.name || 'Kopikas'
-  const petEmoji = pet?.starter_emoji || '🫧'
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-background pwa-safe-bottom">
       <div className="max-w-lg mx-auto flex items-center justify-around h-14">
-        <TabLink to={base} end label="Kodu" emoji="🏠" />
-        <TabLink to={`${base}/analytics`} label="Ülevaade" emoji="📊" />
-        <TabLink to={`${base}/pet`} label={petLabel} emoji={petEmoji} />
+        <TabLink to={base} end label="Kodu" icon={Home} />
+        <TabLink to={`${base}/analytics`} label="Ülevaade" icon={BarChart3} />
+        <TabLink to={`${base}/pet`} label={petLabel} icon={Heart} />
       </div>
     </nav>
   )
 }
 
-function TabLink({ to, label, emoji, end }: { to: string; label: string; emoji: string; end?: boolean }) {
+function TabLink({ to, label, icon: Icon, end }: { to: string; label: string; icon: LucideIcon; end?: boolean }) {
   return (
     <NavLink
       to={to}
       end={end}
       className={({ isActive }) =>
         `flex flex-col items-center gap-0.5 px-3 py-1.5 text-xs transition-colors ${
-          isActive ? 'text-foreground' : 'text-muted-foreground'
+          isActive ? 'text-primary' : 'text-muted-foreground'
         }`
       }
     >
-      <span className="text-lg">{emoji}</span>
+      <Icon size={20} />
       <span>{label}</span>
     </NavLink>
   )

--- a/src/kopikas/components/TransactionList.tsx
+++ b/src/kopikas/components/TransactionList.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WalletTransaction } from '../types'
 import { getCategoryEmoji } from '../lib/kopikasCategories'
+import { Wallet } from 'lucide-react'
 
 interface TransactionListProps {
   transactions: WalletTransaction[]
@@ -39,9 +40,12 @@ export function TransactionList({ transactions, limit }: TransactionListProps) {
     <ul className="divide-y divide-border">
       {items.map(tx => (
         <li key={tx.id} className="flex items-center gap-3 py-3 px-1">
-          <span className="text-xl shrink-0">
-            {tx.type === 'allowance' ? '💰' : getCategoryEmoji(tx.category!)}
-          </span>
+          <div className="w-8 h-8 rounded-full shrink-0 flex items-center justify-center">
+            {tx.type === 'allowance'
+              ? <Wallet size={18} className="text-green-500" />
+              : <span className="text-lg">{getCategoryEmoji(tx.category!)}</span>
+            }
+          </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm truncate">
               {tx.description || (tx.type === 'allowance' ? 'Taskuraha' : 'Kulu')}

--- a/src/kopikas/pages/KopikasHome.tsx
+++ b/src/kopikas/pages/KopikasHome.tsx
@@ -8,7 +8,7 @@ import { PetSpeechBubble } from '../components/PetSpeechBubble'
 import { TransactionList } from '../components/TransactionList'
 import { ManualAddSheet } from '../components/ManualAddSheet'
 import { ScanFlow } from '../components/ScanFlow'
-import { Loader2 } from 'lucide-react'
+import { Loader2, ScanLine, PencilLine, BarChart3 } from 'lucide-react'
 
 export function KopikasHome() {
   const { walletCode } = useParams<{ walletCode: string }>()
@@ -61,23 +61,29 @@ export function KopikasHome() {
       <div className="grid grid-cols-3 gap-3 mb-8">
         <button
           onClick={() => setScanOpen(true)}
-          className="flex flex-col items-center gap-1.5 p-4 rounded-xl border border-border hover:bg-muted transition-colors"
+          className="flex flex-col items-center gap-2 p-4 rounded-xl border border-border hover:bg-muted transition-colors"
         >
-          <span className="text-2xl">📸</span>
+          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+            <ScanLine size={20} className="text-primary" />
+          </div>
           <span className="text-xs font-medium">Skanni</span>
         </button>
         <button
           onClick={() => setManualAddOpen(true)}
-          className="flex flex-col items-center gap-1.5 p-4 rounded-xl border border-border hover:bg-muted transition-colors"
+          className="flex flex-col items-center gap-2 p-4 rounded-xl border border-border hover:bg-muted transition-colors"
         >
-          <span className="text-2xl">✏️</span>
+          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+            <PencilLine size={20} className="text-primary" />
+          </div>
           <span className="text-xs font-medium">Lisa</span>
         </button>
         <button
           onClick={() => navigate(`/kopikas/${walletCode}/analytics`)}
-          className="flex flex-col items-center gap-1.5 p-4 rounded-xl border border-border hover:bg-muted transition-colors"
+          className="flex flex-col items-center gap-2 p-4 rounded-xl border border-border hover:bg-muted transition-colors"
         >
-          <span className="text-2xl">📊</span>
+          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+            <BarChart3 size={20} className="text-primary" />
+          </div>
           <span className="text-xs font-medium">Ülevaade</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary

- Action buttons on kid home: emoji → lucide icons in `bg-primary/10` circles (matches Spl1t QuickActionButton pattern)
- Tab bar: emoji → lucide `Home`, `BarChart3`, `Heart` icons at size 20 with `text-primary` active state
- Transaction list: allowance 💰 emoji → lucide `Wallet` icon
- Category emoji (🍬🍔 etc) kept — those are data labels, not UI chrome

## Test plan

- [ ] Kid home page action buttons render as clean SVG circles
- [ ] Tab bar icons match Spl1t style
- [ ] Transaction list shows wallet icon for allowances, category emoji for expenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)