### PR TITLE
fix(receipt): persist tip_amount on save and restore on re-edit

### DIFF
--- a/src/components/receipts/PendingReceiptBanner.tsx
+++ b/src/components/receipts/PendingReceiptBanner.tsx
@@ -15,6 +15,7 @@ export interface ReceiptReviewData {
   category: string | null
   existingExpenseId?: string
   mappedItems?: (MappedItem | LegacyMappedItem)[] | null
+  savedTipAmount?: number | null
 }
 
 interface PendingReceiptBannerProps {
@@ -72,6 +73,7 @@ export function PendingReceiptBanner({ tasks, defaultCurrency, onReview, onDismi
                       imagePath: task.receipt_image_path ?? null,
                       category: task.extracted_category ?? null,
                       mappedItems: task.mapped_items,
+                      savedTipAmount: task.tip_amount,
                     })
                   }
                 >

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -45,6 +45,7 @@ interface ReceiptReviewSheetProps {
   extractedCategory?: string | null
   existingExpenseId?: string
   mappedItems?: (MappedItem | LegacyMappedItem)[] | null
+  savedTipAmount?: number | null
   onDone: () => void
 }
 
@@ -69,6 +70,7 @@ export function ReceiptReviewSheet({
   extractedCategory,
   existingExpenseId,
   mappedItems,
+  savedTipAmount,
   onDone,
 }: ReceiptReviewSheetProps) {
   const { t } = useTranslation()
@@ -152,7 +154,7 @@ export function ReceiptReviewSheet({
     setAllocations(initialAllocs)
     setExpandedPersonIds(new Set())
     setConfirmedTotal(extractedTotal != null ? extractedTotal.toFixed(2) : '')
-    setTipAmount('0')
+    setTipAmount(savedTipAmount != null && savedTipAmount > 0 ? savedTipAmount.toFixed(2) : '0')
     setPaidBy(existingExpense?.paid_by ?? defaultPayerId)
     setMerchantName(merchant ?? '')
     setCategory(
@@ -351,7 +353,7 @@ export function ReceiptReviewSheet({
       }
 
       const mappedItemsToSave: MappedItem[] = allocationsToMappedItems(allocations)
-      await completeReceiptTask(taskId, expenseId, mappedItemsToSave)
+      await completeReceiptTask(taskId, expenseId, mappedItemsToSave, tipFloat)
 
       toast({
         title: existingExpenseId ? t('receipt.receiptUpdated') : t('receipt.receiptAdded'),

--- a/src/contexts/ReceiptContext.tsx
+++ b/src/contexts/ReceiptContext.tsx
@@ -16,7 +16,7 @@ interface ReceiptContextType {
   clearError: () => void
   createReceiptTask: (tripId: string, imagePath?: string) => Promise<ReceiptTask>
   updateReceiptTask: (id: string, updates: ReceiptTaskUpdate) => Promise<boolean>
-  completeReceiptTask: (id: string, expenseId: string, mappedItems?: MappedItem[]) => Promise<boolean>
+  completeReceiptTask: (id: string, expenseId: string, mappedItems?: MappedItem[], tipAmount?: number) => Promise<boolean>
   reopenReceiptTask: (id: string) => Promise<boolean>
   dismissReceiptTask: (id: string) => Promise<boolean>
   refreshPendingReceipts: () => Promise<void>
@@ -181,7 +181,7 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const completeReceiptTask = async (id: string, expenseId: string, mappedItems?: MappedItem[]): Promise<boolean> => {
+  const completeReceiptTask = async (id: string, expenseId: string, mappedItems?: MappedItem[], tipAmount?: number): Promise<boolean> => {
     try {
       const completeController = new AbortController()
       const { error: updateError } = await withTimeout(
@@ -191,6 +191,7 @@ export function ReceiptProvider({ children }: { children: ReactNode }) {
             status: 'complete',
             expense_id: expenseId,
             ...(mappedItems ? { mapped_items: mappedItems } : {}),
+            ...(tipAmount !== undefined ? { tip_amount: tipAmount } : {}),
             updated_at: new Date().toISOString(),
           } as Record<string, unknown>)
           .eq('id', id)

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -109,6 +109,7 @@ export function ExpensesPage() {
       category: task.extracted_category ?? null,
       existingExpenseId: task.expense_id ?? undefined,
       mappedItems: task.mapped_items,
+      savedTipAmount: task.tip_amount,
     })
   }
 
@@ -355,6 +356,7 @@ export function ExpensesPage() {
           extractedCategory={receiptReviewData.category}
           existingExpenseId={receiptReviewData.existingExpenseId}
           mappedItems={receiptReviewData.mappedItems}
+          savedTipAmount={receiptReviewData.savedTipAmount}
           onDone={() => setReceiptReviewData(null)}
         />
       )}

--- a/src/pages/QuickGroupDetailPage.tsx
+++ b/src/pages/QuickGroupDetailPage.tsx
@@ -315,6 +315,7 @@ export function QuickGroupDetailPage() {
           currency={receiptReviewData.currency}
           imagePath={receiptReviewData.imagePath}
           extractedCategory={receiptReviewData.category}
+          savedTipAmount={receiptReviewData.savedTipAmount}
           onDone={() => setReceiptReviewData(null)}
         />
       )}


### PR DESCRIPTION
## Bug
Tip entered on a scanned receipt disappeared when re-editing the mapping.

## Root cause
Two compounding bugs:
1. \`completeReceiptTask\` in \`ReceiptContext\` never wrote \`tip_amount\` to the DB (the column exists on \`receipt_tasks\` but no code populated it). The tip flowed into the expense's total amount, but the original tip value itself was lost.
2. Even if the DB had the value, \`ReceiptReviewSheet\` had no path to read it back — its state reset always set tip to \`'0'\`.

Pre-existing — neither old nor new allocation code persisted tip.

## Fix
- \`completeReceiptTask(id, expenseId, mappedItems?, tipAmount?)\` now writes \`tip_amount\` when provided.
- \`ReceiptReviewSheet\` accepts a new \`savedTipAmount?: number | null\` prop and hydrates the tip input from it.
- \`PendingReceiptBanner\` forwards \`task.tip_amount\` as \`savedTipAmount\` on the Review button.
- \`ExpensesPage\` and \`QuickGroupDetailPage\` forward the field through to the sheet.

## Test plan
- [x] \`npm run type-check\` clean
- [x] \`npm test\` passes (323/323)
- [ ] Scan a receipt, add a tip, complete; reopen via "Edit mapping" — tip should now show its original value instead of 0
- [ ] Scan a receipt with no tip — tip input stays at 0 (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)