### PR TITLE
fix(kopikas): notch safe area, PWA name, and Google auth branding

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -1,0 +1,61 @@
+// Cloudflare Pages Function — rewrite HTML meta tags for Kopikas subdomain
+// so iOS reads "Kopikas" instead of "Spl1t" at Add to Home Screen time.
+
+export const onRequest: PagesFunction = async (context) => {
+  const response = await context.next()
+  const contentType = response.headers.get('content-type') || ''
+
+  // Only rewrite HTML responses on kopikas.* hostname
+  if (!contentType.includes('text/html')) return response
+  const hostname = new URL(context.request.url).hostname
+  if (!hostname.startsWith('kopikas.')) return response
+
+  let html = await response.text()
+
+  // Swap apple-mobile-web-app-title
+  html = html.replace(
+    'content="Spl1t"',
+    'content="Kopikas"'
+  )
+
+  // Swap <title>
+  html = html.replace(
+    '<title>Spl1t</title>',
+    '<title>Kopikas</title>'
+  )
+
+  // Swap theme-color
+  html = html.replace(
+    /content="#e8613a"/g,
+    'content="#d97706"'
+  )
+  html = html.replace(
+    /content="#1A1A2E"/g,
+    'content="#d97706"'
+  )
+
+  // Swap manifest
+  html = html.replace(
+    'href="/manifest.webmanifest"',
+    'href="/kopikas-manifest.webmanifest"'
+  )
+
+  // Swap icons
+  html = html.replace(
+    'href="/favicon.png?v=2"',
+    'href="/kopikas-favicon.png"'
+  )
+  html = html.replace(
+    'href="/favicon-16.png?v=2"',
+    'href="/kopikas-favicon.png"'
+  )
+  html = html.replace(
+    'href="/apple-touch-icon.png?v=2"',
+    'href="/kopikas-apple-touch-icon.png"'
+  )
+
+  return new Response(html, {
+    status: response.status,
+    headers: response.headers,
+  })
+}

--- a/src/kopikas/app/KopikasApp.tsx
+++ b/src/kopikas/app/KopikasApp.tsx
@@ -1,20 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BrowserRouter } from 'react-router-dom'
+import { GoogleOAuthProvider } from '@react-oauth/google'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { KopikasAuthProvider } from './KopikasAuthProvider'
 import { KopikasThemeProvider } from './KopikasThemeProvider'
 import { KopikasAppRoutes } from './KopikasAppRoutes'
 
+const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID || ''
+
 export function KopikasApp() {
   return (
-    <BrowserRouter>
-      <ErrorBoundary>
-        <KopikasAuthProvider>
-          <KopikasThemeProvider>
-            <KopikasAppRoutes />
-          </KopikasThemeProvider>
-        </KopikasAuthProvider>
-      </ErrorBoundary>
-    </BrowserRouter>
+    <GoogleOAuthProvider clientId={googleClientId}>
+      <BrowserRouter>
+        <ErrorBoundary>
+          <KopikasAuthProvider>
+            <KopikasThemeProvider>
+              <KopikasAppRoutes />
+            </KopikasThemeProvider>
+          </KopikasAuthProvider>
+        </ErrorBoundary>
+      </BrowserRouter>
+    </GoogleOAuthProvider>
   )
 }

--- a/src/kopikas/app/KopikasAuthProvider.tsx
+++ b/src/kopikas/app/KopikasAuthProvider.tsx
@@ -7,7 +7,7 @@ import { logger } from '@/lib/logger'
 export interface KopikasAuthContextValue {
   user: User | null
   loading: boolean
-  signInWithGoogle: () => Promise<void>
+  signInWithGoogle: (credential: string) => Promise<void>
   signOut: () => Promise<void>
 }
 
@@ -33,10 +33,10 @@ export function KopikasAuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe()
   }, [])
 
-  const signInWithGoogle = async () => {
-    const { error } = await supabase.auth.signInWithOAuth({
+  const signInWithGoogle = async (credential: string) => {
+    const { error } = await supabase.auth.signInWithIdToken({
       provider: 'google',
-      options: { redirectTo: window.location.origin },
+      token: credential,
     })
     if (error) {
       logger.error('Google sign-in failed', { error: error.message })

--- a/src/kopikas/app/KopikasLandingPage.tsx
+++ b/src/kopikas/app/KopikasLandingPage.tsx
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useKopikasAuth } from './KopikasAuthProvider'
 import { Pet } from '../components/Pet'
+import { GoogleLogin } from '@react-oauth/google'
+import { logger } from '@/lib/logger'
 import { ScanLine, Heart, Users } from 'lucide-react'
 
 export function KopikasLandingPage() {
@@ -8,7 +10,7 @@ export function KopikasLandingPage() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="py-6 px-4 flex justify-center">
+      <header className="py-6 px-4 flex justify-center pwa-safe-top">
         <img src="/kopikas-logo.png" alt="Kopikas" className="h-10" />
       </header>
 
@@ -54,12 +56,19 @@ export function KopikasLandingPage() {
           </div>
         </div>
 
-        <button
-          onClick={signInWithGoogle}
-          className="w-full py-3 rounded-xl bg-primary text-primary-foreground font-medium mb-4"
-        >
-          Alusta — logi sisse
-        </button>
+        <GoogleLogin
+          onSuccess={(response) => {
+            if (response.credential) {
+              signInWithGoogle(response.credential)
+            }
+          }}
+          onError={() => {
+            logger.error('Google Sign-In failed')
+          }}
+          size="large"
+          theme="outline"
+          text="signin_with"
+        />
 
         <p className="text-xs text-muted-foreground text-center">
           Oled laps? Küsi oma linki vanemalt.

--- a/src/kopikas/app/KopikasLoginPage.tsx
+++ b/src/kopikas/app/KopikasLoginPage.tsx
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useKopikasAuth } from './KopikasAuthProvider'
 import { Navigate } from 'react-router-dom'
+import { GoogleLogin } from '@react-oauth/google'
+import { logger } from '@/lib/logger'
 import { Loader2 } from 'lucide-react'
 
 export function KopikasLoginPage() {
@@ -23,18 +25,19 @@ export function KopikasLoginPage() {
         <p className="text-muted-foreground">Lapse taskuraha, mänguliselt</p>
       </div>
 
-      <button
-        onClick={signInWithGoogle}
-        className="flex items-center gap-3 px-6 py-3 rounded-xl bg-card border border-border hover:bg-muted transition-colors"
-      >
-        <svg viewBox="0 0 24 24" className="w-5 h-5" aria-hidden="true">
-          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-        </svg>
-        <span className="font-medium">Logi sisse Google'iga</span>
-      </button>
+      <GoogleLogin
+        onSuccess={(response) => {
+          if (response.credential) {
+            signInWithGoogle(response.credential)
+          }
+        }}
+        onError={() => {
+          logger.error('Google Sign-In failed')
+        }}
+        size="large"
+        theme="outline"
+        text="signin_with"
+      />
     </div>
   )
 }

--- a/src/kopikas/components/KopikasLayout.tsx
+++ b/src/kopikas/components/KopikasLayout.tsx
@@ -19,7 +19,7 @@ function KopikasInner() {
   return (
     <PetProvider walletId={wallet?.id ?? null} transactions={transactions}>
       <div className="min-h-screen bg-background text-foreground">
-        <main className="pb-16">
+        <main className="pb-16 pwa-safe-top">
           <Outlet />
         </main>
         <KopikasTabBar />

--- a/src/kopikas/components/KopikasParentLayout.tsx
+++ b/src/kopikas/components/KopikasParentLayout.tsx
@@ -22,7 +22,7 @@ function ParentInner() {
   return (
     <PetProvider walletId={wallet?.id ?? null} transactions={transactions}>
       <div className="min-h-screen bg-background text-foreground">
-        <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
+        <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur pwa-safe-top">
           <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
             <div className="flex items-center gap-3">
               <button

--- a/src/kopikas/components/KopikasUserMenu.tsx
+++ b/src/kopikas/components/KopikasUserMenu.tsx
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useKopikasAuth } from '../app/KopikasAuthProvider'
+import { GoogleLogin } from '@react-oauth/google'
+import { logger } from '@/lib/logger'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,30 +16,20 @@ export function KopikasUserMenu() {
 
   if (!user) {
     return (
-      <button
-        onClick={signInWithGoogle}
-        className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors"
-        aria-label="Logi sisse"
-      >
-        <svg viewBox="0 0 24 24" className="w-5 h-5">
-          <path
-            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-            fill="#4285F4"
-          />
-          <path
-            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-            fill="#34A853"
-          />
-          <path
-            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.77.42 3.45 1.18 4.93l3.66-2.84z"
-            fill="#FBBC05"
-          />
-          <path
-            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-            fill="#EA4335"
-          />
-        </svg>
-      </button>
+      <GoogleLogin
+        onSuccess={(response) => {
+          if (response.credential) {
+            signInWithGoogle(response.credential)
+          }
+        }}
+        onError={() => {
+          logger.error('Google Sign-In failed')
+        }}
+        size="medium"
+        type="icon"
+        shape="circle"
+        theme="outline"
+      />
     )
   }
 

--- a/src/kopikas/pages/CreateWallet.tsx
+++ b/src/kopikas/pages/CreateWallet.tsx
@@ -77,7 +77,7 @@ export function CreateWallet() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
+      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur pwa-safe-top">
         <div className="max-w-lg mx-auto px-4 h-14 flex items-center gap-3">
           <button onClick={() => navigate(-1)}
             className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors">

--- a/src/kopikas/pages/WalletList.tsx
+++ b/src/kopikas/pages/WalletList.tsx
@@ -60,7 +60,7 @@ export function WalletList() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
+      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur pwa-safe-top">
         <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
           <img src="/kopikas-logo.png" alt="Kopikas" className="h-7" />
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Add `pwa-safe-top` to all Kopikas headers/layouts for iPhone notch clearance in PWA mode
- Add Cloudflare Pages Function (`functions/[[path]].ts`) to rewrite HTML meta/title/manifest for `kopikas.*` hostname at the edge, fixing iOS "Add to Home Screen" showing "Spl1t"
- Switch from `signInWithOAuth` to `signInWithIdToken` + `GoogleLogin` component so Google consent screen shows app domain instead of Supabase project URL

## Test plan
- [ ] iPhone PWA: logo no longer hidden behind notch
- [ ] Add to Home Screen on kopikas.xtian.me shows "Kopikas" as name
- [ ] Google sign-in screen shows "xtian.me" instead of Supabase URL
- [ ] Sign-in works on landing page, login page, and user menu icon
- [ ] Ensure `https://kopikas.xtian.me` is in Google Cloud Console authorized JS origins

🤖 Generated with [Claude Code](https://claude.com/claude-code)