### PR TITLE
fix(kopikas): serve dynamic manifest for PWA wallet start_url

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -2,12 +2,38 @@
 // so iOS reads "Kopikas" instead of "Spl1t" at Add to Home Screen time.
 
 export const onRequest: PagesFunction = async (context) => {
+  const url = new URL(context.request.url)
+  const hostname = url.hostname
+
+  // Serve dynamic Kopikas manifest with custom start_url when ?start= is present
+  if (hostname.startsWith('kopikas.') && url.pathname === '/kopikas-manifest.webmanifest' && url.searchParams.has('start')) {
+    const startUrl = '/' + url.searchParams.get('start')!.replace(/^\/+/, '').replace(/[^a-zA-Z0-9/\-_]/g, '')
+    const manifest = {
+      name: 'Kopikas',
+      short_name: 'Kopikas',
+      description: 'Lapse taskuraha, mänguliselt',
+      start_url: startUrl,
+      scope: '/',
+      display: 'standalone',
+      orientation: 'portrait',
+      background_color: '#1a1308',
+      theme_color: '#d97706',
+      icons: [
+        { src: '/kopikas-favicon.png', sizes: '32x32', type: 'image/png' },
+        { src: '/kopikas-icon-192.png', sizes: '192x192', type: 'image/png' },
+        { src: '/kopikas-icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
+      ],
+    }
+    return new Response(JSON.stringify(manifest), {
+      headers: { 'Content-Type': 'application/manifest+json' },
+    })
+  }
+
   const response = await context.next()
   const contentType = response.headers.get('content-type') || ''
 
   // Only rewrite HTML responses on kopikas.* hostname
   if (!contentType.includes('text/html')) return response
-  const hostname = new URL(context.request.url).hostname
   if (!hostname.startsWith('kopikas.')) return response
 
   let html = await response.text()
@@ -34,16 +60,16 @@ export const onRequest: PagesFunction = async (context) => {
     'content="#d97706"'
   )
 
-  // Swap manifest — inject data-start-url for wallet routes so the
-  // client-side script bakes the wallet path into the dynamic manifest
-  const urlPath = new URL(context.request.url).pathname
+  // Swap manifest — on wallet routes, add ?start= so iOS fetches a
+  // dynamic manifest with start_url pointing to the wallet path
+  const urlPath = url.pathname
   const isWalletRoute = urlPath !== '/' && urlPath !== '/login' && urlPath !== '/create'
     && !urlPath.endsWith('/parent')
   if (isWalletRoute) {
     const safeUrl = urlPath.replace(/[^a-zA-Z0-9/\-_]/g, '')
     html = html.replace(
       'href="/manifest.webmanifest"',
-      `href="/kopikas-manifest.webmanifest" data-start-url="${safeUrl}"`
+      `href="/kopikas-manifest.webmanifest?start=${encodeURIComponent(safeUrl)}"`
     )
   } else {
     html = html.replace(

--- a/index.html
+++ b/index.html
@@ -36,28 +36,16 @@
             if (appleIcon) appleIcon.href = '/kopikas-apple-touch-icon.png';
             var manifest = document.querySelector('link[rel="manifest"]');
             if (manifest) {
+              // Use a real URL (not blob:) so iOS Safari fetches it at "Add to Home Screen" time.
+              // The Pages Function intercepts ?start= and returns manifest JSON with that start_url.
               var path = location.pathname;
               var isWalletRoute = path !== '/' && path !== '/login' && path !== '/create'
                 && !path.endsWith('/parent');
-              var startUrl = manifest.getAttribute('data-start-url') || (isWalletRoute ? path : '/');
-              var manifestData = {
-                name: 'Kopikas',
-                short_name: 'Kopikas',
-                description: 'Lapse taskuraha, mänguliselt',
-                start_url: startUrl,
-                scope: '/',
-                display: 'standalone',
-                orientation: 'portrait',
-                background_color: '#1a1308',
-                theme_color: '#d97706',
-                icons: [
-                  { src: '/kopikas-favicon.png', sizes: '32x32', type: 'image/png' },
-                  { src: '/kopikas-icon-192.png', sizes: '192x192', type: 'image/png' },
-                  { src: '/kopikas-icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any' }
-                ]
-              };
-              var blob = new Blob([JSON.stringify(manifestData)], { type: 'application/manifest+json' });
-              manifest.href = URL.createObjectURL(blob);
+              var manifestUrl = '/kopikas-manifest.webmanifest';
+              if (isWalletRoute) {
+                manifestUrl += '?start=' + encodeURIComponent(path);
+              }
+              manifest.href = manifestUrl;
             }
           } else {
             var stored = localStorage.getItem('spl1t:theme');


### PR DESCRIPTION
## Summary
- Replaces blob URL approach (iOS Safari ignores blob: manifest URLs) with a real HTTP URL
- Pages Function now intercepts `/kopikas-manifest.webmanifest?start=/<code>` and returns manifest JSON with `start_url` set to the wallet path
- Both server-side HTML rewrite and client-side JS append `?start=` to the manifest href — iOS gets the correct manifest regardless of which runs first
- Non-wallet routes (`/`, `/login`, `/create`, `*/parent`) still get static manifest with `start_url: "/"`

## Test plan
- [ ] Deploy to Cloudflare Pages
- [ ] On iPhone Safari, visit `kopikas.xtian.me/<wallet-code>` → Share → "Add to Home Screen"
- [ ] Open from home screen → should land on `/<wallet-code>` directly
- [ ] Verify `curl kopikas.xtian.me/kopikas-manifest.webmanifest?start=/abc123` returns `start_url: "/abc123"`
- [ ] Verify `curl kopikas.xtian.me/kopikas-manifest.webmanifest` returns static file with `start_url: "/"`
- [ ] Verify parent route and landing page still use `/` as start_url

🤖 Generated with [Claude Code](https://claude.com/claude-code)