### PR TITLE
fix(receipt): split shared single-qty items across everyone (#783)

### DIFF
--- a/docs/superpowers/specs/2026-05-06-receipt-allocation-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-06-receipt-allocation-redesign-design.md
@@ -44,9 +44,9 @@ type Allocations = Map<ItemId, Map<ParticipantId, number>>
 //                  ^itemId   ^who got how many units of that item
 ```
 
-**Invariant:** `sum(counts) <= item.qty` for every item. Going over is blocked at the UI; under is allowed mid-edit but blocks submit.
+**Invariant (superseded — see Addendum 2026-06-29):** ~~`sum(counts) <= item.qty` for every item. Going over is blocked at the UI; under is allowed mid-edit but blocks submit.~~ Counts are now uncapped per-item **share weights**; an item is complete once it has at least one sharer.
 
-**Distribution math:** `pricePerUnit = item.price / item.qty`. Each participant's share for a line = `count * pricePerUnit`. Sum over all items → final per-person totals fed into `buildDistribution`.
+**Distribution math (superseded):** ~~`pricePerUnit = item.price / item.qty`. Each participant's share for a line = `count * pricePerUnit`.~~ Now per-item proportional: `share_p = item.price * weight_p / sum(weights for that item)`. Sum over all items → per-person totals fed into `buildDistribution`. (For a fully-assigned multi-qty item this is numerically identical to the old `count * pricePerUnit`.)
 
 ## UI — By-Item View
 
@@ -64,10 +64,10 @@ Each item is one row, regardless of qty.
 +---------------------------------------------+
 ```
 
-- **Stepper** per participant: `-` decrement disabled at 0, `+` disabled when item is full (`assigned == qty`).
+- **Stepper** per participant: `-` decrement disabled at 0; `+` is never disabled (weights are uncapped — see Addendum).
 - For `qty == 1`, the stepper collapses to a tap-to-toggle chip — same density as the current UI on simple receipts.
-- **"Everyone equally"** distributes qty across all current participants: floor across, remainder lumped on first participant alphabetically (deterministic).
-- **Progress chip:** amber while `0 < assigned < qty`, green at `assigned == qty`, hidden when `assigned == 0`.
+- **"Everyone equally"** assigns weight 1 to every current participant (splits the line equally regardless of qty).
+- **Progress chip:** green "Assigned to 1 person" / "Split between N people" once a line has a sharer; hidden when nobody shares it.
 - **Inline name editing** preserved.
 - **No expansion.** `expandItem()` deleted.
 
@@ -94,8 +94,8 @@ Tap to expand a person:
     Bread              fully assigned  (-)
 ```
 
-- **"X left"** = `item.qty - sum(allAllocationsForItem)`. Disables `+` at 0.
-- **Sheet header chip** shows global progress: "10 of 12 units assigned".
+- ~~**"X left"** = `item.qty - sum(allAllocationsForItem)`. Disables `+` at 0.~~ (Superseded: rows now show each person's proportional share, e.g. `EUR 2.00 . split 3 ways`; `+` is never disabled.)
+- **Sheet header chip** shows global progress: "N of M items assigned" (per-item, not per-unit — see Addendum).
 - **No carry-forward in this view** — concept doesn't apply. Toggle is hidden.
 - Translated names rendered the same way as By-Item view.
 
@@ -244,3 +244,21 @@ Recomputed from data: any item with `count > 0` for any participant is `manually
 - A receipt scanned in French shows French original + English translation (for an `en` browser) inline.
 - Re-editing a receipt saved before this change loads with prior allocations intact.
 - Submit blocks with a clear error when any item is under-assigned.
+
+---
+
+## Addendum 2026-06-29 — Proportional share weights (fixes #783)
+
+**Problem.** The counter model treated `count` as a capped unit allocation with the invariant `sum(counts) <= item.qty`. For a `qty == 1` item this means only ONE participant can ever be assigned — `distributeEvenly([a,b,c], 1)` gives the single unit to the alphabetical first, and `applyCountChange` clamps away any second participant. A restaurant bill where every line is `qty 1` and the table shares each dish (the common case, e.g. trip `f1-red-bull-ring-uWu3wA`) could not be split at all. "Everyone equally" silently assigned one person.
+
+Worse, the old global-scaling distribution math gave *wrong* per-person amounts on **mixed** receipts (some lines shared, some not), because it normalized total cost across the whole receipt instead of per line.
+
+**Fix.** `count` is reinterpreted as a per-item **share weight**, with no upper bound:
+
+- Per-line share: `share_p = item.price * weight_p / sum(weights on that line)` (`itemShare` in `receiptDistribution.ts`). Fully-assigned multi-qty lines are numerically unchanged.
+- `distributeEvenly(ids)` assigns weight 1 to everyone (qty-independent).
+- The `sum(counts) <= qty` UI clamp is removed; `+` is never disabled.
+- A line is "assigned" when it has >= 1 sharer (not `sum == qty`); submit blocks only on priced lines with zero sharers.
+- `ItemRow`/`PersonRow` show "Split between N people" and each person's proportional amount instead of "X of Y units".
+
+Tests: `receiptDistribution.test.ts` (mixed-receipt proportional split, `itemShare`), `ItemRow`/`PersonRow` tests, and integration tests for sharing a `qty=1` item across multiple people and "Everyone equally".

--- a/src/components/receipts/ItemRow.test.tsx
+++ b/src/components/receipts/ItemRow.test.tsx
@@ -65,7 +65,7 @@ describe('ItemRow', () => {
     expect(screen.queryByText('Borscht')).not.toBeInTheDocument()
   })
 
-  it('shows progress chip with assigned/qty', () => {
+  it('shows how many people an item is split between', () => {
     const counts = new Map([['alice', 1], ['bob', 1]])
     render(
       <ItemRow
@@ -80,10 +80,10 @@ describe('ItemRow', () => {
         onAssignEvenly={noop}
       />
     )
-    expect(screen.getByText('2 of 4 assigned')).toBeInTheDocument()
+    expect(screen.getByText('Split between 2 people')).toBeInTheDocument()
   })
 
-  it('disables the + button when item is fully assigned', () => {
+  it('never disables the + button — weights are uncapped so anyone can share', () => {
     const counts = new Map([['alice', 4]])
     render(
       <ItemRow
@@ -99,7 +99,7 @@ describe('ItemRow', () => {
       />
     )
     const plus = screen.getAllByLabelText(/Increment/i)
-    plus.forEach(btn => expect(btn).toBeDisabled())
+    plus.forEach(btn => expect(btn).not.toBeDisabled())
   })
 
   it('disables the - button when count is 0 for that participant', () => {

--- a/src/components/receipts/ItemRow.tsx
+++ b/src/components/receipts/ItemRow.tsx
@@ -52,9 +52,11 @@ export function ItemRow({
   onAssignEvenly,
 }: ItemRowProps) {
   const { t } = useTranslation()
-  const assigned = Array.from(counts.values()).reduce((a, b) => a + b, 0)
-  const fullyAssigned = assigned >= item.qty
-  const showProgress = assigned > 0
+  // Counts are per-item share weights; an item is "assigned" once at least one
+  // person shares it. Its cost then splits proportionally across the sharers.
+  const sharerCount = Array.from(counts.values()).filter(c => c > 0).length
+  const assigned = sharerCount > 0
+  const showProgress = assigned
   const showOriginal = !!item.nameOriginal && item.nameOriginal !== item.name
   const isSingleQty = item.qty === 1
 
@@ -89,8 +91,8 @@ export function ItemRow({
       </div>
 
       {showProgress && (
-        <div className={`text-xs font-medium ${fullyAssigned ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}`}>
-          {`${assigned} of ${item.qty} assigned`}
+        <div className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+          {sharerCount === 1 ? 'Assigned to 1 person' : `Split between ${sharerCount} people`}
         </div>
       )}
 
@@ -134,8 +136,7 @@ export function ItemRow({
                 type="button"
                 aria-label={`Increment ${p.name}`}
                 onClick={() => onCountChange(p.id, 1)}
-                disabled={fullyAssigned}
-                className="w-5 h-5 inline-flex items-center justify-center rounded-full bg-white/20 disabled:opacity-30 hover:bg-white/30"
+                className="w-5 h-5 inline-flex items-center justify-center rounded-full bg-white/20 hover:bg-white/30"
               >
                 <Plus size={10} />
               </button>

--- a/src/components/receipts/PersonRow.test.tsx
+++ b/src/components/receipts/PersonRow.test.tsx
@@ -57,7 +57,7 @@ describe('PersonRow', () => {
     expect(screen.getByText('Bread')).toBeInTheDocument()
   })
 
-  it('shows "fully assigned" when an item has no remaining units globally', () => {
+  it('shows who an item is shared by when the user is not on it', () => {
     const allCounts = new Map([['i2', new Map([['bob', 1]])]])
     render(
       <PersonRow
@@ -71,10 +71,28 @@ describe('PersonRow', () => {
         onCountChange={() => {}}
       />
     )
-    expect(screen.getByText(/fully assigned/i)).toBeInTheDocument()
+    expect(screen.getByText(/shared by 1/i)).toBeInTheDocument()
   })
 
-  it('disables the + button on items with no remaining units (and the user has none of them)', () => {
+  it('shows the participant proportional share for a shared item', () => {
+    // Bread price 4 shared by alice + bob -> alice owes 2.00
+    const allCounts = new Map([['i2', new Map([['alice', 1], ['bob', 1]])]])
+    render(
+      <PersonRow
+        participant={mkParticipant('alice', 'Alice')}
+        items={items}
+        myCounts={new Map([['i2', 1]])}
+        allCounts={allCounts}
+        currency="EUR"
+        expanded={true}
+        onToggleExpand={() => {}}
+        onCountChange={() => {}}
+      />
+    )
+    expect(screen.getByText(/EUR 2\.00 . split 2 ways/i)).toBeInTheDocument()
+  })
+
+  it('never disables the + button (any number of people can share an item)', () => {
     const allCounts = new Map([['i2', new Map([['bob', 1]])]])
     render(
       <PersonRow
@@ -89,7 +107,7 @@ describe('PersonRow', () => {
       />
     )
     const plus = screen.getByLabelText(/Increment Bread for Alice/i)
-    expect(plus).toBeDisabled()
+    expect(plus).not.toBeDisabled()
   })
 
   it('calls onCountChange when + is clicked', () => {

--- a/src/components/receipts/PersonRow.tsx
+++ b/src/components/receipts/PersonRow.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ChevronDown, ChevronUp, Plus, Minus } from 'lucide-react'
 import type { Participant } from '@/types/participant'
-import { pricePerUnit } from '@/lib/receiptDistribution'
+import { itemShare, totalAssigned } from '@/lib/receiptDistribution'
 
 interface PersonRowItem {
   id: string
@@ -36,8 +36,9 @@ export function PersonRow({
   onCountChange,
 }: PersonRowProps) {
   const myTotal = items.reduce((sum, item) => {
-    const c = myCounts.get(item.id) ?? 0
-    return sum + c * pricePerUnit(item)
+    const weight = myCounts.get(item.id) ?? 0
+    const sumWeights = totalAssigned(allCounts.get(item.id) ?? new Map())
+    return sum + itemShare(item.price, weight, sumWeights)
   }, 0)
   const itemCountForMe = items.filter(i => (myCounts.get(i.id) ?? 0) > 0).length
 
@@ -61,10 +62,9 @@ export function PersonRow({
         <div className="border-t border-border divide-y divide-border">
           {items.map(item => {
             const myCount = myCounts.get(item.id) ?? 0
-            const totalForItem = Array.from((allCounts.get(item.id) ?? new Map()).values()).reduce((a, b) => a + b, 0)
-            const remaining = item.qty - totalForItem
-            const fullyAssigned = remaining <= 0 && myCount === 0
-            const canIncrement = !fullyAssigned && (totalForItem < item.qty)
+            const sumWeights = totalAssigned(allCounts.get(item.id) ?? new Map())
+            const sharerCount = Array.from((allCounts.get(item.id) ?? new Map()).values()).filter(c => c > 0).length
+            const myShare = itemShare(item.price, myCount, sumWeights)
             return (
               <div key={item.id} className="px-3 py-2 flex items-center justify-between gap-2">
                 <div className="flex-1 min-w-0">
@@ -73,7 +73,11 @@ export function PersonRow({
                     <div className="text-xs italic text-muted-foreground truncate">{item.nameOriginal}</div>
                   )}
                   <div className="text-xs text-muted-foreground">
-                    {fullyAssigned ? 'fully assigned' : `${remaining} left`}
+                    {myCount > 0
+                      ? `${currency} ${myShare.toFixed(2)}${sharerCount > 1 ? ` · split ${sharerCount} ways` : ''}`
+                      : sharerCount > 0
+                        ? `shared by ${sharerCount}`
+                        : 'unassigned'}
                   </div>
                 </div>
                 <div className="shrink-0 inline-flex items-center gap-1.5 border border-border rounded-full px-1 py-0.5">
@@ -91,8 +95,7 @@ export function PersonRow({
                     type="button"
                     aria-label={`Increment ${item.name} for ${participant.name}`}
                     onClick={() => onCountChange(item.id, 1)}
-                    disabled={!canIncrement}
-                    className="w-6 h-6 inline-flex items-center justify-center rounded-full hover:bg-accent disabled:opacity-30"
+                    className="w-6 h-6 inline-flex items-center justify-center rounded-full hover:bg-accent"
                   >
                     <Plus size={12} />
                   </button>

--- a/src/components/receipts/ReceiptReviewSheet.integration.test.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.integration.test.tsx
@@ -141,6 +141,34 @@ describe('ReceiptReviewSheet -- multi-qty regression', () => {
   })
 })
 
+describe('ReceiptReviewSheet -- shared single-qty items (issue #783)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('spl1t:receipt-carry-forward', 'false')
+    localStorage.setItem('spl1t:receipt-allocation-view', 'by-item')
+  })
+
+  it('lets multiple people share a qty=1 item (Bread), not just the first', () => {
+    renderSheet()
+    const breadRow = getItemRow('Bread') // qty=1 -> chip toggle mode
+
+    // Select Alice, then Bob, then Carol on the same single-unit item.
+    fireEvent.click(within(breadRow).getByText('Alice'))
+    fireEvent.click(within(breadRow).getByText('Bob'))
+    fireEvent.click(within(breadRow).getByText('Carol'))
+
+    // All three must remain selected -> "Split between 3 people".
+    expect(within(breadRow).getByText('Split between 3 people')).toBeInTheDocument()
+  })
+
+  it('"Everyone equally" on a qty>1 item selects every participant', () => {
+    renderSheet()
+    const wineRow = getItemRow('Wine') // qty=2, has the "Everyone equally" button
+    fireEvent.click(within(wineRow).getByText(/Everyone equally/i))
+    expect(within(wineRow).getByText('Split between 3 people')).toBeInTheDocument()
+  })
+})
+
 describe('ReceiptReviewSheet -- view toggle', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -183,15 +211,15 @@ describe('ReceiptReviewSheet -- carry-forward semantics', () => {
     renderSheet()
 
     // Assign Alice to beer (qty=3). Items are ordered: beer, bread, wine.
-    // Carry-forward should distribute alice across bread (qty=1) and wine (qty=2).
+    // Carry-forward copies the source participant set onto later items with an
+    // equal share weight of 1 each.
     const beerRow = getItemRow('Beer')
     fireEvent.click(within(beerRow).getByLabelText(/Increment Alice/i))
 
-    // wine has qty=2, with only alice in the source set:
-    // distributeEvenly(['alice'], 2) -> alice gets 2
+    // wine inherits the {alice} set with weight 1 (proportional shares, not units).
     await waitFor(() => {
       const wineRow = getItemRow('Wine')
-      expect(within(wineRow).getByText('2')).toBeInTheDocument()
+      expect(within(wineRow).getByText('1')).toBeInTheDocument()
     })
   })
 
@@ -236,7 +264,7 @@ describe('ReceiptReviewSheet -- legacy mapped_items load', () => {
     const breadRow = getItemRow('Bread')
     // Bread has qty=1, so it uses chip-toggle mode (isSingleQty).
     // The carol chip will show as selected (on=true via getChipColor).
-    // The count display is not shown for single-qty; verify via "1 of 1 assigned" progress chip.
-    expect(within(breadRow).getByText('1 of 1 assigned')).toBeInTheDocument()
+    // The count display is not shown for single-qty; verify via the sharer chip.
+    expect(within(breadRow).getByText('Assigned to 1 person')).toBeInTheDocument()
   })
 })

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -194,10 +194,11 @@ export function ReceiptReviewSheet({
       for (const [k, v] of prev) next.set(k, new Map(v))
       const inner = next.get(itemId) ?? new Map<string, number>()
       const current = inner.get(participantId) ?? 0
-      const totalSoFar = Array.from(inner.values()).reduce((a, b) => a + b, 0)
-      let newCount = Math.max(0, current + delta)
-      const proposedTotal = totalSoFar - current + newCount
-      if (proposedTotal > item.qty) newCount = current + (item.qty - totalSoFar)
+      // Counts are per-item share weights, not capped unit allocations, so any
+      // number of people can share an item (a single pizza splits across the
+      // table). No upper bound — increasing a weight just grows that person's
+      // proportional share of the line.
+      const newCount = Math.max(0, current + delta)
       if (newCount === current) return prev
       if (newCount === 0) inner.delete(participantId)
       else inner.set(participantId, newCount)
@@ -209,7 +210,7 @@ export function ReceiptReviewSheet({
         for (let i = itemIndex + 1; i < editableItems.length; i++) {
           const target = editableItems[i]
           if (target.manuallySet) continue
-          const distributed = distributeEvenly(sourceSet, target.qty)
+          const distributed = distributeEvenly(sourceSet)
           next.set(target.id, distributed)
         }
       }
@@ -226,7 +227,7 @@ export function ReceiptReviewSheet({
     const item = editableItems.find(i => i.id === itemId)
     if (!item) return
     const ids = participants.map(p => p.id)
-    const distributed = distributeEvenly(ids, item.qty)
+    const distributed = distributeEvenly(ids)
 
     setAllocations(prev => {
       const next: Allocations = new Map()
@@ -238,7 +239,7 @@ export function ReceiptReviewSheet({
         for (let i = itemIndex + 1; i < editableItems.length; i++) {
           const target = editableItems[i]
           if (target.manuallySet) continue
-          next.set(target.id, distributeEvenly(ids, target.qty))
+          next.set(target.id, distributeEvenly(ids))
         }
       }
       return next
@@ -270,18 +271,18 @@ export function ReceiptReviewSheet({
   const tipFloat = parseFloat(tipAmount) || 0
   const totalExpense = totalFloat + tipFloat
 
+  // A priced item is "unassigned" only when nobody shares it. Each item's cost
+  // is split proportionally across whoever is on it, so qty no longer gates
+  // completeness — one sharer is enough.
   const underAssignedItems = editableItems.filter(item => {
     const inner = allocations.get(item.id)
-    const total = inner ? Array.from(inner.values()).reduce((a, b) => a + b, 0) : 0
-    return total < item.qty && parseFloat(item.price) > 0
+    return (inner?.size ?? 0) === 0 && parseFloat(item.price) > 0
   })
 
-  const totalUnits = editableItems.reduce((sum, i) => sum + (parseFloat(i.price) > 0 ? i.qty : 0), 0)
+  const totalUnits = editableItems.reduce((sum, i) => sum + (parseFloat(i.price) > 0 ? 1 : 0), 0)
   const assignedUnits = editableItems.reduce((sum, i) => {
     if (parseFloat(i.price) <= 0) return sum
-    const inner = allocations.get(i.id)
-    const t = inner ? Array.from(inner.values()).reduce((a, b) => a + b, 0) : 0
-    return sum + Math.min(t, i.qty)
+    return sum + ((allocations.get(i.id)?.size ?? 0) > 0 ? 1 : 0)
   }, 0)
 
   const canSubmit =
@@ -551,7 +552,7 @@ export function ReceiptReviewSheet({
       {underAssignedItems.length > 0 && (
         <div className="flex items-start gap-2 text-sm text-amber-600 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-3 py-2">
           <AlertCircle size={16} className="mt-0.5 shrink-0" />
-          <span>{underAssignedItems.length} item(s) still have unassigned units</span>
+          <span>{underAssignedItems.length} item(s) not assigned to anyone</span>
         </div>
       )}
 

--- a/src/lib/receiptDistribution.test.ts
+++ b/src/lib/receiptDistribution.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest'
 import {
   pricePerUnit,
   distributeEvenly,
+  itemShare,
   totalAssigned,
   buildReceiptDistribution,
 } from './receiptDistribution'
@@ -19,33 +20,35 @@ describe('pricePerUnit', () => {
 
 describe('distributeEvenly', () => {
   it('returns an empty map for an empty participant set', () => {
-    expect(distributeEvenly([], 3)).toEqual(new Map())
+    expect(distributeEvenly([])).toEqual(new Map())
   })
 
-  it('returns an empty map for qty 0', () => {
-    expect(distributeEvenly(['a', 'b'], 0)).toEqual(new Map())
-  })
-
-  it('splits qty equally when divisible', () => {
-    const result = distributeEvenly(['a', 'b', 'c'], 6)
-    expect(result.get('a')).toBe(2)
-    expect(result.get('b')).toBe(2)
-    expect(result.get('c')).toBe(2)
-  })
-
-  it('lumps remainder onto the first participant id alphabetically', () => {
-    // 7 / 3 = 2 remainder 1, lumped on 'a'
-    const result = distributeEvenly(['c', 'a', 'b'], 7)
-    expect(result.get('a')).toBe(3)
-    expect(result.get('b')).toBe(2)
-    expect(result.get('c')).toBe(2)
-  })
-
-  it('handles 1 unit across many participants by giving it to the alphabetical first', () => {
-    const result = distributeEvenly(['z', 'a', 'm'], 1)
+  it('assigns an equal weight of 1 to every participant', () => {
+    const result = distributeEvenly(['a', 'b', 'c'])
     expect(result.get('a')).toBe(1)
-    expect(result.get('m')).toBeUndefined()
-    expect(result.get('z')).toBeUndefined()
+    expect(result.get('b')).toBe(1)
+    expect(result.get('c')).toBe(1)
+  })
+
+  it('weights everyone equally regardless of how many share (single shared item)', () => {
+    // The bug fix: a qty=1 item shared by 3 must include all three, not just one.
+    const result = distributeEvenly(['z', 'a', 'm'])
+    expect(result.get('a')).toBe(1)
+    expect(result.get('m')).toBe(1)
+    expect(result.get('z')).toBe(1)
+  })
+})
+
+describe('itemShare', () => {
+  it('splits price by weight fraction', () => {
+    expect(itemShare(10, 1, 2)).toBeCloseTo(5)
+    expect(itemShare(9, 1, 3)).toBeCloseTo(3)
+    expect(itemShare(12, 10, 19)).toBeCloseTo(6.3158, 3)
+  })
+
+  it('returns 0 when nobody shares or weight is 0', () => {
+    expect(itemShare(10, 0, 0)).toBe(0)
+    expect(itemShare(10, 0, 5)).toBe(0)
   })
 })
 
@@ -115,6 +118,29 @@ describe('buildReceiptDistribution', () => {
     const aliceSplit = splits.find(s => s.participantId === 'alice')
     const bobSplit = splits.find(s => s.participantId === 'bob')
     expect(aliceSplit!.value + bobSplit!.value).toBeCloseTo(23.10, 2)
+  })
+
+  it('splits a shared qty=1 item proportionally in a MIXED receipt', () => {
+    // i1 (qty=1, price 10) shared by alice+bob -> 5 each.
+    // i2 (qty=1, price 9) to bob alone -> 9.
+    // Desired: alice 5, bob 14. confirmedTotal already equals raw (19).
+    const mixedItems = [
+      { id: 'i1', price: 10, qty: 1 },
+      { id: 'i2', price: 9, qty: 1 },
+    ]
+    const allocations = new Map([
+      ['i1', new Map([['alice', 1], ['bob', 1]])],
+      ['i2', new Map([['bob', 1]])],
+    ])
+    const result = buildReceiptDistribution({
+      items: mixedItems,
+      allocations,
+      confirmedTotal: 19,
+      tipAmount: 0,
+    })
+    const splits = result.distribution.participantSplits!
+    expect(splits.find(s => s.participantId === 'alice')?.value).toBeCloseTo(5, 2)
+    expect(splits.find(s => s.participantId === 'bob')?.value).toBeCloseTo(14, 2)
   })
 
   it('adds tip equally across involved participants', () => {

--- a/src/lib/receiptDistribution.ts
+++ b/src/lib/receiptDistribution.ts
@@ -16,21 +16,26 @@ export function pricePerUnit(item: { price: number; qty: number }): number {
 }
 
 /**
- * Distribute `qty` units across `participantIds` as evenly as possible.
- * Floor across, remainder lumped onto participants in alphabetical id order.
- * Returns Map<participantId, count> with only positive entries.
+ * Assign an equal share weight (1) to every participant.
+ * Counts are per-item share weights, not capped unit allocations, so an
+ * item is always split proportionally across whoever shares it. Giving
+ * everyone a weight of 1 means "split this item equally" regardless of qty
+ * (so a single shared pizza splits across the whole table).
+ * Returns Map<participantId, weight> with only positive entries.
  */
-export function distributeEvenly(participantIds: string[], qty: number): Map<string, number> {
+export function distributeEvenly(participantIds: string[]): Map<string, number> {
   const result = new Map<string, number>()
-  if (participantIds.length === 0 || qty <= 0) return result
-  const sorted = [...participantIds].sort()
-  const base = Math.floor(qty / sorted.length)
-  const remainder = qty - base * sorted.length
-  for (let i = 0; i < sorted.length; i++) {
-    const count = base + (i < remainder ? 1 : 0)
-    if (count > 0) result.set(sorted[i], count)
-  }
+  for (const id of participantIds) result.set(id, 1)
   return result
+}
+
+/**
+ * A participant's cost share of one item: their weight as a fraction of the
+ * item's total weight, times the item price. Returns 0 when nobody shares it.
+ */
+export function itemShare(price: number, weight: number, sumWeights: number): number {
+  if (sumWeights <= 0 || weight <= 0) return 0
+  return (price * weight) / sumWeights
 }
 
 export function totalAssigned(perParticipant: Map<string, number>): number {
@@ -66,11 +71,11 @@ export function buildReceiptDistribution({
 
   for (const item of items) {
     const perPersonMap = allocations.get(item.id)
-    if (!perPersonMap || perPersonMap.size === 0 || item.price === 0 || item.qty === 0) continue
-    const unit = pricePerUnit(item)
-    for (const [pid, count] of perPersonMap) {
-      if (count <= 0) continue
-      rawShares[pid] = (rawShares[pid] ?? 0) + unit * count
+    if (!perPersonMap || perPersonMap.size === 0 || item.price === 0) continue
+    const sumWeights = totalAssigned(perPersonMap)
+    for (const [pid, weight] of perPersonMap) {
+      if (weight <= 0) continue
+      rawShares[pid] = (rawShares[pid] ?? 0) + itemShare(item.price, weight, sumWeights)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #783 — in receipt review, "select everyone" only assigned one participant.

## Root cause

The counter-based allocation model (PR #780) treats each item's assignment as integer **unit counts** with the invariant `sum(counts) <= item.qty`. For a `qty == 1` line that means **only one participant can ever be assigned**:
- `distributeEvenly([a,b,c], 1)` floors `1/3 = 0` and lumps the remainder on the alphabetical first → only that person gets the unit.
- `applyCountChange` clamps `proposedTotal > qty`, so adding a second person to a qty=1 line is silently rejected.

Almost every restaurant line is `qty 1` (one pizza, one bottle shared by the table), so the most common receipt could not be split. The pending receipt in trip `f1-red-bull-ring-uWu3wA` (Cervo doro, 4 items all qty=1, 3 people) is exactly this and got stuck.

Separately, the old global-scaling distribution math produced **wrong per-person amounts on mixed receipts** (some lines shared, some not) — it normalized total cost across the whole receipt instead of per line.

## Fix — proportional share weights

`count` is reinterpreted as an uncapped per-item **share weight**:
- Per-line share: `share_p = price * weight_p / sum(weights on that line)` (new `itemShare`). **Numerically identical** to the old `count * pricePerUnit` for fully-assigned multi-qty lines, so existing behavior there is unchanged.
- `distributeEvenly(ids)` assigns weight 1 to everyone (qty-independent) → "Everyone equally" splits across the whole table.
- The `sum <= qty` clamp is removed; `+` is never disabled.
- A line is "assigned" once it has ≥1 sharer; submit blocks only on priced lines with **zero** sharers.
- `ItemRow`/`PersonRow` show "Split between N people" and each person's proportional amount instead of "X of Y units".

## Tests

- `receiptDistribution.test.ts`: new failing-then-passing **mixed-receipt** proportional test (old math gave alice 6.55, correct is 5.00) + `itemShare` tests; existing distribution tests stay green (backward-compatible math).
- `ItemRow`/`PersonRow` tests updated to the new semantics + proportional-share assertion.
- Integration: sharing a `qty=1` item across Alice+Bob+Carol keeps all three; "Everyone equally" selects everyone.
- Full suite: 347 pass, type-check clean.

## Notes

- Frontend-only; no DB/migration. Once deployed, the stuck F1 receipt can be completed normally.
- Touches bottom sheets indirectly; a manual iPhone pass on the receipt review sheet is worthwhile per repo norms, but the interaction logic is covered by the integration tests.
- Spec `docs/superpowers/specs/2026-05-06-receipt-allocation-redesign-design.md` updated with a dated addendum; the superseded `sum<=qty` invariant is struck through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
