### PR TITLE
fix(kopikas): move link/meta tags before swap script in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-visual" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Spl1t" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="theme-color" content="#e8613a" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1A1A2E" media="(prefers-color-scheme: dark)" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png?v=2" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <script>
       (function () {
         try {
@@ -34,18 +46,6 @@
         } catch (e) {}
       })();
     </script>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png?v=2" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
-    <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-visual" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Spl1t" />
-    <meta name="mobile-web-app-capable" content="yes" />
-    <meta name="theme-color" content="#e8613a" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#1A1A2E" media="(prefers-color-scheme: dark)" />
     <title>Spl1t</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- The Kopikas branding swap script in `index.html` ran before `<link>` and `<meta>` tags were parsed, so `querySelector` returned `null` and PWA icons/manifest were never swapped
- Reordered `<head>` so all targeted tags appear before the script block
- "Add to Home Screen" on kopikas.xtian.me now correctly shows Kopikas name and icon

## Test plan
- [x] `npm run build` succeeds
- [x] Built `dist/index.html` has link/meta tags before swap script
- [ ] Deploy → kopikas.xtian.me "Add to Home Screen" shows "Kopikas" branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)