### PR TITLE
fix(kopikas): PWA Add to Home Screen saves wallet URL

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -34,11 +34,23 @@ export const onRequest: PagesFunction = async (context) => {
     'content="#d97706"'
   )
 
-  // Swap manifest
-  html = html.replace(
-    'href="/manifest.webmanifest"',
-    'href="/kopikas-manifest.webmanifest"'
-  )
+  // Swap manifest — inject data-start-url for wallet routes so the
+  // client-side script bakes the wallet path into the dynamic manifest
+  const urlPath = new URL(context.request.url).pathname
+  const isWalletRoute = urlPath !== '/' && urlPath !== '/login' && urlPath !== '/create'
+    && !urlPath.endsWith('/parent')
+  if (isWalletRoute) {
+    const safeUrl = urlPath.replace(/[^a-zA-Z0-9/\-_]/g, '')
+    html = html.replace(
+      'href="/manifest.webmanifest"',
+      `href="/kopikas-manifest.webmanifest" data-start-url="${safeUrl}"`
+    )
+  } else {
+    html = html.replace(
+      'href="/manifest.webmanifest"',
+      'href="/kopikas-manifest.webmanifest"'
+    )
+  }
 
   // Swap icons
   html = html.replace(

--- a/index.html
+++ b/index.html
@@ -35,7 +35,30 @@
             var appleIcon = document.querySelector('link[rel="apple-touch-icon"]');
             if (appleIcon) appleIcon.href = '/kopikas-apple-touch-icon.png';
             var manifest = document.querySelector('link[rel="manifest"]');
-            if (manifest) manifest.href = '/kopikas-manifest.webmanifest';
+            if (manifest) {
+              var path = location.pathname;
+              var isWalletRoute = path !== '/' && path !== '/login' && path !== '/create'
+                && !path.endsWith('/parent');
+              var startUrl = manifest.getAttribute('data-start-url') || (isWalletRoute ? path : '/');
+              var manifestData = {
+                name: 'Kopikas',
+                short_name: 'Kopikas',
+                description: 'Lapse taskuraha, mänguliselt',
+                start_url: startUrl,
+                scope: '/',
+                display: 'standalone',
+                orientation: 'portrait',
+                background_color: '#1a1308',
+                theme_color: '#d97706',
+                icons: [
+                  { src: '/kopikas-favicon.png', sizes: '32x32', type: 'image/png' },
+                  { src: '/kopikas-icon-192.png', sizes: '192x192', type: 'image/png' },
+                  { src: '/kopikas-icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any' }
+                ]
+              };
+              var blob = new Blob([JSON.stringify(manifestData)], { type: 'application/manifest+json' });
+              manifest.href = URL.createObjectURL(blob);
+            }
           } else {
             var stored = localStorage.getItem('spl1t:theme');
             var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;


### PR DESCRIPTION
## Summary
- When a child visits `kopikas.xtian.me/<wallet-code>` and taps "Add to Home Screen", iOS previously saved `start_url: "/"` from the static manifest, launching to the landing page instead of the wallet
- Now generates a dynamic manifest blob in `index.html` with `start_url` set to the current wallet path
- Cloudflare Pages Function injects `data-start-url` server-side so the correct path is available before JS runs
- Parent routes (`/:code/parent`), `/login`, `/create`, and `/` still default to `start_url: "/"`

## Test plan
- [ ] Deploy to Cloudflare Pages
- [ ] On iPhone Safari, visit `kopikas.xtian.me/<wallet-code>` → Share → "Add to Home Screen"
- [ ] Open from home screen → should land on `/<wallet-code>` directly, no flash
- [ ] Verify parent route (`/:code/parent`) still uses `/` as start_url
- [ ] Verify landing page `/` "Add to Home Screen" still works normally
- [ ] Verify `/login` and `/create` routes use `/` as start_url

🤖 Generated with [Claude Code](https://claude.com/claude-code)