### PR TITLE
fix(receipts): update Anthropic SDK to 0.80.0

### DIFF
--- a/supabase/functions/process-kopikas-receipt/index.ts
+++ b/supabase/functions/process-kopikas-receipt/index.ts
@@ -1,5 +1,5 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts"
-import Anthropic from 'npm:@anthropic-ai/sdk@0.32.1'
+import Anthropic from 'npm:@anthropic-ai/sdk@0.80.0'
 import { createClient } from 'npm:@supabase/supabase-js@2'
 import { createLogger } from '../_shared/logger.ts'
 import { createMetrics } from '../_shared/metrics.ts'
@@ -202,8 +202,9 @@ Rules:
     })
     metrics.push([{ name: 'receipt_errors', value: 1, labels: { service_name: 'process-kopikas-receipt' }, type: 'counter' }])
 
+    const errorMessage = error instanceof Error ? error.message : String(error)
     return new Response(
-      JSON.stringify({ error: "Receipt processing failed" }),
+      JSON.stringify({ error: errorMessage }),
       { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     )
   }

--- a/supabase/functions/process-receipt/index.ts
+++ b/supabase/functions/process-receipt/index.ts
@@ -1,5 +1,5 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts"
-import Anthropic from 'npm:@anthropic-ai/sdk@0.32.1'
+import Anthropic from 'npm:@anthropic-ai/sdk@0.80.0'
 import { createClient } from 'npm:@supabase/supabase-js@2'
 import { createLogger } from '../_shared/logger.ts'
 import { createMetrics } from '../_shared/metrics.ts'


### PR DESCRIPTION
## Summary
- Update `@anthropic-ai/sdk` from `0.32.1` to `0.80.0` in both `process-kopikas-receipt` and `process-receipt` edge functions
- Old SDK version sent an incompatible `anthropic-version` header, causing `claude-sonnet-4-6` API calls to fail with a generic error
- Return actual error messages in `process-kopikas-receipt` catch block instead of generic "Receipt processing failed"
- Both functions deployed and tested — Anthropic API is now reachable

## Verification
- Tested `process-kopikas-receipt` via curl: function reaches Anthropic API (returns "Could not process image" for 1x1px test image, which is expected)
- Before SDK upgrade: same call returned generic 500 "Receipt processing failed"
- `npm run type-check` passes

## Test plan
- [ ] Scan a receipt on `kopikas.xtian.me` — should now work end-to-end
- [ ] Scan a receipt on `split.xtian.me` — verify Spl1t receipt scan still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)