### PR TITLE
fix: fix Kopikas receipt scanning model ID

### DIFF
--- a/src/kopikas/components/ScanFlow.tsx
+++ b/src/kopikas/components/ScanFlow.tsx
@@ -8,6 +8,7 @@ import { getCategoryEmoji } from '../lib/kopikasCategories'
 import { getXpForAction } from '../lib/xpCalculator'
 import { supabase } from '@/lib/supabase'
 import { withTimeout } from '@/lib/fetchWithTimeout'
+import { logger } from '@/lib/logger'
 import type { KopikasCategory } from '../types'
 import { X, Camera, ArrowLeft, Loader2 } from 'lucide-react'
 
@@ -75,7 +76,8 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
         category: (item.category as KopikasCategory) || 'other',
       })))
       setStep('review')
-    } catch {
+    } catch (err) {
+      logger.error('Receipt scan failed', { error: err instanceof Error ? err.message : String(err) })
       setError('Hmm, ma ei saanud aru. Proovi uuesti! 📸')
     } finally {
       setProcessing(false)

--- a/supabase/functions/process-kopikas-receipt/index.ts
+++ b/supabase/functions/process-kopikas-receipt/index.ts
@@ -114,7 +114,7 @@ Rules:
     const anthropic = new Anthropic({ apiKey: anthropicKey })
 
     const response = await anthropic.messages.create({
-      model: 'claude-sonnet-4-5-20241022',
+      model: 'claude-sonnet-4-6',
       max_tokens: 2048,
       messages: [
         {


### PR DESCRIPTION
## Summary

- Fix AI model ID from outdated `claude-sonnet-4-5-20241022` to `claude-sonnet-4-6`
- Add error logging to ScanFlow for debugging scan failures
- Edge function redeployed

## Test plan

- [ ] Scan a receipt on the kid's Kopikas view → items should be extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)