### PR TITLE
chore(kopikas): remove redundant auth header from receipt scan

### DIFF
--- a/src/kopikas/components/ScanFlow.tsx
+++ b/src/kopikas/components/ScanFlow.tsx
@@ -64,12 +64,11 @@ export function ScanFlow({ open, onClose, onScanComplete }: ScanFlowProps) {
       // Resize image to max 1600px to keep payload small for the edge function
       const base64 = await resizeImage(file, 1600)
 
-      // Call edge function — kids are unauthenticated, so skip sending
-      // the session JWT (gateway rejects malformed/missing tokens)
+      // Call edge function — deployed with --no-verify-jwt since kids
+      // are unauthenticated (wallet_code is the access control)
       const { data, error: fnError } = await withTimeout(
         supabase.functions.invoke('process-kopikas-receipt', {
           body: { wallet_code: wallet.wallet_code, image: base64 },
-          headers: { Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}` },
         }),
         55000,
         'Kviitungi töötlemine aegus. Proovi uuesti!'


### PR DESCRIPTION
## Summary
- The actual fix for receipt scanning was deploying `process-kopikas-receipt` with `--no-verify-jwt`
- The explicit anon key header added in #778 was unnecessary — remove it
- Comment updated to document the real fix

## Test plan
- [x] `npm run type-check` passes
- [x] 274 unit tests pass
- [ ] Receipt scanning still works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)