### PR TITLE
fix(kopikas): wrap embedded routes with KopikasAuthBridge

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -20,6 +20,7 @@ import { QuickGroupDetailPage } from './pages/QuickGroupDetailPage'
 import { QuickHistoryPage } from './pages/QuickHistoryPage'
 import { KopikasLayout } from './kopikas/components/KopikasLayout'
 import { KopikasParentLayout } from './kopikas/components/KopikasParentLayout'
+import { KopikasAuthBridge } from './kopikas/components/KopikasAuthBridge'
 import { KopikasHome } from './kopikas/pages/KopikasHome'
 import { Analytics } from './kopikas/pages/Analytics'
 import { PetDetail } from './kopikas/pages/PetDetail'
@@ -72,8 +73,8 @@ export function AppRoutes() {
       </Route>
 
       {/* Kopikas routes — outside Spl1t layouts */}
-      <Route path="kopikas" element={<ErrorBoundary><WalletList /></ErrorBoundary>} />
-      <Route path="kopikas/create" element={<ErrorBoundary><CreateWallet /></ErrorBoundary>} />
+      <Route path="kopikas" element={<ErrorBoundary><KopikasAuthBridge><WalletList /></KopikasAuthBridge></ErrorBoundary>} />
+      <Route path="kopikas/create" element={<ErrorBoundary><KopikasAuthBridge><CreateWallet /></KopikasAuthBridge></ErrorBoundary>} />
       <Route path="kopikas/:walletCode" element={<KopikasLayout />}>
         <Route index element={<ErrorBoundary><KopikasHome /></ErrorBoundary>} />
         <Route path="analytics" element={<ErrorBoundary><Analytics /></ErrorBoundary>} />


### PR DESCRIPTION
## Summary
- Back button from Kopikas parent view (`/kopikas/:walletCode/parent`) navigates to `/kopikas` which crashed with `useKopikasAuth must be used within KopikasAuthProvider`
- Root cause: `WalletList` and `CreateWallet` routes in `routes.tsx` were not wrapped with `KopikasAuthBridge`, unlike the layout-based Kopikas routes which include it internally
- Wrapped both standalone routes with `KopikasAuthBridge` to bridge Spl1t auth into Kopikas auth context

## Test plan
- [ ] Navigate to a Kopikas wallet from Spl1t home page → parent view loads
- [ ] Press back arrow → wallet list renders without crash
- [ ] Navigate to `/kopikas/create` from wallet list → create page renders without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)