### PR TITLE
fix: remove Kopikas section from Spl1t home page

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -25,7 +25,6 @@ import { useUserPreferences } from '@/contexts/UserPreferencesContext'
 import { useMyTripBalances } from '@/hooks/useMyTripBalances'
 import { motion } from 'framer-motion'
 import { ThemeToggle } from '@/components/ThemeToggle'
-import { KopikasHomeSection } from '@/kopikas/components/KopikasHomeSection'
 
 const DEMO_TRIP_CODE = 'livigno-2025'
 
@@ -450,9 +449,6 @@ export function HomePage() {
         <div>
           {isAuthenticated ? renderAuthenticatedTrips() : renderLocalTrips()}
         </div>
-
-        {/* Kopikas section — authenticated parents */}
-        {user && <KopikasHomeSection userId={user.id} />}
 
         {/* Footer: theme toggle (for anon users) + What's New */}
         <div className="mt-8 flex flex-col items-center gap-3">


### PR DESCRIPTION
## Summary
- Removes the `KopikasHomeSection` integration from the Spl1t home page
- Kopikas is a standalone product at kopikas.xtian.me and should not appear on the Spl1t home screen
- The embedded `/kopikas/*` routes in `routes.tsx` remain for direct URL access

## Test plan
- [ ] Load Spl1t home page as authenticated user — no Kopikas section visible
- [ ] Kopikas standalone at kopikas.xtian.me still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)