### PR TITLE
fix(kopikas): surface actual HTTP status from receipt scan errors

### DIFF
--- a/src/kopikas/components/ScanFlow.tsx
+++ b/src/kopikas/components/ScanFlow.tsx
@@ -74,12 +74,29 @@ export function ScanFlow({ open, onClose, onScanComplete }: ScanFlowProps) {
       )
 
       if (fnError) {
-        let message = 'Receipt processing failed'
+        let message = fnError.message ?? 'Receipt processing failed'
         try {
-          const body = await (fnError as any).context?.json?.()
-          message = body?.error ?? fnError.message ?? message
-        } catch {
-          message = fnError.message ?? message
+          const ctx = (fnError as any).context
+          if (ctx && typeof ctx.text === 'function') {
+            const status = ctx.status
+            const text = await ctx.text()
+            logger.error('Edge function non-2xx', {
+              status,
+              statusText: ctx.statusText,
+              body: text?.slice(0, 500),
+              wallet_code: wallet.wallet_code,
+            })
+            try {
+              const body = JSON.parse(text)
+              message = body?.error ?? `HTTP ${status}: ${text.slice(0, 200)}`
+            } catch {
+              message = `HTTP ${status}: ${text?.slice(0, 200) || ctx.statusText}`
+            }
+          }
+        } catch (extractErr) {
+          logger.error('Failed to extract error details', {
+            extractError: extractErr instanceof Error ? extractErr.message : String(extractErr),
+          })
         }
         throw new Error(message)
       }


### PR DESCRIPTION
## Summary
- Error extraction used `.json()` which silently failed on non-JSON responses (gateway HTML error pages, empty bodies)
- Now reads response as `.text()` first, logs HTTP status + body to Grafana, then tries JSON parse
- Next failed scan will show the actual error (e.g. `HTTP 502: ...`) instead of generic "non-2xx status code"

## Test plan
- [x] `npm run type-check` passes
- [x] 274 unit tests pass
- [ ] Deploy → scan a receipt on kopikas → read actual error message
- [ ] Check Grafana for logged status code and body

🤖 Generated with [Claude Code](https://claude.com/claude-code)