### PR TITLE
fix(kopikas): pig clipping in evolution row and false 'miss you' mood

### DIFF
--- a/src/kopikas/components/PetSpeechBubble.tsx
+++ b/src/kopikas/components/PetSpeechBubble.tsx
@@ -9,7 +9,7 @@ function pickMessage(mood: MoodResult): string {
   const { signals } = mood
 
   // Priority order: specific concerns first, then positive feedback
-  if (signals.loggingConsistency < 0.3) {
+  if (signals.loggingConsistency === 0) {
     return 'Ma igatsen sind... Lisa midagi! 😴'
   }
   if (signals.categoryDiversity < 0.3) {

--- a/src/kopikas/lib/petMoodCalculator.test.ts
+++ b/src/kopikas/lib/petMoodCalculator.test.ts
@@ -83,6 +83,12 @@ describe('calculateMood', () => {
     expect(result.signals.loggingConsistency).toBe(0)
   })
 
+  it('logging consistency returns 0.5 when only allowances exist (no expenses ever)', () => {
+    const allowance = tx({ type: 'allowance', amount: 50, category: null, created_at: day(0) })
+    const result = calculateMood([allowance], now)
+    expect(result.signals.loggingConsistency).toBeCloseTo(0.5)
+  })
+
   it('category diversity returns ~0.67 for 2 balanced categories', () => {
     const allowance = tx({ type: 'allowance', amount: 50, category: null, created_at: day(6) })
     const expenses = [

--- a/src/kopikas/lib/petMoodCalculator.ts
+++ b/src/kopikas/lib/petMoodCalculator.ts
@@ -73,9 +73,13 @@ function loggingConsistencySignal(transactions: WalletTransaction[], now: Date):
   // No transactions at all → neutral default
   if (transactions.length === 0) return 0.5
 
+  // Has transactions but no expenses ever (e.g. only allowances) → neutral
+  const allExpenses = transactions.filter((t) => t.type === 'expense')
+  if (allExpenses.length === 0) return 0.5
+
   const sevenDaysAgo = new Date(now.getTime() - 7 * 86400000)
-  const recentExpenses = transactions.filter(
-    (t) => t.type === 'expense' && new Date(t.created_at) >= sevenDaysAgo
+  const recentExpenses = allExpenses.filter(
+    (t) => new Date(t.created_at) >= sevenDaysAgo
   )
 
   if (recentExpenses.length === 0) return 0

--- a/src/kopikas/pages/PetDetail.tsx
+++ b/src/kopikas/pages/PetDetail.tsx
@@ -94,7 +94,7 @@ export function PetDetail() {
       {/* Evolution history */}
       <div>
         <h2 className="font-semibold mb-3">Evolutsioon</h2>
-        <div className="flex gap-4 overflow-x-auto pb-2">
+        <div className="flex gap-4 overflow-x-auto pt-4 pb-2 -mt-4">
           {PET_LEVELS.filter(l => l.level <= pet.level).map(l => (
             <div key={l.level} className="flex flex-col items-center gap-1 shrink-0">
               <Pet


### PR DESCRIPTION
## Summary
- Evolution row: `overflow-x-auto` was clipping pig ears/crown/sparkles vertically. Added internal top padding with negative margin to give room.
- "Ma igatsen sind" speech bubble fired incorrectly when child had only allowances (no expenses ever) or logged just 1 day this week (signal=0.2 < 0.3 threshold). Fixed by returning neutral for no-expenses-ever and tightening the speech bubble to only trigger at signal === 0 (truly absent 3+ days).

## Test plan
- [x] All 246 tests pass (including new test for allowance-only scenario)
- [ ] Manual: check evolution row pigs have visible ears, not clipped
- [ ] Manual: add an allowance only → pig should NOT say "Ma igatsen sind"
- [ ] Manual: add 1 expense today → pig should NOT say "Ma igatsen sind"

🤖 Generated with [Claude Code](https://claude.com/claude-code)