### PR TITLE
feat(kopikas): add auth UI — avatar, user menu, sign in/out

### DIFF
--- a/src/kopikas/components/KopikasParentLayout.tsx
+++ b/src/kopikas/components/KopikasParentLayout.tsx
@@ -8,6 +8,7 @@ import { useWallet } from '../hooks/useWallet'
 import { useKopikasBasePath } from '../hooks/useKopikasBasePath'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { ArrowLeft } from 'lucide-react'
+import { KopikasUserMenu } from './KopikasUserMenu'
 
 function ParentInner() {
   const { wallet, transactions } = useWallet()
@@ -22,15 +23,18 @@ function ParentInner() {
     <PetProvider walletId={wallet?.id ?? null} transactions={transactions}>
       <div className="min-h-screen bg-background text-foreground">
         <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
-          <div className="max-w-lg mx-auto px-4 h-14 flex items-center gap-3">
-            <button
-              onClick={() => navigate(basePath || '/')}
-              className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors"
-              aria-label="Tagasi"
-            >
-              <ArrowLeft className="w-5 h-5" />
-            </button>
-            <h1 className="font-semibold text-lg">Kopikas</h1>
+          <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => navigate(basePath || '/')}
+                className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors"
+                aria-label="Tagasi"
+              >
+                <ArrowLeft className="w-5 h-5" />
+              </button>
+              <h1 className="font-semibold text-lg">Kopikas</h1>
+            </div>
+            <KopikasUserMenu />
           </div>
         </header>
         <main className="max-w-lg mx-auto px-4 py-6">

--- a/src/kopikas/components/KopikasUserMenu.tsx
+++ b/src/kopikas/components/KopikasUserMenu.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useKopikasAuth } from '../app/KopikasAuthProvider'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { LogOut } from 'lucide-react'
+
+export function KopikasUserMenu() {
+  const { user, signInWithGoogle, signOut } = useKopikasAuth()
+
+  if (!user) {
+    return (
+      <button
+        onClick={signInWithGoogle}
+        className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors"
+        aria-label="Logi sisse"
+      >
+        <svg viewBox="0 0 24 24" className="w-5 h-5">
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.77.42 3.45 1.18 4.93l3.66-2.84z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
+        </svg>
+      </button>
+    )
+  }
+
+  const avatarUrl = user.user_metadata?.avatar_url || user.user_metadata?.picture
+  const displayName = user.user_metadata?.full_name || user.user_metadata?.name || user.email?.split('@')[0] || 'Kasutaja'
+  const initials = displayName
+    .split(' ')
+    .map((n: string) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors overflow-hidden"
+          aria-label="Kasutaja menüü"
+        >
+          {avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt={displayName}
+              className="w-8 h-8 rounded-full"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div className="w-8 h-8 rounded-full flex items-center justify-center bg-primary/10 text-primary text-xs font-medium">
+              {initials}
+            </div>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <div className="px-2 py-1.5">
+          <p className="text-sm font-medium">{displayName}</p>
+          {user.email && (
+            <p className="text-xs text-muted-foreground">{user.email}</p>
+          )}
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => { signOut() }} className="gap-2 text-destructive focus:text-destructive">
+          <LogOut size={16} />
+          Logi välja
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/kopikas/pages/WalletList.tsx
+++ b/src/kopikas/pages/WalletList.tsx
@@ -8,6 +8,7 @@ import { withTimeout } from '@/lib/fetchWithTimeout'
 import { logger } from '@/lib/logger'
 import type { Wallet } from '../types'
 import { Loader2, Plus } from 'lucide-react'
+import { KopikasUserMenu } from '../components/KopikasUserMenu'
 
 export function WalletList() {
   const { user, loading: authLoading } = useKopikasAuth()
@@ -62,15 +63,18 @@ export function WalletList() {
       <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
         <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
           <img src="/kopikas-logo.png" alt="Kopikas" className="h-7" />
-          {user && (
-            <Link
-              to={`${basePath}/create`}
-              className="rounded-full w-8 h-8 flex items-center justify-center bg-primary text-primary-foreground"
-              aria-label="Loo uus"
-            >
-              <Plus className="w-4 h-4" />
-            </Link>
-          )}
+          <div className="flex items-center gap-2">
+            <KopikasUserMenu />
+            {user && (
+              <Link
+                to={`${basePath}/create`}
+                className="rounded-full w-8 h-8 flex items-center justify-center bg-primary text-primary-foreground"
+                aria-label="Loo uus"
+              >
+                <Plus className="w-4 h-4" />
+              </Link>
+            )}
+          </div>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- Add `KopikasUserMenu` component: avatar dropdown with sign-out when authenticated, Google "G" sign-in button when not
- Integrate into WalletList header (between logo and create button) and KopikasParentLayout header (right side)
- Uses `useKopikasAuth()` — no dependency on Spl1t's auth context

## Test plan
- [ ] Visit kopikas.xtian.me signed in → avatar visible in wallet list and parent view headers
- [ ] Click avatar → dropdown shows name, email, "Logi välja"
- [ ] Sign out → Google "G" button replaces avatar
- [ ] Click "G" → triggers Google OAuth sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)