### PR TITLE
fix(kopikas): send anon key for receipt scan (unauthenticated kids)

### DIFF
--- a/src/kopikas/components/ScanFlow.tsx
+++ b/src/kopikas/components/ScanFlow.tsx
@@ -64,10 +64,12 @@ export function ScanFlow({ open, onClose, onScanComplete }: ScanFlowProps) {
       // Resize image to max 1600px to keep payload small for the edge function
       const base64 = await resizeImage(file, 1600)
 
-      // Call edge function
+      // Call edge function — kids are unauthenticated, so skip sending
+      // the session JWT (gateway rejects malformed/missing tokens)
       const { data, error: fnError } = await withTimeout(
         supabase.functions.invoke('process-kopikas-receipt', {
           body: { wallet_code: wallet.wallet_code, image: base64 },
+          headers: { Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}` },
         }),
         55000,
         'Kviitungi töötlemine aegus. Proovi uuesti!'


### PR DESCRIPTION
## Summary
- Root cause: `supabase.functions.invoke()` sends the session JWT as Authorization header by default
- Kids using Kopikas are unauthenticated — no valid JWT exists, so the Supabase gateway rejects with "invalid token or protected header formatting"
- Fix: explicitly pass the anon key as Bearer token, which the gateway accepts
- The edge function itself doesn't check auth (uses service role key internally)

## Test plan
- [x] `npm run type-check` passes
- [x] 274 unit tests pass
- [ ] Deploy → scan a receipt on kopikas as unauthenticated user → should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)