### PR TITLE
feat: store and display Kopikas receipt images

### DIFF
--- a/src/kopikas/components/ScanFlow.tsx
+++ b/src/kopikas/components/ScanFlow.tsx
@@ -33,6 +33,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
   const [items, setItems] = useState<ScannedItem[]>([])
   const [processing, setProcessing] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  const [receiptImagePath, setReceiptImagePath] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [editingCategory, setEditingCategory] = useState<number | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -69,6 +70,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
         throw new Error('No items found')
       }
 
+      setReceiptImagePath(parsed.receipt_image_path || null)
       setItems(parsed.items.map((item: { name?: string; price?: number; qty?: number; category?: string }) => ({
         name: item.name || 'Tundmatu',
         price: Number(item.price) || 0,
@@ -111,7 +113,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
     setSubmitting(true)
 
     try {
-      // Create one transaction per item
+      // Create one transaction per item (all share the same receipt image)
       for (const item of items) {
         await addTransaction({
           wallet_id: wallet.id,
@@ -119,6 +121,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
           amount: item.price,
           description: item.name,
           category: item.category,
+          receipt_image_path: receiptImagePath ?? undefined,
         })
       }
 
@@ -140,6 +143,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
       setItems([])
       setError(null)
       setEditingCategory(null)
+      setReceiptImagePath(null)
     }, 300)
   }
 

--- a/src/kopikas/components/TransactionList.tsx
+++ b/src/kopikas/components/TransactionList.tsx
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from 'react'
 import type { WalletTransaction } from '../types'
 import { getCategoryEmoji } from '../lib/kopikasCategories'
-import { Wallet } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { Wallet, Receipt, X } from 'lucide-react'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 
 interface TransactionListProps {
   transactions: WalletTransaction[]
@@ -25,8 +28,14 @@ function formatAmount(amount: number): string {
   return `€${amount.toFixed(2)}`
 }
 
+function getReceiptUrl(path: string): string {
+  const { data } = supabase.storage.from('kopikas-receipts').getPublicUrl(path)
+  return data.publicUrl
+}
+
 export function TransactionList({ transactions, limit }: TransactionListProps) {
   const items = limit ? transactions.slice(0, limit) : transactions
+  const [receiptUrl, setReceiptUrl] = useState<string | null>(null)
 
   if (items.length === 0) {
     return (
@@ -37,28 +46,64 @@ export function TransactionList({ transactions, limit }: TransactionListProps) {
   }
 
   return (
-    <ul className="divide-y divide-border">
-      {items.map(tx => (
-        <li key={tx.id} className="flex items-center gap-3 py-3 px-1">
-          <div className="w-8 h-8 rounded-full shrink-0 flex items-center justify-center">
-            {tx.type === 'allowance'
-              ? <Wallet size={18} className="text-green-500" />
-              : <span className="text-lg">{getCategoryEmoji(tx.category!)}</span>
-            }
+    <>
+      <ul className="divide-y divide-border">
+        {items.map(tx => (
+          <li
+            key={tx.id}
+            className={`flex items-center gap-3 py-3 px-1 ${tx.receipt_image_path ? 'cursor-pointer hover:bg-muted/50 rounded-lg transition-colors' : ''}`}
+            onClick={() => {
+              if (tx.receipt_image_path) {
+                setReceiptUrl(getReceiptUrl(tx.receipt_image_path))
+              }
+            }}
+          >
+            <div className="w-8 h-8 rounded-full shrink-0 flex items-center justify-center">
+              {tx.type === 'allowance'
+                ? <Wallet size={18} className="text-green-500" />
+                : <span className="text-lg">{getCategoryEmoji(tx.category!)}</span>
+              }
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm truncate">
+                {tx.description || (tx.type === 'allowance' ? 'Taskuraha' : 'Kulu')}
+              </p>
+              <p className="text-xs text-muted-foreground flex items-center gap-1">
+                {relativeDate(tx.created_at)}
+                {tx.receipt_image_path && <Receipt size={12} className="text-muted-foreground" />}
+              </p>
+            </div>
+            <span className={`text-sm font-medium tabular-nums ${
+              tx.type === 'allowance' ? 'text-green-500' : 'text-foreground'
+            }`}>
+              {tx.type === 'allowance' ? '+' : '-'}{formatAmount(tx.amount)}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Receipt image viewer */}
+      <Sheet open={!!receiptUrl} onOpenChange={(open) => { if (!open) setReceiptUrl(null) }}>
+        <SheetContent side="bottom" hideClose className="flex flex-col p-0 rounded-t-2xl" style={{ height: '85dvh' }}>
+          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="w-8" />
+            <SheetTitle>Kviitung</SheetTitle>
+            <button onClick={() => setReceiptUrl(null)} aria-label="Close"
+              className="rounded-full w-8 h-8 flex items-center justify-center border border-border hover:bg-muted transition-colors">
+              <X className="w-4 h-4 text-muted-foreground" />
+            </button>
           </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm truncate">
-              {tx.description || (tx.type === 'allowance' ? 'Taskuraha' : 'Kulu')}
-            </p>
-            <p className="text-xs text-muted-foreground">{relativeDate(tx.created_at)}</p>
+          <div className="flex-1 overflow-y-auto overscroll-contain p-4 flex items-start justify-center">
+            {receiptUrl && (
+              <img
+                src={receiptUrl}
+                alt="Kviitung"
+                className="max-w-full rounded-lg"
+              />
+            )}
           </div>
-          <span className={`text-sm font-medium tabular-nums ${
-            tx.type === 'allowance' ? 'text-green-500' : 'text-foreground'
-          }`}>
-            {tx.type === 'allowance' ? '+' : '-'}{formatAmount(tx.amount)}
-          </span>
-        </li>
-      ))}
-    </ul>
+        </SheetContent>
+      </Sheet>
+    </>
   )
 }

--- a/supabase/functions/process-kopikas-receipt/index.ts
+++ b/supabase/functions/process-kopikas-receipt/index.ts
@@ -151,10 +151,35 @@ Rules:
 
     const parsed = JSON.parse(jsonStr)
 
+    // Upload receipt image to storage
+    let receiptImagePath: string | null = null
+    try {
+      const imageData = image.replace(/^data:image\/\w+;base64,/, '')
+      const imageBytes = Uint8Array.from(atob(imageData), c => c.charCodeAt(0))
+      const receiptId = crypto.randomUUID()
+      const storagePath = `${wallet.id}/${receiptId}.jpg`
+
+      const { error: uploadError } = await supabase.storage
+        .from('kopikas-receipts')
+        .upload(storagePath, imageBytes, { contentType: 'image/jpeg' })
+
+      if (uploadError) {
+        logger.error('Failed to upload receipt image', { error: uploadError.message })
+      } else {
+        receiptImagePath = storagePath
+      }
+    } catch (uploadErr) {
+      logger.error('Receipt image upload error', { error: uploadErr instanceof Error ? uploadErr.message : String(uploadErr) })
+    }
+
+    // Add receipt path to response
+    parsed.receipt_image_path = receiptImagePath
+
     const duration = performance.now() - requestStart
     logger.info('Receipt processed', {
       wallet_id: wallet.id,
       items: parsed.items?.length ?? 0,
+      receipt_image_path: receiptImagePath,
       duration_ms: Math.round(duration),
     })
     metrics.push([{ name: 'receipts_processed', value: 1, labels: { service_name: 'process-kopikas-receipt' }, type: 'counter' }])


### PR DESCRIPTION
## Summary

- Edge function now uploads receipt images to `kopikas-receipts` storage bucket
- `receipt_image_path` is set on transactions created from scans
- Transactions with receipts show a small receipt icon
- Tapping a transaction with a receipt opens an image viewer sheet
- Works in both kid and parent views

## Test plan

- [ ] Scan a receipt → items created with receipt icon visible
- [ ] Tap a transaction with receipt icon → image viewer opens
- [ ] Parent view shows same receipt icons and viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)