### PR TITLE
fix(kopikas): surface actual receipt scan error message

### DIFF
--- a/src/kopikas/components/ScanFlow.tsx
+++ b/src/kopikas/components/ScanFlow.tsx
@@ -73,9 +73,21 @@ export function ScanFlow({ open, onClose, onScanComplete }: ScanFlowProps) {
         'Kviitungi töötlemine aegus. Proovi uuesti!'
       )
 
-      if (fnError) throw fnError
+      if (fnError) {
+        let message = 'Receipt processing failed'
+        try {
+          const body = await (fnError as any).context?.json?.()
+          message = body?.error ?? fnError.message ?? message
+        } catch {
+          message = fnError.message ?? message
+        }
+        throw new Error(message)
+      }
 
       const parsed = typeof data === 'string' ? JSON.parse(data) : data
+      if (parsed?.error) {
+        throw new Error(parsed.error)
+      }
       if (!parsed?.items || parsed.items.length === 0) {
         throw new Error('No items found')
       }
@@ -104,9 +116,11 @@ export function ScanFlow({ open, onClose, onScanComplete }: ScanFlowProps) {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       logger.error('Receipt scan failed', { error: msg, wallet_code: wallet.wallet_code })
-      setError(msg === 'No items found'
-        ? 'Ei leidnud kviitungilt midagi. Proovi uuesti!'
-        : 'Hmm, midagi läks valesti. Proovi uuesti!')
+      if (msg === 'No items found') {
+        setError('Ei leidnud kviitungilt midagi. Proovi uuesti!')
+      } else {
+        setError(`Hmm, midagi läks valesti: ${msg}`)
+      }
     } finally {
       setProcessing(false)
     }


### PR DESCRIPTION
## Summary
- Extract real error from `FunctionsHttpError` via `fnError.context.json()` (matching the Spl1t `ReceiptCaptureSheet` pattern) instead of swallowing the message
- Handle edge function 200-with-error responses (`{ error: "..." }`)
- Show actual error message to user instead of always generic "midagi läks valesti"
- Re-deployed `process-kopikas-receipt` edge function

## Test plan
- [ ] Scan a receipt on `kopikas.xtian.me/<wallet-code>` — verify error message is descriptive if it fails
- [ ] Check Grafana logs for the real error message
- [ ] `npm run type-check` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)