### PR TITLE
fix: translate Kopikas strings to Estonian

### DIFF
--- a/src/kopikas/contexts/PetContext.tsx
+++ b/src/kopikas/contexts/PetContext.tsx
@@ -66,7 +66,7 @@ export function PetProvider({ walletId, transactions, children }: PetProviderPro
           .update(updates)
           .eq('wallet_id', walletId),
         15000,
-        'Awarding bonuses timed out. Please check your connection and try again.'
+        'Boonuste andmine aegus. Kontrolli ühendust ja proovi uuesti.'
       ) as { error: any }
 
       if (error) {
@@ -100,7 +100,7 @@ export function PetProvider({ walletId, transactions, children }: PetProviderPro
           .maybeSingle()
           .abortSignal(signal),
         15000,
-        'Loading pet timed out. Please check your connection and try again.'
+        'Lemmiku laadimine aegus. Kontrolli ühendust ja proovi uuesti.'
       )
 
       if (signal.aborted) return
@@ -132,7 +132,7 @@ export function PetProvider({ walletId, transactions, children }: PetProviderPro
             .select()
             .single(),
           15000,
-          'Creating pet timed out. Please check your connection and try again.'
+          'Lemmiku loomine aegus. Kontrolli ühendust ja proovi uuesti.'
         )
 
         if (signal.aborted) return
@@ -174,7 +174,7 @@ export function PetProvider({ walletId, transactions, children }: PetProviderPro
           .update({ name, updated_at: new Date().toISOString() })
           .eq('wallet_id', walletId),
         15000,
-        'Naming pet timed out. Please check your connection and try again.'
+        'Nime salvestamine aegus. Kontrolli ühendust ja proovi uuesti.'
       ) as { error: any }
 
       if (error) {
@@ -208,7 +208,7 @@ export function PetProvider({ walletId, transactions, children }: PetProviderPro
           .update(updates)
           .eq('wallet_id', walletId),
         15000,
-        'Awarding XP timed out. Please check your connection and try again.'
+        'XP andmine aegus. Kontrolli ühendust ja proovi uuesti.'
       ) as { error: any }
 
       if (error) {

--- a/src/kopikas/contexts/WalletContext.tsx
+++ b/src/kopikas/contexts/WalletContext.tsx
@@ -61,7 +61,7 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
           .order('created_at', { ascending: false })
           .abortSignal(signal),
         15000,
-        'Loading wallet transactions timed out. Please check your connection and try again.'
+        'Tehingute laadimine aegus. Kontrolli ühendust ja proovi uuesti.'
       )
 
       if (signal.aborted) return
@@ -69,7 +69,7 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
       if (fetchError) {
         logger.error('Failed to fetch wallet transactions', { wallet_id: walletId, error: fetchError.message })
         setTransactions([])
-        setError('Failed to load transactions.')
+        setError('Tehingute laadimine ebaõnnestus.')
       } else {
         setTransactions((data as WalletTransaction[]) || [])
       }
@@ -77,7 +77,7 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
       if ((err as any)?.name === 'AbortError' || signal.aborted) return
       logger.error('Failed to fetch wallet transactions', { wallet_id: walletId, error: err instanceof Error ? err.message : String(err) })
       setTransactions([])
-      setError('Failed to load transactions.')
+      setError('Tehingute laadimine ebaõnnestus.')
     }
   }
 
@@ -94,7 +94,7 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
           .single()
           .abortSignal(signal),
         15000,
-        'Loading wallet timed out. Please check your connection and try again.'
+        'Rahakoti laadimine aegus. Kontrolli ühendust ja proovi uuesti.'
       )
 
       if (signal.aborted) return
@@ -102,7 +102,7 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
       if (fetchError) {
         logger.error('Failed to fetch wallet', { wallet_code: walletCode, error: fetchError.message })
         setWallet(null)
-        setError('Wallet not found.')
+        setError('Rahakotti ei leitud.')
         setLoading(false)
         return
       }
@@ -114,7 +114,7 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
       if ((err as any)?.name === 'AbortError' || signal.aborted) return
       logger.error('Failed to fetch wallet', { wallet_code: walletCode, error: err instanceof Error ? err.message : String(err) })
       setWallet(null)
-      setError('Failed to load wallet.')
+      setError('Rahakoti laadimine ebaõnnestus.')
     } finally {
       if (!signal.aborted) {
         setLoading(false)
@@ -157,13 +157,13 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
           .single()
           .abortSignal(controller.signal),
         15000,
-        'Adding transaction timed out. Please check your connection and try again.',
+        'Tehingu lisamine aegus. Kontrolli ühendust ja proovi uuesti.',
         controller
       )
 
       if (insertError) {
         logger.error('Failed to add wallet transaction', { wallet_id: input.wallet_id, error: insertError.message })
-        setError('Failed to add transaction.')
+        setError('Tehingu lisamine ebaõnnestus.')
         // Roll back optimistic insert
         setTransactions((prev) => prev.filter((tx) => tx.id !== optimisticId))
         return null
@@ -175,7 +175,7 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
       return savedTx
     } catch (err) {
       logger.error('Failed to add wallet transaction', { wallet_id: input.wallet_id, error: err instanceof Error ? err.message : String(err) })
-      setError('Failed to add transaction.')
+      setError('Tehingu lisamine ebaõnnestus.')
       // Roll back optimistic insert
       setTransactions((prev) => prev.filter((tx) => tx.id !== optimisticId))
       return null

--- a/src/kopikas/types.ts
+++ b/src/kopikas/types.ts
@@ -76,11 +76,11 @@ export interface CategoryCorrection {
 }
 
 export const PET_LEVELS = [
-  { level: 1, xpNeeded: 0, description: 'Small blob, simple eyes' },
-  { level: 2, xpNeeded: 100, description: 'Slightly bigger, gets a mouth' },
-  { level: 3, xpNeeded: 300, description: 'Gets blush marks, subtle glow' },
-  { level: 4, xpNeeded: 600, description: 'Gets a crown/hat accessory' },
-  { level: 5, xpNeeded: 1000, description: 'Full glow, sparkle trail, evolved form' },
+  { level: 1, xpNeeded: 0, description: 'Väike klõmps, lihtsad silmad' },
+  { level: 2, xpNeeded: 100, description: 'Natuke suurem, sai suu' },
+  { level: 3, xpNeeded: 300, description: 'Punased põsed, kerge sära' },
+  { level: 4, xpNeeded: 600, description: 'Sai krooni!' },
+  { level: 5, xpNeeded: 1000, description: 'Täis sära, sädemeid ja ilu!' },
 ] as const
 
 export const STARTER_EMOJIS = ['🫧', '🟣', '🔮', '💜'] as const


### PR DESCRIPTION
## Summary

- PET_LEVELS descriptions translated ("Small blob, simple eyes" → "Väike klõmps, lihtsad silmad")
- All error/timeout messages in WalletContext and PetContext translated
- No more English/Estonian mix in the UI

## Test plan

- [ ] Pet detail page shows Estonian level descriptions
- [ ] Error states show Estonian messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)