### PR TITLE
fix(kopikas): show child view back arrow only for authenticated users

### DIFF
--- a/src/kopikas/components/KopikasLayout.tsx
+++ b/src/kopikas/components/KopikasLayout.tsx
@@ -8,11 +8,13 @@ import { KopikasTabBar } from './KopikasTabBar'
 import { NamePetSheet } from './NamePetSheet'
 import { useWallet } from '../hooks/useWallet'
 import { useKopikasBasePath } from '../hooks/useKopikasBasePath'
+import { useKopikasAuth } from '../app/KopikasAuthProvider'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { ArrowLeft } from 'lucide-react'
 
 function KopikasInner() {
   const { wallet, transactions } = useWallet()
+  const { user } = useKopikasAuth()
   const navigate = useNavigate()
   const basePath = useKopikasBasePath()
 
@@ -23,17 +25,19 @@ function KopikasInner() {
   return (
     <PetProvider walletId={wallet?.id ?? null} transactions={transactions}>
       <div className="min-h-screen bg-background text-foreground">
-        <header className="sticky top-0 z-40 bg-background/95 backdrop-blur pwa-safe-top">
-          <div className="max-w-lg mx-auto px-4 h-10 flex items-center">
-            <button
-              onClick={() => navigate(basePath || '/')}
-              className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors -ml-1"
-              aria-label="Tagasi"
-            >
-              <ArrowLeft className="w-4 h-4 text-muted-foreground" />
-            </button>
-          </div>
-        </header>
+        {user && (
+          <header className="sticky top-0 z-40 bg-background/95 backdrop-blur pwa-safe-top">
+            <div className="max-w-lg mx-auto px-4 h-10 flex items-center">
+              <button
+                onClick={() => navigate(basePath || '/')}
+                className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-muted transition-colors -ml-1"
+                aria-label="Tagasi"
+              >
+                <ArrowLeft className="w-4 h-4 text-muted-foreground" />
+              </button>
+            </div>
+          </header>
+        )}
         <main className="pb-16">
           <Outlet />
         </main>


### PR DESCRIPTION
## Summary
- Gate the back arrow in KopikasLayout behind `user` check
- Kids (unauthenticated) see no back button — they stay in their wallet
- Parents (authenticated) can navigate back to wallet list

## Test plan
- [x] Build passes
- [ ] Unauthenticated kid view: no back arrow visible
- [ ] Authenticated parent in child view: back arrow visible and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)