### PR TITLE
fix(receipt): make 'Everyone equally' a toggle

### DIFF
--- a/src/components/receipts/ItemRow.tsx
+++ b/src/components/receipts/ItemRow.tsx
@@ -59,6 +59,7 @@ export function ItemRow({
   const showProgress = assigned
   const showOriginal = !!item.nameOriginal && item.nameOriginal !== item.name
   const isSingleQty = item.qty === 1
+  const everyoneSelected = participants.length > 0 && participants.every(p => (counts.get(p.id) ?? 0) > 0)
 
   return (
     <div data-testid="item-row" className={`border border-border rounded-lg p-3 space-y-2 ${index % 2 !== 0 ? 'bg-muted/25' : ''}`}>
@@ -148,7 +149,13 @@ export function ItemRow({
           <button
             type="button"
             onClick={onAssignEvenly}
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border border-border bg-muted text-muted-foreground hover:bg-accent"
+            aria-pressed={everyoneSelected}
+            className={[
+              'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border transition-colors',
+              everyoneSelected
+                ? 'bg-foreground text-background border-foreground'
+                : 'border-border bg-muted text-muted-foreground hover:bg-accent',
+            ].join(' ')}
           >
             <Users size={10} />
             Everyone equally

--- a/src/components/receipts/ReceiptReviewSheet.integration.test.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.integration.test.tsx
@@ -167,6 +167,17 @@ describe('ReceiptReviewSheet -- shared single-qty items (issue #783)', () => {
     fireEvent.click(within(wineRow).getByText(/Everyone equally/i))
     expect(within(wineRow).getByText('Split between 3 people')).toBeInTheDocument()
   })
+
+  it('"Everyone equally" toggles off on a second click (deselects everyone)', () => {
+    renderSheet()
+    const wineRow = getItemRow('Wine')
+    const btn = within(wineRow).getByText(/Everyone equally/i)
+    fireEvent.click(btn)
+    expect(within(wineRow).getByText('Split between 3 people')).toBeInTheDocument()
+    // Second click clears the allocation -> no sharers, progress chip hidden.
+    fireEvent.click(within(getItemRow('Wine')).getByText(/Everyone equally/i))
+    expect(within(getItemRow('Wine')).queryByText('Split between 3 people')).not.toBeInTheDocument()
+  })
 })
 
 describe('ReceiptReviewSheet -- view toggle', () => {

--- a/src/components/receipts/ReceiptReviewSheet.tsx
+++ b/src/components/receipts/ReceiptReviewSheet.tsx
@@ -227,19 +227,22 @@ export function ReceiptReviewSheet({
     const item = editableItems.find(i => i.id === itemId)
     if (!item) return
     const ids = participants.map(p => p.id)
-    const distributed = distributeEvenly(ids)
+    // Toggle: if everyone already shares this item, a second click clears it.
+    const inner = allocations.get(itemId)
+    const everyoneSelected = ids.length > 0 && ids.every(id => (inner?.get(id) ?? 0) > 0)
+    const apply = (): Map<string, number> => (everyoneSelected ? new Map() : distributeEvenly(ids))
 
     setAllocations(prev => {
       const next: Allocations = new Map()
       for (const [k, v] of prev) next.set(k, new Map(v))
-      next.set(itemId, distributed)
+      next.set(itemId, apply())
 
       if (carryForward) {
         const itemIndex = editableItems.findIndex(i => i.id === itemId)
         for (let i = itemIndex + 1; i < editableItems.length; i++) {
           const target = editableItems[i]
           if (target.manuallySet) continue
-          next.set(target.id, distributeEvenly(ids))
+          next.set(target.id, apply())
         }
       }
       return next


### PR DESCRIPTION
Follow-up to #784. `Everyone equally` now toggles: a second click (when everyone is already on the item) clears the line's allocation. The button reflects state via `aria-pressed` + active styling, and carry-forward mirrors the toggle for auto-filled items.

Adds an integration test for the toggle-off behavior. Full suite 348 pass, type-check clean. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)