### PR TITLE
feat(kopikas): group scanned receipt items in transaction list

### DIFF
--- a/src/kopikas/components/ScanFlow.tsx
+++ b/src/kopikas/components/ScanFlow.tsx
@@ -34,6 +34,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
   const [processing, setProcessing] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [receiptImagePath, setReceiptImagePath] = useState<string | null>(null)
+  const [merchant, setMerchant] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [editingCategory, setEditingCategory] = useState<number | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -71,6 +72,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
       }
 
       setReceiptImagePath(parsed.receipt_image_path || null)
+      setMerchant(parsed.merchant || null)
       setItems(parsed.items.map((item: { name?: string; price?: number; qty?: number; category?: string }) => ({
         name: item.name || 'Tundmatu',
         price: Number(item.price) || 0,
@@ -113,7 +115,10 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
     setSubmitting(true)
 
     try {
-      // Create one transaction per item (all share the same receipt image)
+      // All items from one scan share a batch ID for grouping
+      const batchId = crypto.randomUUID()
+
+      // Create one transaction per item (all share the same receipt image + batch)
       for (const item of items) {
         await addTransaction({
           wallet_id: wallet.id,
@@ -122,6 +127,8 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
           description: item.name,
           category: item.category,
           receipt_image_path: receiptImagePath ?? undefined,
+          receipt_batch_id: batchId,
+          vendor: merchant ?? undefined,
         })
       }
 
@@ -144,6 +151,7 @@ export function ScanFlow({ open, onClose }: ScanFlowProps) {
       setError(null)
       setEditingCategory(null)
       setReceiptImagePath(null)
+      setMerchant(null)
     }, 300)
   }
 

--- a/src/kopikas/components/TransactionList.tsx
+++ b/src/kopikas/components/TransactionList.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import type { WalletTransaction } from '../types'
 import { getCategoryEmoji } from '../lib/kopikasCategories'
 import { supabase } from '@/lib/supabase'
-import { Wallet, Receipt, X } from 'lucide-react'
+import { Wallet, Receipt, X, ChevronDown, ChevronRight } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 
 interface TransactionListProps {
@@ -33,11 +33,88 @@ function getReceiptUrl(path: string): string {
   return data.publicUrl
 }
 
-export function TransactionList({ transactions, limit }: TransactionListProps) {
-  const items = limit ? transactions.slice(0, limit) : transactions
-  const [receiptUrl, setReceiptUrl] = useState<string | null>(null)
+type ListEntry =
+  | { kind: 'single'; tx: WalletTransaction }
+  | { kind: 'group'; groupKey: string; vendor: string | null; total: number; date: string; receiptImagePath: string | null; items: WalletTransaction[] }
 
-  if (items.length === 0) {
+function buildGroupedList(transactions: WalletTransaction[]): ListEntry[] {
+  // Pre-compute how many transactions share each grouping key
+  const keyCounts = new Map<string, number>()
+  for (const tx of transactions) {
+    const key = tx.receipt_batch_id ?? tx.receipt_image_path
+    if (key) keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1)
+  }
+
+  const batchMap = new Map<string, WalletTransaction[]>()
+  const ungrouped: WalletTransaction[] = []
+
+  for (const tx of transactions) {
+    const key = tx.receipt_batch_id ?? tx.receipt_image_path
+    if (key && (keyCounts.get(key) ?? 0) > 1) {
+      const existing = batchMap.get(key)
+      if (existing) {
+        existing.push(tx)
+      } else {
+        batchMap.set(key, [tx])
+      }
+    } else {
+      ungrouped.push(tx)
+    }
+  }
+
+  const entries: ListEntry[] = []
+
+  // Merge groups and singles in chronological order (newest first)
+  // Use earliest transaction date as group date for sorting
+  const groupEntries: ListEntry[] = []
+  for (const [groupKey, items] of batchMap) {
+    const sortedItems = [...items].sort((a, b) => a.created_at.localeCompare(b.created_at))
+    const total = items.reduce((sum, tx) => sum + tx.amount, 0)
+    const vendor = items[0].vendor
+    const receiptImagePath = items.find(tx => tx.receipt_image_path)?.receipt_image_path ?? null
+    groupEntries.push({
+      kind: 'group',
+      groupKey,
+      vendor,
+      total,
+      date: items[0].created_at,
+      receiptImagePath,
+      items: sortedItems,
+    })
+  }
+
+  const singleEntries: ListEntry[] = ungrouped.map(tx => ({ kind: 'single', tx }))
+
+  // Merge and sort by date descending
+  entries.push(...groupEntries, ...singleEntries)
+  entries.sort((a, b) => {
+    const dateA = a.kind === 'single' ? a.tx.created_at : a.date
+    const dateB = b.kind === 'single' ? b.tx.created_at : b.date
+    return dateB.localeCompare(dateA)
+  })
+
+  return entries
+}
+
+export function TransactionList({ transactions, limit }: TransactionListProps) {
+  const [receiptUrl, setReceiptUrl] = useState<string | null>(null)
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
+
+  const entries = useMemo(() => {
+    const grouped = buildGroupedList(transactions)
+    return limit ? grouped.slice(0, limit) : grouped
+  }, [transactions, limit])
+
+  const toggleGroup = (key: string) => {
+    setExpandedGroups(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  if (entries.length === 0) {
     return (
       <div className="py-8 text-center text-muted-foreground text-sm">
         Tehinguid pole veel
@@ -48,43 +125,108 @@ export function TransactionList({ transactions, limit }: TransactionListProps) {
   return (
     <>
       <ul className="divide-y divide-border">
-        {items.map(tx => (
-          <li
-            key={tx.id}
-            className={`flex items-center gap-3 py-3 px-1 ${tx.receipt_image_path ? 'cursor-pointer hover:bg-muted/50 rounded-lg transition-colors' : ''}`}
-            onClick={() => {
-              if (tx.receipt_image_path) {
-                setReceiptUrl(getReceiptUrl(tx.receipt_image_path))
-              }
-            }}
-          >
-            <div className="w-8 h-8 rounded-full shrink-0 flex items-center justify-center">
-              {tx.type === 'allowance'
-                ? <Wallet size={18} className="text-green-500" />
-                : <span className="text-lg">{getCategoryEmoji(tx.category!)}</span>
-              }
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm truncate">
-                {tx.description || (tx.type === 'allowance' ? 'Taskuraha' : 'Kulu')}
-              </p>
-              <p className="text-xs text-muted-foreground flex items-center gap-1">
-                {relativeDate(tx.created_at)}
-                {tx.receipt_image_path && <Receipt size={12} className="text-muted-foreground" />}
-              </p>
-            </div>
-            <span className={`text-sm font-medium tabular-nums ${
-              tx.type === 'allowance' ? 'text-green-500' : 'text-foreground'
-            }`}>
-              {tx.type === 'allowance' ? '+' : '-'}{formatAmount(tx.amount)}
-            </span>
-          </li>
-        ))}
+        {entries.map(entry => {
+          if (entry.kind === 'single') {
+            const tx = entry.tx
+            return (
+              <li
+                key={tx.id}
+                className={`flex items-center gap-3 py-3 px-1 ${tx.receipt_image_path ? 'cursor-pointer hover:bg-muted/50 rounded-lg transition-colors' : ''}`}
+                onClick={() => {
+                  if (tx.receipt_image_path) {
+                    setReceiptUrl(getReceiptUrl(tx.receipt_image_path))
+                  }
+                }}
+              >
+                <div className="w-8 h-8 rounded-full shrink-0 flex items-center justify-center">
+                  {tx.type === 'allowance'
+                    ? <Wallet size={18} className="text-green-500" />
+                    : <span className="text-lg">{getCategoryEmoji(tx.category!)}</span>
+                  }
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm truncate">
+                    {tx.description || (tx.type === 'allowance' ? 'Taskuraha' : 'Kulu')}
+                  </p>
+                  <p className="text-xs text-muted-foreground flex items-center gap-1">
+                    {relativeDate(tx.created_at)}
+                    {tx.receipt_image_path && <Receipt size={12} className="text-muted-foreground" />}
+                  </p>
+                </div>
+                <span className={`text-sm font-medium tabular-nums ${
+                  tx.type === 'allowance' ? 'text-green-500' : 'text-foreground'
+                }`}>
+                  {tx.type === 'allowance' ? '+' : '-'}{formatAmount(tx.amount)}
+                </span>
+              </li>
+            )
+          }
+
+          // Receipt group
+          const isExpanded = expandedGroups.has(entry.groupKey)
+          return (
+            <li key={entry.groupKey} className="py-1">
+              {/* Group header */}
+              <div
+                className="flex items-center gap-3 py-3 px-1 cursor-pointer hover:bg-muted/50 rounded-lg transition-colors"
+                onClick={() => toggleGroup(entry.groupKey)}
+              >
+                <div className="w-8 h-8 rounded-full shrink-0 flex items-center justify-center bg-muted">
+                  <Receipt size={16} className="text-muted-foreground" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">
+                    {entry.vendor || 'Kviitung'}
+                  </p>
+                  <p className="text-xs text-muted-foreground flex items-center gap-1">
+                    {relativeDate(entry.date)}
+                    <span className="text-muted-foreground/60">·</span>
+                    {entry.items.length} kirjet
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium tabular-nums">
+                    -{formatAmount(entry.total)}
+                  </span>
+                  {isExpanded
+                    ? <ChevronDown size={16} className="text-muted-foreground" />
+                    : <ChevronRight size={16} className="text-muted-foreground" />
+                  }
+                </div>
+              </div>
+
+              {/* Expanded items */}
+              {isExpanded && (
+                <div className="ml-4 border-l-2 border-border pl-3 mb-2">
+                  {entry.items.map(tx => (
+                    <div key={tx.id} className="flex items-center gap-2 py-1.5">
+                      <span className="text-sm shrink-0">{getCategoryEmoji(tx.category!)}</span>
+                      <p className="text-sm truncate flex-1 text-muted-foreground">{tx.description || 'Kulu'}</p>
+                      <span className="text-sm tabular-nums text-muted-foreground">{formatAmount(tx.amount)}</span>
+                    </div>
+                  ))}
+                  {entry.receiptImagePath && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setReceiptUrl(getReceiptUrl(entry.receiptImagePath!))
+                      }}
+                      className="flex items-center gap-1.5 text-xs text-primary hover:underline mt-1 mb-1"
+                    >
+                      <Receipt size={12} />
+                      Vaata kviitungit
+                    </button>
+                  )}
+                </div>
+              )}
+            </li>
+          )
+        })}
       </ul>
 
       {/* Receipt image viewer */}
       <Sheet open={!!receiptUrl} onOpenChange={(open) => { if (!open) setReceiptUrl(null) }}>
-        <SheetContent side="bottom" hideClose className="flex flex-col p-0 rounded-t-2xl" style={{ height: '85dvh' }}>
+        <SheetContent side="bottom" hideClose className="flex flex-col p-0 rounded-t-2xl" style={{ height: '75dvh' }}>
           <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border">
             <div className="w-8" />
             <SheetTitle>Kviitung</SheetTitle>
@@ -98,7 +240,7 @@ export function TransactionList({ transactions, limit }: TransactionListProps) {
               <img
                 src={receiptUrl}
                 alt="Kviitung"
-                className="max-w-full rounded-lg"
+                className="max-w-full max-h-[60vh] object-contain rounded-lg"
               />
             )}
           </div>

--- a/src/kopikas/contexts/PetContext.test.tsx
+++ b/src/kopikas/contexts/PetContext.test.tsx
@@ -41,9 +41,11 @@ function makeTransaction(overrides: Partial<WalletTransaction> = {}): WalletTran
     description: 'candy',
     category: 'sweets',
     receipt_image_path: null,
+    receipt_batch_id: null,
+    vendor: null,
     created_at: new Date().toISOString(),
     ...overrides,
-  }
+  } as WalletTransaction
 }
 
 function TestConsumer() {

--- a/src/kopikas/contexts/WalletContext.test.tsx
+++ b/src/kopikas/contexts/WalletContext.test.tsx
@@ -34,6 +34,8 @@ const sampleTransactions: WalletTransaction[] = [
     description: 'Weekly allowance',
     category: null,
     receipt_image_path: null,
+    receipt_batch_id: null,
+    vendor: null,
     created_at: '2025-01-07T10:00:00Z',
   },
   {
@@ -44,6 +46,8 @@ const sampleTransactions: WalletTransaction[] = [
     description: 'Sweets',
     category: 'sweets',
     receipt_image_path: null,
+    receipt_batch_id: null,
+    vendor: null,
     created_at: '2025-01-08T12:00:00Z',
   },
   {
@@ -54,6 +58,8 @@ const sampleTransactions: WalletTransaction[] = [
     description: 'Bonus',
     category: null,
     receipt_image_path: null,
+    receipt_batch_id: null,
+    vendor: null,
     created_at: '2025-01-09T10:00:00Z',
   },
 ]
@@ -244,6 +250,8 @@ describe('WalletContext', () => {
       description: 'Birthday money',
       category: null,
       receipt_image_path: null,
+      receipt_batch_id: null,
+      vendor: null,
       created_at: new Date().toISOString(),
     }
 

--- a/src/kopikas/contexts/WalletContext.tsx
+++ b/src/kopikas/contexts/WalletContext.tsx
@@ -144,6 +144,8 @@ export function WalletProvider({ walletCode, children }: WalletProviderProps) {
       description: input.description ?? null,
       category: input.category ?? null,
       receipt_image_path: input.receipt_image_path ?? null,
+      receipt_batch_id: input.receipt_batch_id ?? null,
+      vendor: input.vendor ?? null,
       created_at: new Date().toISOString(),
     }
     setTransactions((prev) => [optimisticTx, ...prev])

--- a/src/kopikas/lib/petMoodCalculator.test.ts
+++ b/src/kopikas/lib/petMoodCalculator.test.ts
@@ -15,9 +15,11 @@ function tx(overrides: Partial<WalletTransaction>): WalletTransaction {
     description: null,
     category: 'food',
     receipt_image_path: null,
+    receipt_batch_id: null,
+    vendor: null,
     created_at: day(0),
     ...overrides,
-  }
+  } as WalletTransaction
 }
 
 describe('calculateMood', () => {

--- a/src/kopikas/lib/xpCalculator.test.ts
+++ b/src/kopikas/lib/xpCalculator.test.ts
@@ -37,8 +37,9 @@ describe('xpCalculator', () => {
       return {
         id: crypto.randomUUID(), wallet_id: 'w1', type: 'expense',
         amount: 5, description: null, category: 'food',
-        receipt_image_path: null, created_at: day(0), ...overrides,
-      }
+        receipt_image_path: null, receipt_batch_id: null, vendor: null,
+        created_at: day(0), ...overrides,
+      } as WalletTransaction
     }
 
     it('awards under-budget bonus when balance > 0 after full week', () => {

--- a/src/kopikas/types.ts
+++ b/src/kopikas/types.ts
@@ -30,6 +30,8 @@ export interface WalletTransaction {
   description: string | null
   category: KopikasCategory | null
   receipt_image_path: string | null
+  receipt_batch_id: string | null
+  vendor: string | null
   created_at: string
 }
 
@@ -40,6 +42,8 @@ export interface CreateTransactionInput {
   description?: string
   category?: KopikasCategory
   receipt_image_path?: string
+  receipt_batch_id?: string
+  vendor?: string
 }
 
 export interface WalletPet {

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -111,9 +111,11 @@ export function buildWalletTransaction(
     description: `Transaction ${id}`,
     category: 'food',
     receipt_image_path: null,
+    receipt_batch_id: null,
+    vendor: null,
     created_at: '2026-03-15T10:00:00Z',
     ...overrides,
-  }
+  } as WalletTransaction
 }
 
 export function buildWalletPet(overrides: Partial<WalletPet> = {}): WalletPet {

--- a/supabase/migrations/043_kopikas_receipt_grouping.sql
+++ b/supabase/migrations/043_kopikas_receipt_grouping.sql
@@ -1,0 +1,9 @@
+-- Add receipt grouping columns to wallet_transactions
+ALTER TABLE wallet_transactions
+  ADD COLUMN IF NOT EXISTS receipt_batch_id UUID,
+  ADD COLUMN IF NOT EXISTS vendor TEXT;
+
+-- Index for efficient grouping queries
+CREATE INDEX IF NOT EXISTS idx_wallet_transactions_receipt_batch_id
+  ON wallet_transactions (receipt_batch_id)
+  WHERE receipt_batch_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Add `receipt_batch_id` and `vendor` columns to `wallet_transactions` (migration 043)
- Capture `merchant` from edge function response and generate a batch UUID per scan in `ScanFlow`
- Redesign `TransactionList` to group receipt items under collapsible vendor rows with item count and total
- Legacy transactions with shared `receipt_image_path` are grouped as fallback
- Reduce receipt image viewer sheet from `85dvh` to `75dvh` with `max-h-[60vh] object-contain`

## Test plan
- [ ] Existing transactions render as individual rows (no batch ID = flat list)
- [ ] Scan a receipt → items grouped under vendor name with total
- [ ] Click group → expands to show items with category emojis
- [ ] Receipt image viewer opens at smaller size, image doesn't overflow
- [ ] Manual single-item entries still render as individual rows
- [ ] Apply migration 043 to Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)