### PR TITLE
fix(kopikas): save button always closes the edit sheet

### DIFF
--- a/src/kopikas/components/TransactionList.tsx
+++ b/src/kopikas/components/TransactionList.tsx
@@ -115,10 +115,14 @@ export function TransactionList({ transactions, limit }: TransactionListProps) {
   const handleAmountSave = async () => {
     if (!editingTx) return
     const parsed = parseFloat(editAmount.replace(',', '.'))
-    if (isNaN(parsed) || parsed <= 0) return
+    if (isNaN(parsed) || parsed <= 0) {
+      setEditingTx(null)
+      return
+    }
     const rounded = Math.round(parsed * 100) / 100
-    if (rounded === editingTx.amount) return
-    await updateTransactionAmount(editingTx.id, rounded)
+    if (rounded !== editingTx.amount) {
+      await updateTransactionAmount(editingTx.id, rounded)
+    }
     setEditingTx(null)
   }
 


### PR DESCRIPTION
## Summary
- Save button ("Salvesta") now always closes the edit sheet, only persisting the amount when it actually changed
- Previously, unchanged amount caused an early return that left the sheet stuck open

## Test plan
- [ ] Open edit sheet, don't change amount, tap Salvesta — sheet closes
- [ ] Change amount, tap Salvesta — saves and closes
- [ ] Change category then tap Salvesta — closes with both changes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)